### PR TITLE
Fix: CounterfactualEngine works with transforming predictors

### DIFF
--- a/backend/apps/agents/services/orchestrator.py
+++ b/backend/apps/agents/services/orchestrator.py
@@ -98,6 +98,10 @@ class PipelineOrchestrator:
                 feature_cols=predictor.feature_cols,
                 training_data=features_df,
                 threshold=predictor.model_version.optimal_threshold or 0.5,
+                # Pass the predictor's transform so candidate raw-feature
+                # values are scored through the same engineered + one-hot
+                # pipeline the live model expects.
+                transform_fn=predictor._transform,
             )
             return engine.generate(features_df, original_loan_amount, timeout_seconds=10)
         except Exception as e:

--- a/backend/apps/ml_engine/services/counterfactual_engine.py
+++ b/backend/apps/ml_engine/services/counterfactual_engine.py
@@ -68,12 +68,23 @@ class CounterfactualEngine:
     ----------
     model : sklearn-compatible classifier with ``predict_proba``
     feature_cols : list[str]
-        Ordered feature column names the model was trained on.
+        Ordered feature column names the *model* was trained on. In production
+        these are the fully-transformed columns (one-hot + engineered
+        interactions), not the raw applicant input fields.
     training_data : pd.DataFrame
-        Representative sample of training data (used by DiCE for ranges).
+        Representative sample used by DiCE for range estimation. Treated as
+        *raw* (pre-transform) features — the engine applies ``transform_fn``
+        before handing rows to the model.
     threshold : float
         Probability threshold above which the model considers an application
         approved.  Defaults to 0.5.
+    transform_fn : callable, optional
+        Function mapping a raw-features DataFrame to the model's feature
+        space (one-hot, scaling, engineered interactions). Defaults to
+        identity, which is fine for unit tests that use a model trained
+        directly on raw columns but wrong in production — the orchestrator
+        MUST pass ``predictor._transform`` so candidate values are scored
+        through the same pipeline as live predictions.
     """
 
     def __init__(
@@ -82,11 +93,24 @@ class CounterfactualEngine:
         feature_cols: list[str],
         training_data: pd.DataFrame,
         threshold: float = 0.5,
+        transform_fn: Any = None,
     ) -> None:
         self.model = model
         self.feature_cols = feature_cols
         self.training_data = training_data.copy()
         self.threshold = threshold
+        self._transform_fn = transform_fn
+
+    def _predict_prob(self, raw_df: pd.DataFrame) -> float:
+        """Predict approval probability for a single raw-features row.
+
+        Applies ``transform_fn`` (if provided) before calling ``predict_proba``.
+        """
+        if self._transform_fn is not None:
+            transformed = self._transform_fn(raw_df.copy())
+        else:
+            transformed = raw_df
+        return float(self.model.predict_proba(transformed[self.feature_cols])[0][1])
 
     # ------------------------------------------------------------------
     # Public API
@@ -103,18 +127,23 @@ class CounterfactualEngine:
         Returns ``[]`` if the applicant is already predicted as approved.
         """
         # Check if already approved — nothing to explain
-        prob = self.model.predict_proba(features_df[self.feature_cols])[0][1]
+        prob = self._predict_prob(features_df)
         if prob >= self.threshold:
             return []
 
-        # Try DiCE first, fall back to binary-search
-        try:
-            with _timeout_ctx(timeout_seconds):
-                cfs = self._dice_counterfactuals(features_df, original_loan_amount)
-                if cfs:
-                    return cfs
-        except (TimeoutError, Exception) as exc:
-            logger.info("DiCE counterfactuals failed/timed-out: %s — using fallback", exc)
+        # DiCE requires a model that predicts on the same feature space as
+        # the Data object. When a transform_fn is supplied (production path),
+        # the model's input space differs from the raw-features space DiCE
+        # operates in — running DiCE would need a custom wrapper and is
+        # deferred to a future spec. Skip straight to the fallback.
+        if self._transform_fn is None:
+            try:
+                with _timeout_ctx(timeout_seconds):
+                    cfs = self._dice_counterfactuals(features_df, original_loan_amount)
+                    if cfs:
+                        return cfs
+            except (TimeoutError, Exception) as exc:
+                logger.info("DiCE counterfactuals failed/timed-out: %s — using fallback", exc)
 
         return self._fallback_binary_search(features_df, original_loan_amount)
 
@@ -254,9 +283,17 @@ class CounterfactualEngine:
 
     def _fallback_binary_search(self, features_df: pd.DataFrame, original_loan_amount: float) -> list[dict]:
         """Deterministic fallback: binary-search on loan_amount, then try
-        loan_term extension and cosigner toggle."""
+        loan_term extension and cosigner toggle.
+
+        Reads raw feature values from features_df (not indexed by feature_cols,
+        which may be the transformed model-input space that omits categorical
+        string columns like state/purpose).
+        """
         results: list[dict] = []
-        original = features_df[self.feature_cols].iloc[0]
+        # Read raw values directly — features_df is the applicant's raw row,
+        # which has loan_amount / loan_term_months / has_cosigner even when
+        # feature_cols describes the transformed model input space.
+        original = features_df.iloc[0]
 
         # --- 1. Binary-search on loan_amount ---
         flip_amount = self._binary_search_feature(features_df, "loan_amount", 5000.0, original_loan_amount)
@@ -277,7 +314,7 @@ class CounterfactualEngine:
                     continue
                 test_df = features_df.copy()
                 test_df["loan_term_months"] = candidate_term
-                prob = self.model.predict_proba(test_df[self.feature_cols])[0][1]
+                prob = self._predict_prob(test_df)
                 if prob >= self.threshold:
                     changes = {"loan_term_months": candidate_term}
                     results.append(
@@ -292,7 +329,7 @@ class CounterfactualEngine:
         if int(original["has_cosigner"]) == 0:
             test_df = features_df.copy()
             test_df["has_cosigner"] = 1
-            prob = self.model.predict_proba(test_df[self.feature_cols])[0][1]
+            prob = self._predict_prob(test_df)
             if prob >= self.threshold:
                 changes = {"has_cosigner": 1}
                 results.append(
@@ -383,7 +420,7 @@ class CounterfactualEngine:
             test_df = features_df.copy()
             test_df[feature] = mid
             try:
-                prob = self.model.predict_proba(test_df[self.feature_cols])[0][1]
+                prob = self._predict_prob(test_df)
                 if prob >= self.threshold:
                     flip_value = mid
                     # We want the *largest* value that still flips (closest

--- a/backend/apps/ml_engine/tests/test_counterfactual_engine_with_transform.py
+++ b/backend/apps/ml_engine/tests/test_counterfactual_engine_with_transform.py
@@ -1,0 +1,154 @@
+"""Regression test for the production bug where CounterfactualEngine failed
+with ``KeyError: 'state_NSW', 'purpose_home', ... not in index`` because the
+raw features_df doesn't include one-hot / engineered columns the real model
+expects.
+
+The fix: pass ``transform_fn`` so the engine applies the same pipeline the
+predictor uses before scoring candidate values. This test reproduces the
+production shape (raw features in, transformed features for prediction).
+"""
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import GradientBoostingClassifier
+
+from apps.ml_engine.services.counterfactual_engine import CounterfactualEngine
+
+
+def _make_transforming_model():
+    """Return (model, feature_cols, transform_fn) mimicking a real predictor.
+
+    Training data has one-hot + engineered columns the model sees, but the
+    CF engine receives raw features (loan_amount, loan_term_months,
+    has_cosigner, purpose, state) and must apply transform_fn before predict.
+    """
+    rng = np.random.RandomState(0)
+    n = 300
+    raw = pd.DataFrame(
+        {
+            "loan_amount": rng.uniform(5000, 500000, n),
+            "loan_term_months": rng.choice([12, 24, 36, 48, 60], n),
+            "has_cosigner": rng.choice([0, 1], n),
+            "annual_income": rng.uniform(20000, 200000, n),
+            "credit_score": rng.randint(300, 1200, n),
+            "purpose": rng.choice(["home", "auto", "personal"], n),
+            "state": rng.choice(["NSW", "VIC", "QLD"], n),
+        }
+    )
+
+    def transform_fn(df: pd.DataFrame) -> pd.DataFrame:
+        """One-hot encode categoricals and add an engineered interaction."""
+        out = df.copy()
+        for purpose in ("home", "auto", "personal"):
+            out[f"purpose_{purpose}"] = (out["purpose"] == purpose).astype(int)
+        for state in ("NSW", "VIC", "QLD"):
+            out[f"state_{state}"] = (out["state"] == state).astype(int)
+        out["loan_to_income"] = out["loan_amount"] / out["annual_income"].clip(lower=1)
+        return out
+
+    transformed = transform_fn(raw)
+    feature_cols = [
+        "loan_amount",
+        "loan_term_months",
+        "has_cosigner",
+        "annual_income",
+        "credit_score",
+        "purpose_home",
+        "purpose_auto",
+        "purpose_personal",
+        "state_NSW",
+        "state_VIC",
+        "state_QLD",
+        "loan_to_income",
+    ]
+
+    # Label: approve if good credit and manageable loan-to-income
+    y = ((transformed["credit_score"] > 600) & (transformed["loan_to_income"] < 3.5)).astype(int)
+    model = GradientBoostingClassifier(n_estimators=30, random_state=0)
+    model.fit(transformed[feature_cols], y)
+
+    return model, feature_cols, transform_fn
+
+
+def test_engine_runs_against_transforming_model():
+    """Regression: the CF engine must work when the model's feature_cols
+    include columns not present in the raw applicant features_df."""
+    model, feature_cols, transform_fn = _make_transforming_model()
+
+    # Raw features for a denied applicant — note these columns are a
+    # strict subset of what the model expects.
+    raw_query = pd.DataFrame(
+        [
+            {
+                "loan_amount": 300000.0,
+                "loan_term_months": 36,
+                "has_cosigner": 0,
+                "annual_income": 40000.0,
+                "credit_score": 450,
+                "purpose": "home",
+                "state": "NSW",
+            }
+        ]
+    )
+
+    engine = CounterfactualEngine(
+        model=model,
+        feature_cols=feature_cols,
+        training_data=raw_query,  # small — triggers synthetic-dataset path
+        threshold=0.5,
+        transform_fn=transform_fn,
+    )
+
+    # Must not raise. Previously would raise
+    # ``KeyError: '[purpose_home, ..., state_QLD] not in index'``.
+    results = engine.generate(raw_query, original_loan_amount=300000.0, timeout_seconds=2)
+
+    # Binary-search fallback should produce at least one suggestion
+    assert isinstance(results, list)
+    assert len(results) >= 1
+    for cf in results:
+        assert "changes" in cf
+        assert "statement" in cf
+        # Only the allowed features should be varied
+        for feat in cf["changes"]:
+            assert feat in {"loan_amount", "loan_term_months", "has_cosigner"}
+
+
+def test_engine_without_transform_still_works():
+    """Backwards compat: calling the engine without transform_fn uses the
+    model directly (the old test pattern). Verify that path still works."""
+    rng = np.random.RandomState(42)
+    n = 200
+    X = pd.DataFrame(
+        {
+            "loan_amount": rng.uniform(5000, 500000, n),
+            "loan_term_months": rng.choice([12, 24, 36, 48, 60], n),
+            "has_cosigner": rng.choice([0, 1], n),
+            "credit_score": rng.randint(300, 1200, n),
+        }
+    )
+    y = (X["credit_score"] > 600).astype(int)
+    model = GradientBoostingClassifier(n_estimators=20, random_state=42)
+    model.fit(X, y)
+
+    query = pd.DataFrame(
+        [
+            {
+                "loan_amount": 250000.0,
+                "loan_term_months": 36,
+                "has_cosigner": 0,
+                "credit_score": 450,
+            }
+        ]
+    )
+
+    engine = CounterfactualEngine(
+        model=model,
+        feature_cols=list(X.columns),
+        training_data=X,
+        threshold=0.5,
+        # No transform_fn — identity path
+    )
+    results = engine.generate(query, original_loan_amount=250000.0, timeout_seconds=2)
+    assert isinstance(results, list)
+    assert len(results) >= 1


### PR DESCRIPTION
## Summary

Track C (PR #7) shipped with a bug that made counterfactual generation fail in production for every denied applicant. Found during Docker verification after merge, fixed here with a proper regression test.

## What was broken

The predictor stashes raw features (71 columns: \`loan_amount\`, \`credit_score\`, \`state\`, etc.) as \`_features_df\`, but the model's \`feature_cols\` include transformed + one-hot columns (150+: \`state_NSW\`, \`purpose_home\`, \`loan_to_income\`). Every \`features_df[self.feature_cols]\` call in the CF engine failed with:

\`\`\`
KeyError: \"['state_NSW', 'purpose_home', ..., 'loan_to_income'] not in index\"
\`\`\`

The unit tests didn't catch it because mocks used models trained directly on raw columns — an artificial match that doesn't exist in production.

## Fix

- \`CounterfactualEngine.__init__\` accepts optional \`transform_fn\`. The orchestrator passes \`predictor._transform\` so candidates go through the same pipeline as live predictions.
- New \`_predict_prob(raw_df)\` helper applies the transform then predicts. All hot-path sites route through it.
- \`_fallback_binary_search\` reads the raw row directly instead of indexing by feature_cols.
- DiCE path disabled when transform_fn is set. DiCE would need a custom model wrapper to bridge raw → transformed spaces — deferred to a future spec. Binary-search covers production.

## Verification

**Unit:** 9/9 tests pass including the new regression test.

**End-to-end in Docker:** Before the fix, every CF call raised KeyError. After the fix, the existing denied test-applicant produces:

> Reduce your loan amount from \$250,000 to \$188,938

Generated by the real predictor → transform → binary-search path.

## Test plan

- [x] \`test_counterfactual_engine_with_transform.py::test_engine_runs_against_transforming_model\` — new regression using a mock model with one-hot + engineered columns the raw query doesn't have
- [x] \`test_engine_without_transform_still_works\` — preserves the no-transform path for unit tests
- [x] All existing CF engine tests still pass
- [x] End-to-end reproduction in Docker produces valid counterfactuals
- [ ] CI across backend-tests, backend-lint, docker-build, dependency-audit

## Noted follow-up (not in this PR)

DiCE on transforming models would produce nicer multi-feature counterfactuals than binary-search. Needs a proxy-model wrapper that lifts raw-space queries into transformed-space predictions. Deferred — binary-search produces useful output and this PR focuses on making the feature work at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)