### PR TITLE
Quality batch: specific exception types + remove duplicate circuit breaker

### DIFF
--- a/backend/apps/agents/services/api_budget.py
+++ b/backend/apps/agents/services/api_budget.py
@@ -20,6 +20,7 @@ Or use the guarded_api_call() wrapper which handles all of the above:
 import hashlib
 import logging
 
+import redis
 from django.conf import settings
 
 logger = logging.getLogger("agents.api_budget")
@@ -113,7 +114,7 @@ class ApiBudgetGuard:
                 )
         except (BudgetExhausted, CircuitOpen):
             raise
-        except Exception as e:
+        except (redis.RedisError, ConnectionError, TimeoutError) as e:
             # Redis is unavailable. We can't enforce the true daily budget, but
             # we MUST still cap cost exposure — fail-open previously allowed
             # unlimited calls during an outage. Use a per-process fallback
@@ -164,16 +165,16 @@ class ApiBudgetGuard:
                 model or "unknown",
                 cost_usd,
             )
-        except Exception as e:
-            logger.warning("Failed to record API call: %s", e)
+        except (redis.RedisError, ConnectionError, TimeoutError) as e:
+            logger.warning("Failed to record API call (Redis): %s", e)
 
     def record_success(self):
         """Reset consecutive failure counter on success."""
         try:
             r = self._get_redis()
             r.delete("ai_budget:consecutive_failures")
-        except Exception as e:
-            logger.debug("Failed to reset failure counter: %s", e)
+        except (redis.RedisError, ConnectionError, TimeoutError) as e:
+            logger.debug("Failed to reset failure counter (Redis): %s", e)
 
     def record_failure(self):
         """Increment consecutive failure counter. Trip circuit breaker after threshold."""
@@ -193,8 +194,8 @@ class ApiBudgetGuard:
                     failures,
                     cooldown_seconds,
                 )
-        except Exception as e:
-            logger.warning("Failed to record API failure: %s", e)
+        except (redis.RedisError, ConnectionError, TimeoutError) as e:
+            logger.warning("Failed to record API failure (Redis): %s", e)
 
     def get_daily_stats(self):
         """Return current daily usage stats."""
@@ -209,8 +210,8 @@ class ApiBudgetGuard:
                 "call_limit": getattr(settings, "AI_DAILY_CALL_LIMIT", 500),
                 "circuit_breaker_open": bool(r.exists("ai_budget:circuit_breaker")),
             }
-        except Exception as e:
-            logger.debug("Failed to fetch daily stats from Redis: %s", e)
+        except (redis.RedisError, ConnectionError, TimeoutError) as e:
+            logger.debug("Failed to fetch daily stats (Redis): %s", e)
             return {
                 "calls": 0,
                 "tokens": 0,

--- a/backend/apps/email_engine/services/email_generator.py
+++ b/backend/apps/email_engine/services/email_generator.py
@@ -46,8 +46,10 @@ class EmailGenerator:
         else:
             self.client = None
         self.guardrail_checker = GuardrailChecker()
-        self._consecutive_failures = 0
-        self._circuit_open_until = 0
+        # Circuit breaker lives in ApiBudgetGuard (Redis-backed). The previous
+        # per-instance breaker here duplicated that state and did not reset
+        # the failure counter after cooldown expired — a buggy shadow of the
+        # real one. All breaker logic now flows through guarded_api_call.
 
     # Map ML feature names to plain-language denial reasons
     DENIAL_REASON_MAP = {
@@ -281,10 +283,6 @@ class EmailGenerator:
                     "use simpler language and stick to the exact template structure.\n"
                 )
 
-        # Check circuit breaker — fallback to template if API is down
-        if self._consecutive_failures >= 3 and time.time() < self._circuit_open_until:
-            return self._generate_fallback(application, decision, context, start_time)
-
         # Pre-flight: detect billing/auth errors immediately so the pipeline
         # completes end-to-end using templates rather than failing at this step.
         if attempt == 1 and not self._api_available():
@@ -344,7 +342,6 @@ class EmailGenerator:
                     else:
                         raise  # Final attempt — propagate to outer handler
 
-            self._consecutive_failures = 0
             # Read actual token usage from the response
             usage = getattr(response, "usage", None)
             if usage:
@@ -352,11 +349,8 @@ class EmailGenerator:
                 output_tokens = getattr(usage, "output_tokens", 0)
         except BudgetExhausted:
             return self._generate_fallback(application, decision, context, start_time)
-        except Exception:
-            self._consecutive_failures += 1
-            if self._consecutive_failures >= 3:
-                self._circuit_open_until = time.time() + 600  # 10 min cooldown
-            raise
+        # Failure accounting (record_failure, circuit-breaker tripping) happens
+        # inside guarded_api_call. Any exception here propagates to the caller.
 
         # Extract structured output from tool_use response
         subject, body = self._parse_tool_response(response)


### PR DESCRIPTION
## Summary

Two code-quality fixes from the audit that share themes (exception handling, circuit breaker discipline).

### Audit #11 — Specific exception types in api_budget.py

Five \`except Exception\` handlers around Redis calls were swallowing everything — Django ORM errors, import errors, logic bugs. Narrowed to \`(redis.RedisError, ConnectionError, TimeoutError)\` so operators can distinguish transient Redis blips from real bugs.

### Audit #13 — Remove duplicate circuit breaker

\`EmailGenerator\` had an in-process circuit breaker (\`_consecutive_failures\` + \`_circuit_open_until\`) that duplicated Redis-backed state in \`ApiBudgetGuard\`. It had a real bug: after the 10-minute cooldown expired, the failure counter was never reset, so one more failure would immediately re-open the breaker and block recovery.

Removed entirely. \`guarded_api_call\` already routes all failures through \`budget.record_failure()\` which updates the Redis circuit breaker. One source of truth.

## Test plan

- [x] \`tests/test_api_budget.py\` — 9/9 passing (includes the deleted-user + sustained-outage tests from PR #8)
- [x] \`tests/test_email_generator.py\` — 4/4 passing
- [x] Ruff check + format pass
- [ ] CI full sweep on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)