### PR TITLE
chore(ci): add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,59 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Australia/Sydney"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "backend"
+    groups:
+      django-ecosystem:
+        patterns:
+          - "Django*"
+          - "django-*"
+          - "djangorestframework*"
+      ml-stack:
+        patterns:
+          - "scikit-learn"
+          - "xgboost"
+          - "shap"
+          - "dice-ml"
+          - "pandas"
+          - "numpy"
+          - "joblib"
+          - "optuna"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Australia/Sydney"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "frontend"
+    groups:
+      react-ecosystem:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react*"
+      next-ecosystem:
+        patterns:
+          - "next"
+          - "eslint-config-next"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with pip, npm, and github-actions ecosystems
- Grouped updates for Django, ML stack, React, Next.js so PRs stay manageable
- Sydney timezone scheduling (Monday 08:00 AEST)

## Test plan
- [ ] YAML validates (CI runs pre-commit check-yaml)
- [ ] After merge: Dependabot starts scheduling weekly update PRs