### PR TITLE
chore(repo): CODEOWNERS, PR template, issue templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# CODEOWNERS — default reviewer for all paths
+# GitHub user: zeroyuekun (Neville Zeng)
+
+*                               @zeroyuekun
+
+# Specific areas (future contributors can be added here)
+/backend/apps/ml_engine/        @zeroyuekun
+/backend/apps/email_engine/     @zeroyuekun
+/backend/apps/agents/           @zeroyuekun
+/frontend/                      @zeroyuekun
+/.github/                       @zeroyuekun

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Something's broken or behaving unexpectedly
+title: "bug: "
+labels: ["bug"]
+---
+
+## What happened
+<!-- Observable behaviour. Include error messages and stack traces. -->
+
+## What you expected
+<!-- What should have happened instead. -->
+
+## How to reproduce
+1. ...
+2. ...
+3. ...
+
+## Environment
+- Version / commit:
+- OS:
+- Browser (if frontend):
+- Role (admin / officer / customer):
+
+## Logs
+<details>
+<summary>Relevant logs</summary>
+
+```
+<paste logs here>
+```
+</details>
+
+## Severity
+- [ ] Critical — production outage, data loss, security
+- [ ] High — major feature broken, no workaround
+- [ ] Medium — feature impaired, workaround exists
+- [ ] Low — cosmetic or edge case

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security issue
+    url: https://github.com/zeroyuekun/loan-approval-ai-system/security/advisories/new
+    about: Report vulnerabilities privately via GitHub Security Advisories.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Propose a new feature or enhancement
+title: "feat: "
+labels: ["enhancement"]
+---
+
+## Problem
+<!-- What user pain or gap does this address? -->
+
+## Proposed solution
+<!-- High-level sketch of the feature. -->
+
+## Alternatives considered
+<!-- Other approaches you thought about and why they're worse. -->
+
+## Scope
+- [ ] Small (≤ 1 day)
+- [ ] Medium (2–5 days)
+- [ ] Large (> 5 days — consider breaking up)
+
+## Impact on existing behaviour
+<!-- Migrations? Breaking API changes? Config changes? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+## Summary
+<!-- 1–3 bullets. What changed and why. -->
+
+## Type
+- [ ] feat — user-facing feature
+- [ ] fix — bug fix
+- [ ] docs — documentation only
+- [ ] chore — tooling / config
+- [ ] refactor — no behavior change
+- [ ] test — test-only
+
+## Scope (check all that apply)
+- [ ] Backend (`backend/`)
+- [ ] Frontend (`frontend/`)
+- [ ] ML / model
+- [ ] CI
+- [ ] Docs
+- [ ] Schema / migration
+
+## Testing
+<!-- How the change was verified. Commands run, tests added, manual checks. -->
+
+- [ ] Unit tests pass locally
+- [ ] Integration / e2e tests pass (if applicable)
+- [ ] Manually verified in the browser (UI changes)
+- [ ] No regression in coverage
+
+## Rollout
+- [ ] Safe to merge independently
+- [ ] Requires coordinated deploy (explain below)
+- [ ] Adds a migration
+
+## Screenshots (UI only)
+<!-- Drop before/after images here. -->
+
+## Risk & rollback
+<!-- What breaks if this is wrong? How do we roll back? -->


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` with default + area-specific ownership
- Adds `.github/PULL_REQUEST_TEMPLATE.md` standardising PR format
- Adds issue templates (bug_report, feature_request) + config.yml routing security issues to private advisories

## Test plan
- [ ] PR body (this one) uses the new template — verify it rendered
- [ ] After merge: "New issue" on GitHub shows Bug / Feature Request choices
- [ ] Secret scan + yaml lint green