### PR TITLE
docs(adr): scaffold ADRs + XGBoost+RF decision (001)

### DIFF
--- a/docs/adr/000-template.md
+++ b/docs/adr/000-template.md
@@ -1,0 +1,35 @@
+# NNN — [Short decision title]
+
+- **Status:** Proposed | Accepted | Superseded by [NNN](NNN-other.md)
+- **Date:** YYYY-MM-DD
+- **Decider:** @github-handle
+
+## Context
+
+What situation are we in? What problem needs deciding? Include constraints (performance, compliance, budget, team size).
+
+## Decision
+
+What did we choose?
+
+## Consequences
+
+What follows from this choice? Both the good and the costs. Be honest about trade-offs.
+
+## Alternatives considered
+
+What else was on the table?
+
+### Option A — [name]
+- Pros: ...
+- Cons: ...
+- Why we didn't pick this: ...
+
+### Option B — [name]
+- Pros: ...
+- Cons: ...
+- Why we didn't pick this: ...
+
+## References
+
+- Links to issues, PRs, external docs.

--- a/docs/adr/001-xgboost-rf-ensemble.md
+++ b/docs/adr/001-xgboost-rf-ensemble.md
@@ -1,0 +1,61 @@
+# 001 — XGBoost + Random Forest ensemble for loan scoring
+
+- **Status:** Accepted
+- **Date:** 2026-04-17
+- **Decider:** @zeroyuekun
+
+## Context
+
+The system scores Australian loan applicants (approve/deny probability). Model requirements:
+
+- **Calibrated probabilities** — downstream guardrails and NBO use the raw probability, not just the class.
+- **Interpretable** — NCCP responsible-lending obligations require decision reasoning (SHAP explanations). Neural nets are harder to justify.
+- **Tabular data** — ~30 engineered features; no text / images.
+- **Training data volume** — synthetic + seeded, ~10k rows. Not big-data scale.
+- **Inference latency** — p95 < 500ms per applicant.
+- **CPU-only inference** — runs in a Celery worker container, no GPU.
+
+## Decision
+
+Use an ensemble of XGBoost and Random Forest:
+- **XGBoost (primary)** — gradient-boosted trees, tuned via Optuna. Usually the stronger single model on tabular data.
+- **Random Forest (secondary)** — bagged trees. Lower variance on edge cases, cheaper fallback if XGBoost's prediction is marginal or the model artifact fails to load.
+- The active algorithm is selected by `ModelVersion.is_active`; operators can swap without code changes.
+
+SHAP runs on the active model for feature importances surfaced in the dashboard and denial emails.
+
+## Consequences
+
+**Good:**
+- Both models are well-documented, CPU-friendly, and have mature SHAP integration.
+- Two independent algorithms give a simple A/B lever during operation.
+- Training, scoring, and explanation all run in-process in the Celery `ml` worker — no external inference service to operate.
+
+**Costs:**
+- Two model artifacts to version, not one. Mitigated by `ModelVersion.is_active` flag.
+- XGBoost's dependency footprint (~30 MB per worker image) — acceptable given the single-image-per-queue deployment.
+- Tree ensembles are less calibrated out-of-the-box than logistic regression; isotonic calibration is applied post-hoc and monitored via calibration plots in `/dashboard/model-metrics`.
+
+## Alternatives considered
+
+### A — Logistic regression only
+- **Pros:** Simplest, perfectly interpretable, natively calibrated.
+- **Cons:** Meaningfully lower AUC on the feature set (~0.80 vs ~0.87 Optuna-tuned).
+- **Why not:** Approval quality matters more than implementation simplicity; the lift justifies the complexity.
+
+### B — LightGBM
+- **Pros:** Often a touch faster and slightly better than XGBoost on some tabular benchmarks.
+- **Cons:** Slightly smaller ecosystem around SHAP integration; XGBoost was already familiar to the team.
+- **Why not:** Incremental gain not worth the switch. Could revisit if inference latency becomes a constraint.
+
+### C — Deep learning (TabNet / FT-Transformer)
+- **Pros:** Strong on larger tabular datasets.
+- **Cons:** Worse SHAP story, higher inference cost, overkill at our data size.
+- **Why not:** Interpretability requirement makes this a poor fit. Data volume doesn't justify the capacity.
+
+## References
+
+- `backend/apps/ml_engine/services/trainer.py` — model training entry point.
+- `backend/apps/ml_engine/models.py` — `ModelVersion` with `is_active` flag.
+- `backend/apps/ml_engine/services/predictor.py` — inference.
+- Optuna tuning notes: `project_ml_accuracy_context.md` (internal).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,26 @@
+# Architecture Decision Records
+
+This directory holds Architecture Decision Records (ADRs) for the Loan Approval AI System. An ADR captures a significant, intentional decision — what we chose, what we rejected, and why — so future contributors (and future us) can understand the system's shape.
+
+## When to write an ADR
+
+- You're choosing between multiple plausible architectures or libraries
+- You're introducing a cross-cutting pattern (error handling, auth, caching)
+- You're rejecting a plausible default in favour of something else
+- A reviewer asks "why did you do it this way and not X?" and the answer deserves durable writing
+
+Skip ADRs for routine implementation choices, library version bumps, or bug fixes.
+
+## Process
+
+1. Copy `000-template.md` to `NNN-short-slug.md` (NNN = next integer, zero-padded).
+2. Fill in the sections. Keep it short — one page is ideal.
+3. Status starts as **Proposed**. Open a PR.
+4. Once merged, status becomes **Accepted**.
+5. If later superseded, mark **Superseded by NNN-other-adr.md** at the top, don't delete.
+
+## Index
+
+- [001 — XGBoost + Random Forest ensemble](001-xgboost-rf-ensemble.md)
+
+<!-- Append new ADRs here as they're written. -->


### PR DESCRIPTION
## Summary
- Adds `docs/adr/` with README explaining when/how to write ADRs
- Provides `000-template.md` for future ADRs
- First real ADR (001): documents XGBoost + Random Forest ensemble choice with alternatives considered (LogReg, LightGBM, TabNet)

## Test plan
- [ ] Rendering on GitHub (markdown links between README index and 001 work)
- [ ] Secret scan + lint green