### PR TITLE
fix(ml_engine): align DiCE timeout + cut total_CFs

### DIFF
--- a/backend/apps/agents/services/orchestrator.py
+++ b/backend/apps/agents/services/orchestrator.py
@@ -103,7 +103,7 @@ class PipelineOrchestrator:
                 # pipeline the live model expects.
                 transform_fn=predictor._transform,
             )
-            return engine.generate(features_df, original_loan_amount, timeout_seconds=10)
+            return engine.generate(features_df, original_loan_amount)
         except Exception as e:
             logger.warning("Counterfactual generation failed in orchestrator: %s", e)
             return []

--- a/backend/apps/ml_engine/services/counterfactual_engine.py
+++ b/backend/apps/ml_engine/services/counterfactual_engine.py
@@ -120,7 +120,7 @@ class CounterfactualEngine:
         self,
         features_df: pd.DataFrame,
         original_loan_amount: float,
-        timeout_seconds: int = 15,
+        timeout_seconds: int = 20,
     ) -> list[dict]:
         """Return up to 3 counterfactual suggestions for a denied applicant.
 
@@ -224,7 +224,7 @@ class CounterfactualEngine:
 
         cf_result = exp.generate_counterfactuals(
             query,
-            total_CFs=5,
+            total_CFs=3,
             desired_class="opposite",
             features_to_vary=features_to_vary,
             permitted_range=permitted_range,

--- a/backend/apps/ml_engine/tests/test_counterfactual_engine.py
+++ b/backend/apps/ml_engine/tests/test_counterfactual_engine.py
@@ -119,9 +119,7 @@ def test_generate_default_timeout_is_20_seconds():
 
     sig = inspect.signature(CounterfactualEngine.generate)
     param = sig.parameters["timeout_seconds"]
-    assert param.default == 20, (
-        f"generate() default timeout should be 20s after B1 fix; got {param.default}"
-    )
+    assert param.default == 20, f"generate() default timeout should be 20s after B1 fix; got {param.default}"
 
 
 def test_dice_total_cfs_is_three():
@@ -129,6 +127,4 @@ def test_dice_total_cfs_is_three():
     from apps.ml_engine.services.counterfactual_engine import CounterfactualEngine
 
     src = inspect.getsource(CounterfactualEngine._dice_counterfactuals)
-    assert "total_CFs=3" in src or "total_CFs = 3" in src, (
-        "DiCE call should use total_CFs=3 after B1 fix"
-    )
+    assert "total_CFs=3" in src or "total_CFs = 3" in src, "DiCE call should use total_CFs=3 after B1 fix"

--- a/backend/apps/ml_engine/tests/test_counterfactual_engine.py
+++ b/backend/apps/ml_engine/tests/test_counterfactual_engine.py
@@ -108,4 +108,28 @@ class TestCounterfactualEngine:
             ]
         )
         result = engine.generate(approved, original_loan_amount=10000.0)
+
+
+import inspect
+
+
+def test_generate_default_timeout_is_20_seconds():
+    """B1: caller/callee timeout mismatch fix — generate() defaults to 20s."""
+    from apps.ml_engine.services.counterfactual_engine import CounterfactualEngine
+
+    sig = inspect.signature(CounterfactualEngine.generate)
+    param = sig.parameters["timeout_seconds"]
+    assert param.default == 20, (
+        f"generate() default timeout should be 20s after B1 fix; got {param.default}"
+    )
+
+
+def test_dice_total_cfs_is_three():
+    """B1: total_CFs reduced 5→3 to cut DiCE wall time."""
+    from apps.ml_engine.services.counterfactual_engine import CounterfactualEngine
+
+    src = inspect.getsource(CounterfactualEngine._dice_counterfactuals)
+    assert "total_CFs=3" in src or "total_CFs = 3" in src, (
+        "DiCE call should use total_CFs=3 after B1 fix"
+    )
         assert result == []

--- a/backend/apps/ml_engine/tests/test_counterfactual_engine.py
+++ b/backend/apps/ml_engine/tests/test_counterfactual_engine.py
@@ -1,3 +1,5 @@
+import inspect
+
 import numpy as np
 import pandas as pd
 
@@ -108,9 +110,7 @@ class TestCounterfactualEngine:
             ]
         )
         result = engine.generate(approved, original_loan_amount=10000.0)
-
-
-import inspect
+        assert result == []
 
 
 def test_generate_default_timeout_is_20_seconds():
@@ -132,4 +132,3 @@ def test_dice_total_cfs_is_three():
     assert "total_CFs=3" in src or "total_CFs = 3" in src, (
         "DiCE call should use total_CFs=3 after B1 fix"
     )
-        assert result == []


### PR DESCRIPTION
## Summary
- `generate()` default timeout: 15s → 20s
- `total_CFs` passed to DiCE: 5 → 3 (~40% faster genetic search)
- Orchestrator caller no longer overrides with `timeout_seconds=10` — lets the 20s default apply

## Why
Caller (10s) was always winning over callee default (15s), so DiCE fell back to surrogate before finishing. Align both on 20s and cut `total_CFs` to reduce most timeout-driven fallbacks on denied applicants.

## Test plan
- [ ] Existing counterfactual tests still pass
- [ ] New test asserts 20s default via inspect
- [ ] New test asserts `total_CFs=3` in DiCE source
- [ ] Orchestrator CF-step tests unchanged (no stale `timeout_seconds=10` asserts found)