### PR TITLE
fix(celery): tune prefetch, acks_late, JSON serialisation

### DIFF
--- a/backend/config/celery.py
+++ b/backend/config/celery.py
@@ -44,6 +44,27 @@ def _clear_correlation_id(**kwargs):
     _correlation_id.value = None
 
 
+# --- Worker tuning (B2) -----------------------------------------------------
+# Prefer fair dispatch + at-least-once semantics over raw throughput.
+# Per-queue prefetch is configured on the worker command line in
+# docker-compose (ml=1, agents=1, email=2). This is the safe global default.
+app.conf.worker_prefetch_multiplier = 2
+
+# Acknowledge tasks only after successful execution; if a worker dies
+# mid-task, the broker re-delivers to another worker.
+app.conf.task_acks_late = True
+app.conf.task_reject_on_worker_lost = True
+
+# Pin JSON for task payloads + results. Safer than the default serialiser
+# and easier to inspect in Flower / logs.
+app.conf.task_serializer = "json"
+app.conf.result_serializer = "json"
+app.conf.accept_content = ["json"]
+
+# Worker restart every N tasks to mitigate memory leaks (common with
+# ML worker processes importing large libs).
+app.conf.worker_max_tasks_per_child = 1000
+
 app.conf.task_routes = {
     "apps.ml_engine.tasks.*": {"queue": "ml"},
     "apps.email_engine.tasks.*": {"queue": "email"},

--- a/backend/tests/test_celery_config.py
+++ b/backend/tests/test_celery_config.py
@@ -1,0 +1,39 @@
+"""B2: Celery worker tuning tests."""
+
+from config.celery import app
+
+
+def test_task_acks_late_enabled():
+    """Tasks acknowledged after execution, not before.
+
+    Gives at-least-once semantics: if a worker dies mid-task,
+    the broker re-delivers it to another worker.
+    """
+    assert app.conf.task_acks_late is True
+
+
+def test_worker_prefetch_multiplier_conservative():
+    """Prefetch multiplier tuned down from default 4.
+
+    For the agents orchestration + ml queues we prefer strict
+    ordering + fair dispatch over throughput. 1 or 2 both acceptable
+    as a global default.
+    """
+    assert app.conf.worker_prefetch_multiplier in (1, 2)
+
+
+def test_task_reject_on_worker_lost_true():
+    """If a worker is killed (OOM / SIGKILL), requeue the task."""
+    assert app.conf.task_reject_on_worker_lost is True
+
+
+def test_task_serializer_is_json():
+    """JSON serialiser for tasks + results."""
+    assert app.conf.task_serializer == "json"
+    assert app.conf.result_serializer == "json"
+    assert "json" in app.conf.accept_content
+
+
+def test_worker_max_tasks_per_child_set():
+    """Worker restart cap set to mitigate long-running memory growth."""
+    assert app.conf.worker_max_tasks_per_child == 1000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
     # completed tasks so any accumulated native state (XGBoost/OpenMP threads,
     # Optuna memory, file descriptors) gets cleaned up and zombie tasks cannot
     # run indefinitely past their time_limit.
-    command: celery -A config worker -l info -Q ml --concurrency 1 --max-tasks-per-child 5
+    command: celery -A config worker -l info -Q ml --concurrency 1 --max-tasks-per-child 5 --prefetch-multiplier 1
     healthcheck:
       test: ["CMD-SHELL", "celery -A config inspect ping --timeout 10"]
       interval: 30s


### PR DESCRIPTION
## Summary
- `worker_prefetch_multiplier`: 4 (default) → 2; ml worker overridden to 1 via CLI flag
- Turned on `task_acks_late` + `task_reject_on_worker_lost` — at-least-once semantics on worker crashes
- Pinned JSON task/result serialisation (safer than default)
- `worker_max_tasks_per_child=1000` to cap ML worker memory growth

## Test plan
- [ ] 5 new assertion tests in `backend/tests/test_celery_config.py`
- [ ] Backend Tests green (validates new config doesn't break existing Celery integration)
- [ ] Existing `test_celery_integration.py` still passes