### PR TITLE
docs(runbooks): frontend exit-243, Celery backpressure, migration rollback

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,20 @@
+# Runbooks
+
+Operational procedures for incidents and known failure modes. Each runbook follows the same structure so it's fast to use under pressure.
+
+## How to use
+
+1. Match symptoms to a runbook title.
+2. Follow **Diagnose** to confirm the cause — don't skip this, the remediation only works if the diagnosis is right.
+3. Follow **Remediate** to restore service.
+4. If remediation fails, **Escalate** tells you who to tag and what data to attach.
+
+## Index
+
+- [Frontend container exits with code 243](frontend-exit-243.md)
+- [Celery queue backpressure](celery-backpressure.md)
+- [Migration rollback](migration-rollback.md)
+
+## Adding a runbook
+
+Copy an existing runbook file, replace content, and add to the index above. Keep section headings identical (`## Symptoms`, `## Diagnose`, `## Remediate`, `## Escalate`) so readers develop muscle memory.

--- a/docs/runbooks/celery-backpressure.md
+++ b/docs/runbooks/celery-backpressure.md
@@ -1,0 +1,69 @@
+# Celery queue backpressure
+
+**Severity:** Medium–High — applications submitted but decisions not rendering; users see "processing" for minutes.
+
+## Symptoms
+
+- Dashboard shows applications stuck at "scoring" / "generating email"
+- `POST /applications/` returns 202 but the status endpoint never advances past "queued"
+- Redis queue length grows faster than workers drain it
+
+## Diagnose
+
+1. **Queue depth per queue:**
+   ```bash
+   docker compose exec redis redis-cli -a "$REDIS_PASSWORD" LLEN celery
+   docker compose exec redis redis-cli -a "$REDIS_PASSWORD" LLEN ml
+   docker compose exec redis redis-cli -a "$REDIS_PASSWORD" LLEN agents
+   docker compose exec redis redis-cli -a "$REDIS_PASSWORD" LLEN email
+   ```
+
+   Healthy: each < 50. Backpressure: growing monotonically.
+
+2. **Worker heartbeat:**
+   ```bash
+   docker compose exec backend celery -A config inspect active --timeout 5
+   docker compose exec backend celery -A config inspect stats --timeout 5
+   ```
+
+   If a worker doesn't respond, it's dead or stuck.
+
+3. **Worker logs for OOM / unhandled exceptions:**
+   ```bash
+   docker compose logs --tail 500 celery_worker_ml
+   docker compose logs --tail 500 celery_worker_agents
+   ```
+
+4. **Common causes (in order of frequency):**
+   - Worker OOM killed by container (see frontend-exit-243 runbook for the memory-limit pattern)
+   - Long-running task exceeding `task_soft_time_limit`
+   - Redis password mismatch causing workers to silently drop
+   - Dead-letter build-up (check `celery_results` table in Postgres)
+
+## Remediate
+
+**Clear backlog safely:**
+
+1. Scale up workers temporarily:
+   ```bash
+   docker compose up -d --scale celery_worker_ml=3 --scale celery_worker_agents=2
+   ```
+
+2. If a specific task type is stuck, **do not blindly purge the queue** — purging loses applications. Instead:
+   - `celery -A config inspect reserved` to see what's stuck
+   - Identify the task IDs
+   - Revoke only those: `celery -A config control revoke <task_id>`
+
+3. Restart workers if their process heap looks bloated (RSS > 2x the average):
+   ```bash
+   docker compose restart celery_worker_ml
+   ```
+   Workers will re-consume from Redis; `task_acks_late=True` means in-flight tasks come back.
+
+**Purge only in a dev environment.** In production, file an incident and drain manually.
+
+## Escalate
+
+- Attach: queue lengths (all queues, 3 readings 10 minutes apart), worker logs (500 lines each), Flower dashboard screenshot.
+- Tag Backend + Infra owners.
+- If P95 latency > 5 min for > 30 min: flip the "predictions-via-sync-fallback" feature flag (once implemented) so the API blocks on ML instead of queueing.

--- a/docs/runbooks/frontend-exit-243.md
+++ b/docs/runbooks/frontend-exit-243.md
@@ -1,0 +1,82 @@
+# Frontend container exits with code 243
+
+**Severity:** High — end users can't reach the UI.
+
+## Symptoms
+
+- `docker compose ps frontend` shows `exited (243)` in a loop
+- Browsers at port 3000 see "connection refused" or immediate 502
+- Container restarts every 10–30 seconds
+
+## Diagnose
+
+1. **Get the last logs before the exit:**
+
+   ```bash
+   docker compose logs --tail 200 frontend
+   ```
+
+2. **Common signatures:**
+
+   | Signature in logs | Likely cause |
+   |-------------------|--------------|
+   | `JavaScript heap out of memory` / `FATAL ERROR: Reached heap limit` | Node OOM during build or SSR |
+   | `Error: listen EADDRINUSE` | Port conflict inside container |
+   | `unable to resolve host` (for the backend) | Networking — `depends_on` or service name mismatch |
+   | `health check failed` / no logs at all, just a restart | Healthcheck timing out before app is ready |
+   | `kill -9` without message | OOM at container level (cgroup limit) |
+
+3. **Check cgroup memory limit:**
+
+   ```bash
+   docker inspect $(docker compose ps -q frontend) --format '{{.HostConfig.Memory}}'
+   ```
+
+   Value `0` means no limit. A low limit (e.g. 134217728 = 128 MB) with a Next.js build will OOM every time.
+
+4. **Exit code 243 specifically** usually means Node exited with code 115 (128+115 = 243). Common cause: Node hit its heap limit and exited.
+
+## Remediate
+
+**If OOM (most common):**
+
+1. Edit `docker-compose.yml` frontend service:
+   ```yaml
+   services:
+     frontend:
+       deploy:
+         resources:
+           limits:
+             memory: 1G
+       environment:
+         NODE_OPTIONS: "--max-old-space-size=768"
+   ```
+
+2. Rebuild + restart:
+   ```bash
+   docker compose up -d --build frontend
+   docker compose logs -f frontend
+   ```
+
+**If healthcheck timeout:**
+
+In the frontend service, extend `healthcheck.start_period`:
+```yaml
+healthcheck:
+  start_period: 60s
+  interval: 10s
+  timeout: 5s
+  retries: 5
+```
+
+**If networking:**
+
+Confirm the backend hostname used by the frontend container matches the service name in compose. Run `docker compose exec frontend ping backend`.
+
+## Escalate
+
+If the container still crash-loops after applying the fix above:
+
+- Attach to the escalation issue: full `docker compose logs frontend` output (at least 500 lines), `docker inspect frontend` JSON, and `docker stats frontend --no-stream`.
+- Tag the Frontend and Infra owners from `.github/CODEOWNERS`.
+- If production is affected: flip the "maintenance mode" feature flag (once implemented) or route DNS to a static status page.

--- a/docs/runbooks/migration-rollback.md
+++ b/docs/runbooks/migration-rollback.md
@@ -1,0 +1,72 @@
+# Migration rollback
+
+**Severity:** depends on the migration — critical if it's already partially applied in production.
+
+## Symptoms
+
+- A deploy included a Django migration that caused errors / data corruption / unacceptable slowness
+- `python manage.py migrate` failed halfway
+- A new column / constraint is making existing queries blow up
+
+## Diagnose
+
+1. **Find the bad migration:**
+   ```bash
+   docker compose exec backend python manage.py showmigrations --plan | tail -20
+   ```
+
+   The latest `[X]` applied entry is where rollback starts.
+
+2. **Check if the migration is reversible:**
+   ```bash
+   grep -n "migrations.RunPython" backend/apps/*/migrations/<NNNN>*.py
+   ```
+
+   `RunPython` without a `reverse_code` function is **irreversible** — you need a forward-only compensating migration, not a rollback.
+
+3. **Check data changes:**
+   If the migration ran `RunPython` that modified rows, rolling back the schema won't unmodify the data. You may need a data repair migration.
+
+## Remediate
+
+**For a reversible migration on a single app:**
+
+```bash
+docker compose exec backend python manage.py migrate <app_label> <previous_migration_number>
+# Example: migrate loans 0023_before_bad_migration
+```
+
+**For an irreversible migration:**
+
+1. Author a **forward-only compensating migration** in the same app:
+   ```bash
+   docker compose exec backend python manage.py makemigrations --empty <app_label>
+   ```
+2. Fill in the compensating operations (drop column, re-add dropped constraint, restore data from backup).
+3. Commit via the normal PR flow — **no emergency bypass**, CI must still pass.
+4. Deploy and apply the compensating migration.
+
+**For a migration that corrupted data:**
+
+1. Stop writes to the affected tables if safe (maintenance mode).
+2. Restore the affected tables from the most recent Postgres backup:
+   ```bash
+   # from the db container:
+   pg_restore -U postgres -d loan_approval -t <table_name> /backups/latest.dump
+   ```
+3. Re-author the migration with the corruption fixed.
+
+## Post-mortem
+
+Every rollback gets a post-mortem:
+- What did the migration do?
+- Why did local / CI testing not catch it?
+- What test would catch it next time? (Add it.)
+- Do we need pre-deploy migration review for a class of changes (e.g., anything touching `Application` table)?
+
+File the post-mortem under `docs/postmortems/YYYY-MM-DD-<slug>.md`.
+
+## Escalate
+
+- Tag Backend owners immediately if production is affected.
+- If data loss is suspected: stop writes, notify stakeholders, do not attempt "quick fixes" against production without a plan.


### PR DESCRIPTION
## Summary

- Three runbooks in consistent Symptoms → Diagnose → Remediate → Escalate format
- Index page explains the reading order and how to add new runbooks
- Covers real failure modes hit in dev: Node OOM (exit 243), Celery backpressure, Django migration rollback (both reversible and irreversible paths)

## Test plan

- [x] Files render on GitHub — Markdown only, no Mermaid or interactive components
- [x] Runbook link from README quickstart (PR #38) will resolve once this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)