### PR TITLE
fix(api_budget): reset fallback counter on Redis recovery + thread-safe increment

### DIFF
--- a/backend/apps/agents/services/api_budget.py
+++ b/backend/apps/agents/services/api_budget.py
@@ -19,6 +19,7 @@ Or use the guarded_api_call() wrapper which handles all of the above:
 
 import hashlib
 import logging
+import threading
 
 import redis
 from django.conf import settings
@@ -69,6 +70,7 @@ class CircuitOpen(Exception):
 # it caps cost exposure during a Redis outage without blocking traffic entirely.
 _REDIS_FALLBACK_CALLS = 0
 _REDIS_FALLBACK_LIMIT = 20  # calls per process during Redis outage
+_REDIS_FALLBACK_LOCK = threading.Lock()
 
 
 class ApiBudgetGuard:
@@ -95,6 +97,7 @@ class ApiBudgetGuard:
 
     def check_budget(self):
         """Raise BudgetExhausted if daily limit reached, CircuitOpen if breaker tripped."""
+        global _REDIS_FALLBACK_CALLS
         try:
             r = self._get_redis()
 
@@ -121,6 +124,12 @@ class ApiBudgetGuard:
                 raise BudgetExhausted(
                     f"Daily API call limit reached ({call_count}/{daily_limit}). Resets at midnight UTC."
                 )
+
+            # Happy path — Redis is healthy and under limits.
+            # Reset the process-local fallback counter so a transient outage
+            # does not permanently brick this worker (F-04).
+            with _REDIS_FALLBACK_LOCK:
+                _REDIS_FALLBACK_CALLS = 0
         except (BudgetExhausted, CircuitOpen):
             raise
         except (redis.RedisError, ConnectionError, TimeoutError) as e:
@@ -128,18 +137,21 @@ class ApiBudgetGuard:
             # we MUST still cap cost exposure — fail-open previously allowed
             # unlimited calls during an outage. Use a per-process fallback
             # counter so brief blips don't kill availability, but a sustained
-            # Redis outage won't run up the API bill.
-            global _REDIS_FALLBACK_CALLS
-            _REDIS_FALLBACK_CALLS += 1
-            if _REDIS_FALLBACK_CALLS > _REDIS_FALLBACK_LIMIT:
+            # Redis outage won't run up the API bill. The increment must be
+            # lock-guarded because Celery IO workers run with concurrency > 1
+            # and unlocked += is not atomic on multi-threaded Python.
+            with _REDIS_FALLBACK_LOCK:
+                _REDIS_FALLBACK_CALLS += 1
+                current = _REDIS_FALLBACK_CALLS
+            if current > _REDIS_FALLBACK_LIMIT:
                 raise BudgetExhausted(
                     f"Redis unavailable and per-process fallback limit reached "
-                    f"({_REDIS_FALLBACK_CALLS}/{_REDIS_FALLBACK_LIMIT}). "
+                    f"({current}/{_REDIS_FALLBACK_LIMIT}). "
                     f"Blocking calls until Redis recovers. Reason: {e}"
                 ) from e
             logger.warning(
                 "Budget check failed (Redis unavailable, %d/%d fallback calls used): %s",
-                _REDIS_FALLBACK_CALLS,
+                current,
                 _REDIS_FALLBACK_LIMIT,
                 e,
             )

--- a/backend/tests/test_api_budget_fallback.py
+++ b/backend/tests/test_api_budget_fallback.py
@@ -1,0 +1,78 @@
+"""Regression tests for api_budget Redis-fallback behaviour (F-04).
+
+The process-local fallback counter must:
+1. Reset to 0 once Redis recovers, so a transient outage does not permanently
+   brick a Celery worker.
+2. Be thread-safe under concurrent increment, because Celery IO workers run
+   with concurrency > 1 and unlocked ``+=`` is not atomic on multi-threaded
+   Python.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+
+import pytest
+import redis
+
+from apps.agents.services import api_budget
+from apps.agents.services.api_budget import ApiBudgetGuard, BudgetExhausted
+
+
+@pytest.fixture(autouse=True)
+def reset_counter():
+    api_budget._REDIS_FALLBACK_CALLS = 0
+    yield
+    api_budget._REDIS_FALLBACK_CALLS = 0
+
+
+class _FakeRedis:
+    """Minimal healthy-Redis stub — no circuit breaker, zero spend, zero calls."""
+
+    def exists(self, _):
+        return False
+
+    def ttl(self, _):
+        return 0
+
+    def get(self, _):
+        return b"0"
+
+
+def test_fallback_counter_resets_after_redis_recovers():
+    """After 20 Redis-unavailable calls plus one successful call, counter is 0."""
+    guard = ApiBudgetGuard()
+
+    # Simulate 20 Redis outage calls — each warns, none raise (limit is 20).
+    with patch.object(guard, "_get_redis", side_effect=redis.RedisError("down")):
+        for _ in range(20):
+            guard.check_budget()
+
+    assert api_budget._REDIS_FALLBACK_CALLS == 20
+
+    # Redis recovers — the next call should succeed and reset the counter.
+    with patch.object(guard, "_get_redis", return_value=_FakeRedis()):
+        guard.check_budget()
+
+    assert api_budget._REDIS_FALLBACK_CALLS == 0, "Counter must reset once Redis becomes available again"
+
+
+def test_fallback_counter_is_thread_safe():
+    """1000 concurrent increments during a simulated Redis outage count to exactly 1000."""
+    guard = ApiBudgetGuard()
+
+    def _one_call():
+        with patch.object(guard, "_get_redis", side_effect=redis.RedisError("down")):
+            try:
+                guard.check_budget()
+            except BudgetExhausted:
+                pass
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        futures = [pool.submit(_one_call) for _ in range(1000)]
+        for f in futures:
+            f.result()
+
+    # Exactly 1000 increments expected; race conditions would undercount.
+    assert api_budget._REDIS_FALLBACK_CALLS == 1000, (
+        f"Race in counter increment: expected 1000, got {api_budget._REDIS_FALLBACK_CALLS}"
+    )


### PR DESCRIPTION
## Summary

Fixes **F-04** from the P0 baseline review (`docs/reviews/2026-04-17-p0-baseline.md`).

The process-local `_REDIS_FALLBACK_CALLS` counter in `api_budget.py` had two defects:
1. **Never reset.** Once 20 Redis-unavailable calls had happened, `check_budget()` permanently raised `BudgetExhausted` even after Redis came back — bricking Claude API access until the worker was restarted.
2. **Not thread-safe.** Celery IO workers run with concurrency > 1; an unlocked `+=` on a module-level int undercounts under load, so the cost-cap could be silently bypassed.

## Changes

- **`backend/apps/agents/services/api_budget.py`**
  - Add `threading.Lock()` at module scope.
  - Reset `_REDIS_FALLBACK_CALLS = 0` under the lock on a successful happy-path pass through `check_budget()`.
  - Increment the counter inside the lock and capture `current` atomically before the threshold check.
- **`backend/tests/test_api_budget_fallback.py`** (new)
  - `test_fallback_counter_resets_after_redis_recovers` — 20 outage calls, then one healthy call, then assert counter is 0.
  - `test_fallback_counter_is_thread_safe` — 1000 calls across 16 threads during a simulated outage; assert counter is exactly 1000 (races would undercount).

## Test plan

- [ ] CI: lint (ruff check + ruff format) passes
- [ ] CI: backend tests pass including the two new regression tests
- [ ] CI: existing `apps/agents` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)