### PR TITLE
test(api_budget): fix flaky thread-safety test (per-thread guard instance)

### DIFF
--- a/backend/tests/test_api_budget_fallback.py
+++ b/backend/tests/test_api_budget_fallback.py
@@ -57,10 +57,19 @@ def test_fallback_counter_resets_after_redis_recovers():
 
 
 def test_fallback_counter_is_thread_safe():
-    """1000 concurrent increments during a simulated Redis outage count to exactly 1000."""
-    guard = ApiBudgetGuard()
+    """1000 concurrent increments during a simulated Redis outage count to exactly 1000.
+
+    Each worker gets its own ApiBudgetGuard so patch.object never races on a
+    shared instance. unittest.mock's enter/exit uses setattr/delattr, and for
+    an attribute that lives on the class (not on vars(instance)), the restore
+    path is a delattr — under concurrent enter/exit on the same instance,
+    this races and can raise AttributeError at exit. The counter we're
+    actually testing lives at module level, so using a fresh guard per call
+    does not weaken the assertion.
+    """
 
     def _one_call():
+        guard = ApiBudgetGuard()
         with patch.object(guard, "_get_redis", side_effect=redis.RedisError("down")):
             try:
                 guard.check_budget()


### PR DESCRIPTION
## Summary

Companion to #47. Fixes a rare 1-in-N flake in `test_fallback_counter_is_thread_safe` that surfaced during #47's CI run.

## Why it flakes

`unittest.mock.patch.object` saves the current attribute value on `__enter__` and restores on `__exit__`. For an attribute defined on the class (not on `vars(instance)`) — like `_get_redis` on `ApiBudgetGuard` — the restore path is a `delattr(instance, attr)`. Under concurrent enter/exit on the same instance from 16 threads, the dance races:

- Thread A enters: `setattr(guard, "_get_redis", MockA)`
- Thread B enters: sees MockA already on instance, so its saved "original" is MockA
- Thread A exits: `delattr(guard, "_get_redis")` — removes from instance
- Thread B exits: tries `setattr(guard, "_get_redis", MockA)` — this works, but...
- Thread C enters between A and B: `delattr` again on an instance that no longer has the attribute — `AttributeError: 'ApiBudgetGuard' object has no attribute '_get_redis'`

## Fix

Each worker constructs its own `ApiBudgetGuard()` inside `_one_call()`. The patch scope never leaves the thread.

The behaviour under test (module-level `_REDIS_FALLBACK_CALLS` counter thread-safety under concurrent increment) is unchanged — that counter is global, not per-instance. The 1,000-call × 16-thread contention is still there; just the mock is per-thread now.

## Test plan

- [x] Ran `pytest tests/test_api_budget_fallback.py -q` locally — 2 passed
- [x] Re-ran 10× locally — no flakes
- [x] Still exercises the module-level lock (counts to exactly 1000, not ~1000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)