### PR TITLE
test(ml_engine): regression-test post-outcome leak invariant

### DIFF
--- a/backend/apps/ml_engine/services/data_generator.py
+++ b/backend/apps/ml_engine/services/data_generator.py
@@ -12,6 +12,29 @@ from .property_data_service import PropertyDataService
 from .underwriting_engine import UnderwritingEngine
 
 
+# Columns emitted by DataGenerator that encode information only available
+# AFTER a lending decision. Using any of these as a model input is target
+# leakage: validation AUC goes up but the model does not generalise to
+# real prediction-time data where these values do not exist.
+#
+# Referenced by backend/tests/test_data_generator_no_leak.py — deleting
+# entries here would silently weaken the regression test.
+POST_OUTCOME_FEATURES: frozenset[str] = frozenset(
+    {
+        # Calibration target the synthetic label is derived from — would leak
+        # the answer directly if used as a feature.
+        "default_probability",
+        # Computed after approval (see "2E. Prepayment buffer" block in
+        # DataGenerator.generate()). Requires knowing the loan was approved
+        # AND has been running long enough to accumulate buffer months.
+        "prepayment_buffer_months",
+        # Negative-equity flag derived from post-disbursement property-value
+        # movements — not knowable at application time.
+        "has_negative_equity",
+    }
+)
+
+
 class DataGenerator:
     """Creates synthetic loan data calibrated against official Australian sources.
 

--- a/backend/apps/ml_engine/services/data_generator.py
+++ b/backend/apps/ml_engine/services/data_generator.py
@@ -11,7 +11,6 @@ from .loan_performance_simulator import LoanPerformanceSimulator
 from .property_data_service import PropertyDataService
 from .underwriting_engine import UnderwritingEngine
 
-
 # Columns emitted by DataGenerator that encode information only available
 # AFTER a lending decision. Using any of these as a model input is target
 # leakage: validation AUC goes up but the model does not generalise to

--- a/backend/tests/test_data_generator_no_leak.py
+++ b/backend/tests/test_data_generator_no_leak.py
@@ -1,0 +1,33 @@
+"""Regression test: no post-outcome feature may reach the training feature set.
+
+A post-outcome feature is one whose value is only knowable AFTER a lending
+decision has been made (e.g., realised default flags, prepayment buffer
+computed after approval, ex-post loan performance metrics). Including any
+such feature in training is target leakage — it inflates validation AUC
+without generalising to real prediction-time data.
+
+This test enforces the separation as a code-level invariant so the pattern
+cannot be reintroduced without a deliberate test change.
+"""
+
+from apps.ml_engine.services.data_generator import POST_OUTCOME_FEATURES
+from apps.ml_engine.services.trainer import ModelTrainer
+
+
+def test_training_features_exclude_post_outcome_columns():
+    training_features = set(ModelTrainer.NUMERIC_COLS) | set(ModelTrainer.CATEGORICAL_COLS)
+    leaked = training_features & POST_OUTCOME_FEATURES
+    assert not leaked, (
+        f"Post-outcome features leaked into training set: {sorted(leaked)}. "
+        f"These columns represent information only available AFTER a lending "
+        f"decision and must not be used as model inputs."
+    )
+
+
+def test_post_outcome_features_constant_is_not_empty():
+    """Sanity check: if this constant became empty, a future refactor silently
+    defanged the leakage test above. Fail loudly instead."""
+    assert len(POST_OUTCOME_FEATURES) >= 3, (
+        f"POST_OUTCOME_FEATURES has only {len(POST_OUTCOME_FEATURES)} entries. "
+        f"Expected at least 3 known post-decision columns from DataGenerator."
+    )


### PR DESCRIPTION
## Summary
- Adds `POST_OUTCOME_FEATURES` frozenset to `data_generator.py` with 3 known post-decision columns (`default_probability`, `prepayment_buffer_months`, `has_negative_equity`)
- New test `test_data_generator_no_leak.py` asserts `ModelTrainer.NUMERIC_COLS ∪ CATEGORICAL_COLS` has zero intersection with `POST_OUTCOME_FEATURES`
- Audit confirmed the current training set is already clean; this promotes the informal separation into a code-enforced invariant

## Test plan
- [x] New test passes locally (2/2 green)
- [x] Full ml_engine test scope passes (80/80, 1 pre-existing skip)
- [ ] CI backend-test job green

Source: external code review 2026-04-17, Item A. Design: `docs/superpowers/specs/2026-04-17-review-response-v1.9.1-design.md`