### PR TITLE
test(coverage): collect app-level tests + frontend floor (v1.9.1 item B phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Run tests
         working-directory: backend
-        run: pytest -v --tb=short --cov=apps --cov-report=term-missing --cov-fail-under=60
+        run: pytest -v --tb=short --cov=apps --cov-report=term-missing --cov-fail-under=63
 
   backend-lint:
     name: Backend Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Run tests
         working-directory: backend
-        run: pytest tests/ -v --tb=short --cov=apps --cov-report=term-missing --cov-fail-under=60
+        run: pytest -v --tb=short --cov=apps --cov-report=term-missing --cov-fail-under=60
 
   backend-lint:
     name: Backend Lint

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,6 +27,7 @@ indent-style = "space"
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "config.settings.development"
+testpaths = ["tests", "apps"]
 python_files = ["test_*.py", "tests.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -18,7 +18,12 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       include: ['src/components/**', 'src/hooks/**', 'src/lib/**'],
-      thresholds: { lines: 40 },
+      thresholds: {
+        lines: 65,
+        statements: 65,
+        functions: 75,
+        branches: 75,
+      },
     },
   },
 })


### PR DESCRIPTION
## Summary
- **Backend**: `pytest tests/` was missing 5 real test suites in `apps/*/tests/` (counterfactual engine, orchestrator CF step, CF integration, serializer CF fields). Adding `testpaths = ["tests", "apps"]` to pyproject.toml collects both while respecting python_files filters. **Coverage lift: 61.35% → 63.98%** (+20 tests collected, all green in CI).
- **Gate bump**: `--cov-fail-under` raised from 60 → **63** in the same PR, after CI confirmed the lift. Tight enough to bite on regressions, 0.98pt buffer over measured.
- **Frontend**: locked in the current measured vitest floor with per-metric thresholds (65L/75B/75F/65S). Multi-metric catches regressions the old single-`lines` gate would have missed.

## Phase plan for 2026-04-17 review item B
1. **This PR (phase 1)** ✓ — collect existing un-collected tests, tighten frontend floor, measure new baseline, bump gate 60→63.
2. **Phase 2 (next PR)** — write targeted tests for the three lowest-coverage production modules (counterfactual_engine ~11%, marketing_agent ~11%, next_best_offer ~13%) to push the gate further toward the 75% target.

## Test plan
- [x] CI Backend Tests green (1040 → 1060 tests, all passing)
- [x] CI Frontend Tests green with new thresholds
- [x] Backend coverage TOTAL line in CI log: 63.98% (prior master was 61.35%)
- [x] `--cov-fail-under=63` gate passes with 0.98pt buffer over measured

## Run evidence
- [Backend Tests run — 63.98% coverage, 1060 passed](https://github.com/zeroyuekun/loan-approval-ai-system/actions/runs/24549952863/job/71773481312)

🤖 Generated with [Claude Code](https://claude.com/claude-code)