### PR TITLE
ci: split 431-line ci.yml into lint/test/security/build (v1.9.1 D)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,14 @@
-name: CI
+name: Build
 
 on:
   push:
     branches: [master, main]
   pull_request:
     branches: [master, main]
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 
 # Force Node.js 24 runtime for all JS actions (gitleaks@v2 has no native Node 24 version)
 env:
@@ -15,199 +19,6 @@ permissions:
   packages: write
 
 jobs:
-  backend-test:
-    name: Backend Tests
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:17-alpine
-        env:
-          POSTGRES_DB: loan_approval_test
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    env:
-      DJANGO_SETTINGS_MODULE: config.settings.development
-      DJANGO_SECRET_KEY: ci-test-secret-key-not-for-production
-      DJANGO_DEBUG: "True"
-      POSTGRES_DB: loan_approval_test
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_HOST: localhost
-      POSTGRES_PORT: 5432
-      CELERY_BROKER_URL: redis://localhost:6379/0
-      FIELD_ENCRYPTION_KEY: "kA6H1LGRC3JUszuqLoXUyvxw_IX5bjJSDJ6B57rdexU="
-      ANTHROPIC_API_KEY: sk-ant-test-key
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Set up Python 3.13
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-          cache: pip
-          cache-dependency-path: backend/requirements.txt
-
-      - name: Install dependencies
-        working-directory: backend
-        run: pip install -r requirements.txt -r requirements-dev.txt
-
-      - name: Run migrations
-        working-directory: backend
-        run: python manage.py migrate --noinput
-
-      - name: Run tests
-        working-directory: backend
-        run: pytest -v --tb=short --cov=apps --cov-report=term-missing --cov-fail-under=63
-
-  backend-lint:
-    name: Backend Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Set up Python 3.13
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-          cache: pip
-
-      - name: Install linters
-        run: pip install ruff
-
-      - name: Lint with Ruff
-        working-directory: backend
-        run: ruff check .
-
-      - name: Format check with Ruff
-        working-directory: backend
-        run: ruff format --check .
-
-  frontend-lint:
-    name: Frontend Lint & Type Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install dependencies
-        working-directory: frontend
-        run: npm ci
-
-      - name: Type check
-        working-directory: frontend
-        run: npx tsc --noEmit
-
-      - name: Lint
-        working-directory: frontend
-        run: npm run lint
-
-  frontend-test:
-    name: Frontend Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install dependencies
-        working-directory: frontend
-        run: npm ci
-
-      - name: Run tests with coverage
-        working-directory: frontend
-        run: npm run test:ci
-
-      - name: Upload coverage report
-        if: always()
-        uses: actions/upload-artifact@v5
-        with:
-          name: frontend-coverage
-          path: frontend/coverage/
-          retention-days: 14
-
-  security:
-    name: Security Scan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
-      - name: Install security tools
-        run: pip install bandit
-      - name: Bandit SAST scan (Python)
-        run: |
-          bandit -r backend/apps/ -f json -o bandit-report.json --severity-level high
-          bandit -r backend/apps/ --severity-level high -f screen
-      - name: Upload security report
-        uses: actions/upload-artifact@v5
-        if: always()
-        with:
-          name: security-reports
-          path: bandit-report.json
-          retention-days: 30
-
-  dependency-audit:
-    name: Dependency Audit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
-      - name: Audit Python dependencies
-        run: |
-          pip install pip-audit
-          pip-audit -r backend/requirements.txt --desc on
-      - name: Set up Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: '22'
-      - name: Install frontend deps
-        working-directory: frontend
-        run: npm ci
-      - name: Audit npm dependencies
-        working-directory: frontend
-        run: npm audit --audit-level=moderate
-
-  secret-scan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc  # v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   docker-build:
     name: Docker Build
     runs-on: ubuntu-latest
@@ -393,8 +204,11 @@ jobs:
   deploy:
     name: Build & Push Images
     runs-on: ubuntu-latest
-    needs: [backend-test, backend-lint, frontend-lint, frontend-test, security, docker-build, dependency-audit, secret-scan, dast-scan]
-    if: always() && github.ref == 'refs/heads/master' && github.event_name == 'push' && !contains(needs.backend-test.result, 'failure') && !contains(needs.backend-lint.result, 'failure') && !contains(needs.frontend-lint.result, 'failure') && !contains(needs.frontend-test.result, 'failure') && !contains(needs.security.result, 'failure') && !contains(needs.docker-build.result, 'failure') && !contains(needs.dependency-audit.result, 'failure') && !contains(needs.secret-scan.result, 'failure') && !contains(needs.dast-scan.result, 'failure')
+    needs: [docker-build, dast-scan]
+    # Relies on branch-protection rules to require green Lint / Test / Security
+    # workflow conclusions before a push reaches master. See
+    # docs/runbooks/ci-deployment.md for the required-checks list.
+    if: always() && github.ref == 'refs/heads/master' && github.event_name == 'push' && !contains(needs.docker-build.result, 'failure') && !contains(needs.dast-scan.result, 'failure')
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,67 @@
+name: Lint
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+# Force Node.js 24 runtime for all JS actions (gitleaks@v2 has no native Node 24 version)
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+
+jobs:
+  backend-lint:
+    name: Backend Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install linters
+        run: pip install ruff
+
+      - name: Lint with Ruff
+        working-directory: backend
+        run: ruff check .
+
+      - name: Format check with Ruff
+        working-directory: backend
+        run: ruff format --check .
+
+  frontend-lint:
+    name: Frontend Lint & Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Type check
+        working-directory: frontend
+        run: npx tsc --noEmit
+
+      - name: Lint
+        working-directory: frontend
+        run: npm run lint

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,75 @@
+name: Security
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+# Force Node.js 24 runtime for all JS actions (gitleaks@v2 has no native Node 24 version)
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+
+jobs:
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+      - name: Install security tools
+        run: pip install bandit
+      - name: Bandit SAST scan (Python)
+        run: |
+          bandit -r backend/apps/ -f json -o bandit-report.json --severity-level high
+          bandit -r backend/apps/ --severity-level high -f screen
+      - name: Upload security report
+        uses: actions/upload-artifact@v5
+        if: always()
+        with:
+          name: security-reports
+          path: bandit-report.json
+          retention-days: 30
+
+  dependency-audit:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+      - name: Audit Python dependencies
+        run: |
+          pip install pip-audit
+          pip-audit -r backend/requirements.txt --desc on
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+      - name: Install frontend deps
+        working-directory: frontend
+        run: npm ci
+      - name: Audit npm dependencies
+        working-directory: frontend
+        run: npm audit --audit-level=moderate
+
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc  # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,108 @@
+name: Test
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+# Force Node.js 24 runtime for all JS actions (gitleaks@v2 has no native Node 24 version)
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+
+jobs:
+  backend-test:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_DB: loan_approval_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DJANGO_SETTINGS_MODULE: config.settings.development
+      DJANGO_SECRET_KEY: ci-test-secret-key-not-for-production
+      DJANGO_DEBUG: "True"
+      POSTGRES_DB: loan_approval_test
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_HOST: localhost
+      POSTGRES_PORT: 5432
+      CELERY_BROKER_URL: redis://localhost:6379/0
+      FIELD_ENCRYPTION_KEY: "kA6H1LGRC3JUszuqLoXUyvxw_IX5bjJSDJ6B57rdexU="
+      ANTHROPIC_API_KEY: sk-ant-test-key
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        working-directory: backend
+        run: pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Run migrations
+        working-directory: backend
+        run: python manage.py migrate --noinput
+
+      - name: Run tests
+        working-directory: backend
+        run: pytest -v --tb=short --cov=apps --cov-report=term-missing --cov-fail-under=63
+
+  frontend-test:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run tests with coverage
+        working-directory: frontend
+        run: npm run test:ci
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: frontend-coverage
+          path: frontend/coverage/
+          retention-days: 14


### PR DESCRIPTION
## Summary

External code review (2026-04-17) called out the monolithic `ci.yml` as a maintainability smell — 431 lines, 11 jobs in one file, shared concurrency group. Splitting into focused workflows per GitHub Actions 2026 best practice.

**Before:** single `ci.yml` (431 LOC, 11 jobs, one concurrency group)

**After:** four focused workflows, each independently cancellable:

| Workflow | Jobs |
|----------|------|
| `lint.yml` | backend-lint (ruff), frontend-lint & type-check |
| `test.yml` | backend-test (pytest + cov-fail-under=63), frontend-test (vitest) |
| `security.yml` | bandit SAST, pip-audit + npm audit, gitleaks secret-scan |
| `build.yml` | docker-build + trivy, DAST (master), k6 (master), deploy |

## Design decisions

- **Cross-workflow `needs:` constraint.** GitHub Actions does not allow `needs:` across workflow files. Deploy in `build.yml` keeps only `needs: [docker-build, dast-scan]`. Branch-protection rules enforce lint/test/security green before push to master. Documented inline in the deploy job.
- **Job names preserved verbatim.** All 11 job display names are unchanged to avoid breaking branch-protection required-status-checks configuration. No admin action needed.
- **Concurrency groups per workflow.** Each file has its own `concurrency: group: <name>-${{ github.ref }}` so a stalled lint run doesn't block tests.

## Validation

- [x] `python -c "import yaml; [yaml.safe_load(open(f)) for f in ('lint.yml','test.yml','security.yml','build.yml')]"` — all parse
- [ ] CI: this PR itself will validate the workflow split (lint/test/security/docker-build runs)
- [ ] Required checks remain green

## Test plan

- [x] YAML syntax validated locally
- [ ] All 4 new workflows trigger on PR
- [ ] Deploy job stays master-only (verify by inspecting Actions tab — should not run here)
- [ ] Post-merge: observe master run; branch protection auto-picks up new workflow names (same job names)

Part of v1.9.1 portfolio-polish pass. Items A, B shipped in #63, #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)