### PR TITLE
fix(ops): gate metrics and deep health behind auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Security
 
 - Enforce Django CSRF validation on cookie-based JWT authentication. Mutating requests authenticated via the `access_token` HttpOnly cookie now require a matching `X-CSRFToken` header. Bearer-header auth is unchanged. Addresses Codex adversarial review finding #1.
+- Gate `/metrics` and deep-health behind auth. `/metrics` now requires staff session or `X-Health-Token` header (previously unauthenticated). Removed `/metrics` from the public Kubernetes ingress — still reachable on the internal network for Prometheus. `deep_health_check` refuses to respond (503) in non-DEBUG environments when `HEALTH_CHECK_TOKEN` is unset, so production won't silently leak diagnostics. Prometheus scrape config carries the token via `http_headers`. Addresses Codex adversarial review finding #2.
 
 ## 1.9.2 — 2026-04-18
 

--- a/backend/config/ops_auth.py
+++ b/backend/config/ops_auth.py
@@ -1,0 +1,33 @@
+"""Authentication helper for operational endpoints (metrics, deep health).
+
+Accepts either:
+  1. Staff session (user.is_staff True) — for ad-hoc inspection via the admin
+  2. X-Health-Token header matching settings.HEALTH_CHECK_TOKEN — for Prometheus
+     scrapes and automated tooling
+
+Denies all other requests with 403.
+"""
+
+import hmac
+from functools import wraps
+
+from django.conf import settings
+from django.http import JsonResponse
+
+
+def require_ops_auth(view_func):
+    """Gate a view behind staff session OR X-Health-Token header."""
+
+    @wraps(view_func)
+    def _wrapped(request, *args, **kwargs):
+        if getattr(request.user, "is_staff", False):
+            return view_func(request, *args, **kwargs)
+
+        token = getattr(settings, "HEALTH_CHECK_TOKEN", "") or ""
+        provided = request.headers.get("X-Health-Token", "") or ""
+        if token and hmac.compare_digest(provided.encode(), token.encode()):
+            return view_func(request, *args, **kwargs)
+
+        return JsonResponse({"error": "unauthorized"}, status=403)
+
+    return _wrapped

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.contrib import admin
 from django.http import HttpResponse, JsonResponse
 from django.urls import include, path
+from django_prometheus.exports import ExportToDjangoView
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_framework import status as http_status
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
@@ -16,6 +17,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.loans.models import LoanApplication
+from config.ops_auth import require_ops_auth
 
 
 class TaskStatusView(APIView):
@@ -105,9 +107,18 @@ def deep_health_check(request):
     """
     from django.conf import settings as django_settings
 
-    token = getattr(django_settings, "HEALTH_CHECK_TOKEN", "")
-    if token:
-        provided = request.headers.get("X-Health-Token", "")
+    token = getattr(django_settings, "HEALTH_CHECK_TOKEN", "") or ""
+    debug = getattr(django_settings, "DEBUG", False)
+
+    if not token:
+        if not debug:
+            return JsonResponse(
+                {"error": "deep health not configured — set HEALTH_CHECK_TOKEN"},
+                status=503,
+            )
+        # DEBUG=True: allow open access for local development
+    else:
+        provided = request.headers.get("X-Health-Token", "") or ""
         is_staff = getattr(request.user, "is_staff", False)
         if not hmac.compare_digest(provided.encode(), token.encode()) and not is_staff:
             return JsonResponse({"error": "unauthorized"}, status=403)
@@ -204,9 +215,9 @@ def deep_health_check(request):
 
 
 urlpatterns = [
-    # Prometheus metrics — restrict in production via reverse proxy or firewall.
-    # Only expose on internal network; do not route through public ingress.
-    path("", include("django_prometheus.urls")),
+    # Prometheus metrics — gated behind staff session or X-Health-Token header.
+    # Also excluded from public Kubernetes ingress (k8s/ingress.yaml).
+    path("metrics", require_ops_auth(ExportToDjangoView), name="prometheus-django-metrics"),
     path(".well-known/security.txt", security_txt, name="security-txt"),
     path("api/v1/health/", health_check, name="health-check"),
     path("api/v1/health/deep/", deep_health_check, name="deep-health-check"),

--- a/backend/docs/RUNBOOK.md
+++ b/backend/docs/RUNBOOK.md
@@ -56,8 +56,8 @@
 | Method | Endpoint | Auth | Description |
 |--------|----------|------|-------------|
 | GET | `/api/v1/health/` | No | Basic liveness check |
-| GET | `/api/v1/health/deep/` | No | DB + Redis + ML model check |
-| GET | `/metrics` | No | Prometheus metrics (django-prometheus) |
+| GET | `/api/v1/health/deep/` | **Yes** (staff session or X-Health-Token) | DB + Redis + ML model check. Returns 503 in production if `HEALTH_CHECK_TOKEN` is unset. |
+| GET | `/metrics` | **Yes** (staff session or X-Health-Token) | Prometheus metrics (django-prometheus). Not publicly routed. |
 
 ### Authentication (`/api/v1/auth/`)
 

--- a/backend/tests/test_ops_endpoints.py
+++ b/backend/tests/test_ops_endpoints.py
@@ -1,0 +1,110 @@
+"""Tests for operational endpoint gating: /metrics and /api/v1/health/deep/.
+
+Both endpoints must be unreachable without either staff session or a valid
+X-Health-Token. Deep health must also refuse to respond in production-like
+settings when HEALTH_CHECK_TOKEN is unset.
+"""
+
+import pytest
+from django.test.utils import override_settings
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.accounts.models import CustomUser
+
+
+@pytest.fixture
+def staff_user(db):
+    return CustomUser.objects.create_user(
+        username="ops_staff",
+        email="ops@test.com",
+        password="testpass123",
+        role="admin",
+        is_staff=True,
+        first_name="Ops",
+        last_name="Staff",
+    )
+
+
+@pytest.fixture
+def regular_user(db):
+    return CustomUser.objects.create_user(
+        username="ops_regular",
+        email="regular@test.com",
+        password="testpass123",
+        role="customer",
+        is_staff=False,
+        first_name="Regular",
+        last_name="User",
+    )
+
+
+@pytest.mark.django_db
+class TestMetricsEndpointGating:
+    """GET /metrics must be gated behind staff session or X-Health-Token."""
+
+    def test_unauthenticated_denied(self):
+        client = APIClient()
+        resp = client.get("/metrics")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_non_staff_user_denied(self, regular_user):
+        client = APIClient()
+        client.login(username="ops_regular", password="testpass123")
+        resp = client.get("/metrics")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_staff_user_allowed(self, staff_user):
+        client = APIClient()
+        client.login(username="ops_staff", password="testpass123")
+        resp = client.get("/metrics")
+        assert resp.status_code == status.HTTP_200_OK
+        assert b"django_http_requests_total" in resp.content or b"# HELP" in resp.content
+
+    @override_settings(HEALTH_CHECK_TOKEN="s3cr3t-ops-token")
+    def test_valid_token_header_allowed(self):
+        client = APIClient()
+        resp = client.get("/metrics", HTTP_X_HEALTH_TOKEN="s3cr3t-ops-token")
+        assert resp.status_code == status.HTTP_200_OK
+
+    @override_settings(HEALTH_CHECK_TOKEN="s3cr3t-ops-token")
+    def test_invalid_token_header_denied(self):
+        client = APIClient()
+        resp = client.get("/metrics", HTTP_X_HEALTH_TOKEN="wrong-token")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+class TestDeepHealthConfigured:
+    """Deep health must refuse to respond if token is unconfigured in production."""
+
+    @override_settings(DEBUG=False, HEALTH_CHECK_TOKEN="")
+    def test_unconfigured_token_in_prod_returns_503(self):
+        client = APIClient()
+        resp = client.get("/api/v1/health/deep/")
+        assert resp.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert "not configured" in resp.json().get("error", "").lower()
+
+    @override_settings(DEBUG=True, HEALTH_CHECK_TOKEN="")
+    def test_unconfigured_token_in_debug_allowed(self):
+        """Local dev with DEBUG=True may run deep health without a token."""
+        client = APIClient()
+        resp = client.get("/api/v1/health/deep/")
+        # 200 healthy or 503 degraded (no DB/Redis locally) — both OK, not "unconfigured"
+        body = resp.json()
+        assert "error" not in body or "not configured" not in body.get("error", "")
+
+    @override_settings(DEBUG=False, HEALTH_CHECK_TOKEN="health-tok-xyz")
+    def test_configured_token_wrong_header_denied(self):
+        client = APIClient()
+        resp = client.get("/api/v1/health/deep/", HTTP_X_HEALTH_TOKEN="wrong")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+    @override_settings(DEBUG=False, HEALTH_CHECK_TOKEN="health-tok-xyz")
+    def test_configured_token_correct_header_allowed(self):
+        client = APIClient()
+        resp = client.get("/api/v1/health/deep/", HTTP_X_HEALTH_TOKEN="health-tok-xyz")
+        # Status may be 200 or 503 depending on DB/Redis availability — both pass auth
+        assert resp.status_code in (200, 503)
+        body = resp.json()
+        assert body.get("error") != "unauthorized"

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -28,13 +28,6 @@ spec:
                 name: backend
                 port:
                   number: 8000
-          - path: /metrics
-            pathType: Prefix
-            backend:
-              service:
-                name: backend
-                port:
-                  number: 8000
           - path: /
             pathType: Prefix
             backend:

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -16,6 +16,10 @@ scrape_configs:
     static_configs:
       - targets: ['backend:8000']
     scrape_interval: 10s
+    http_headers:
+      X-Health-Token:
+        values:
+          - ${HEALTH_CHECK_TOKEN}
 
   - job_name: 'redis'
     static_configs:


### PR DESCRIPTION
## Summary
- Wraps `/metrics` with an `X-Health-Token` / staff session check via `require_ops_auth` so Prometheus metrics are no longer publicly scrapeable.
- Tightens `/api/v1/health/deep/` to return 503 when `HEALTH_CHECK_TOKEN` is unset in non-DEBUG mode.
- Drops the public `/metrics` path from `k8s/ingress.yaml`; Prometheus job now sends `X-Health-Token` via `http_headers`.
- Addresses Codex adversarial review finding #2 (2026-04-18).

## Test plan
- [x] `pytest tests/test_ops_endpoints.py -v` — 9/9 pass (anon 403, bad token 403, good token 200, staff 200, regular user 403, deep-health 503 when unset)
- [ ] Post-merge: update the Prometheus server's env so the scrape actually sends `X-Health-Token`
- [ ] Post-merge: verify k8s ingress no longer routes `/metrics` publicly

🤖 Generated with [Claude Code](https://claude.com/claude-code)