### PR TITLE
fix(loans): validate complaint ownership on create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v1.9.4 — Security & Reliability Follow-ups (2026-04-18)
 
+### Security
+
+- Validate complaint ownership on create. `ComplaintSerializer` now rejects (400) a complaint whose `loan_application` belongs to another customer; staff (`admin`/`officer`) may still file on behalf of customers, which is recorded as `details.on_behalf_of_id` on the new `complaint_filed` audit entry. Addresses Codex adversarial review finding #3 (second pass).
+
 ### Reliability
 
 - Hard-cap batch orchestration default path at 100 applications (was unbounded). The `recheck=true` path already had the cap; the default `POST /api/v1/agents/orchestrate-all/` now applies the same limit, orders oldest-first, and reports `skipped` + a drain-hint `detail` when the backlog exceeds the cap. The `batch_pipeline_triggered` audit entry gains a `skipped_count` field. Addresses Codex adversarial review finding #2 (second pass).

--- a/backend/apps/loans/serializers.py
+++ b/backend/apps/loans/serializers.py
@@ -296,13 +296,30 @@ class ComplaintSerializer(serializers.ModelSerializer):
             "updated_at",
         )
 
+    def validate_loan_application(self, value):
+        if value is None:
+            return value
+        request = self.context["request"]
+        user = request.user
+        if getattr(user, "role", None) in ("admin", "officer"):
+            return value
+        if value.applicant_id != user.id:
+            raise serializers.ValidationError(
+                "You can only file complaints on your own applications."
+            )
+        return value
+
     def create(self, validated_data):
         from datetime import timedelta
 
         from django.utils import timezone
 
         now = timezone.now()
-        validated_data["complainant"] = self.context["request"].user
+        request = self.context["request"]
+        user = request.user
+        loan_app = validated_data.get("loan_application")
+
+        validated_data["complainant"] = user
         validated_data["acknowledged_at"] = now
 
         # ASIC RG 271: 21 days for credit-related, 30 days for standard
@@ -310,4 +327,23 @@ class ComplaintSerializer(serializers.ModelSerializer):
         sla_days = 21 if category == "decision" else 30
         validated_data["sla_deadline"] = now + timedelta(days=sla_days)
 
-        return super().create(validated_data)
+        instance = super().create(validated_data)
+
+        on_behalf_of_id = None
+        if loan_app and loan_app.applicant_id != user.id:
+            on_behalf_of_id = loan_app.applicant_id
+
+        AuditLog.objects.create(
+            user=user,
+            action="complaint_filed",
+            resource_type="Complaint",
+            resource_id=str(instance.id),
+            details={
+                "category": category,
+                "loan_application_id": str(loan_app.id) if loan_app else None,
+                "on_behalf_of_id": on_behalf_of_id,
+            },
+            ip_address=request.META.get("REMOTE_ADDR"),
+        )
+
+        return instance

--- a/backend/apps/loans/serializers.py
+++ b/backend/apps/loans/serializers.py
@@ -304,9 +304,7 @@ class ComplaintSerializer(serializers.ModelSerializer):
         if getattr(user, "role", None) in ("admin", "officer"):
             return value
         if value.applicant_id != user.id:
-            raise serializers.ValidationError(
-                "You can only file complaints on your own applications."
-            )
+            raise serializers.ValidationError("You can only file complaints on your own applications.")
         return value
 
     def create(self, validated_data):

--- a/backend/tests/test_complaint_tenant.py
+++ b/backend/tests/test_complaint_tenant.py
@@ -1,0 +1,166 @@
+"""Tests for Finding 3 — ComplaintSerializer cross-tenant validation.
+
+Closes the Codex adversarial review finding that any authenticated user
+could file a Complaint tied to another user's loan_application because
+ComplaintSerializer.create() overwrote `complainant` with request.user
+but never validated ownership of the referenced loan.
+"""
+
+from decimal import Decimal
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.accounts.models import CustomUser
+from apps.loans.models import AuditLog, Complaint, LoanApplication
+
+COMPLAINTS_URL = "/api/v1/loans/complaints/"
+
+
+def _make_customer(username, email):
+    return CustomUser.objects.create_user(
+        username=username,
+        email=email,
+        password="testpass123",
+        role="customer",
+        first_name=username.title(),
+        last_name="Tester",
+    )
+
+
+def _make_application(applicant):
+    return LoanApplication.objects.create(
+        applicant=applicant,
+        annual_income=Decimal("75000.00"),
+        credit_score=720,
+        loan_amount=Decimal("25000.00"),
+        loan_term_months=36,
+        debt_to_income=Decimal("1.50"),
+        employment_length=5,
+        purpose="personal",
+        home_ownership="rent",
+        has_cosigner=False,
+        monthly_expenses=Decimal("2200.00"),
+        existing_credit_card_limit=Decimal("8000.00"),
+        number_of_dependants=0,
+        employment_type="payg_permanent",
+        applicant_type="single",
+        has_hecs=False,
+        has_bankruptcy=False,
+        state="NSW",
+    )
+
+
+@pytest.fixture
+def customer_a(db):
+    return _make_customer("customer_a", "a@test.com")
+
+
+@pytest.fixture
+def customer_b(db):
+    return _make_customer("customer_b", "b@test.com")
+
+
+@pytest.fixture
+def loan_a(customer_a):
+    return _make_application(customer_a)
+
+
+@pytest.fixture
+def loan_b(customer_b):
+    return _make_application(customer_b)
+
+
+def _payload(loan_application_id):
+    return {
+        "loan_application": str(loan_application_id) if loan_application_id else None,
+        "category": "decision",
+        "subject": "Concerned about outcome",
+        "description": "Please re-review my file.",
+    }
+
+
+@pytest.mark.django_db
+class TestComplaintTenantValidation:
+    def test_customer_cannot_file_on_other_customers_loan(
+        self, customer_a, loan_b
+    ):
+        client = APIClient()
+        client.force_authenticate(user=customer_a)
+
+        response = client.post(COMPLAINTS_URL, _payload(loan_b.id), format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        body = response.json()
+        assert "loan_application" in body
+        assert "You can only file complaints on your own applications." in str(
+            body["loan_application"]
+        )
+        assert Complaint.objects.count() == 0
+        assert not AuditLog.objects.filter(action="complaint_filed").exists()
+
+    def test_customer_can_file_on_own_loan(self, customer_a, loan_a):
+        client = APIClient()
+        client.force_authenticate(user=customer_a)
+
+        response = client.post(COMPLAINTS_URL, _payload(loan_a.id), format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Complaint.objects.count() == 1
+        audit = AuditLog.objects.get(action="complaint_filed")
+        assert audit.user == customer_a
+        assert audit.details["on_behalf_of_id"] is None
+        assert audit.details["loan_application_id"] == str(loan_a.id)
+        assert audit.details["category"] == "decision"
+
+    def test_officer_can_file_on_any_customer_loan(
+        self, officer_user, customer_b, loan_b
+    ):
+        client = APIClient()
+        client.force_authenticate(user=officer_user)
+
+        response = client.post(COMPLAINTS_URL, _payload(loan_b.id), format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Complaint.objects.count() == 1
+        audit = AuditLog.objects.get(action="complaint_filed")
+        assert audit.user == officer_user
+        assert audit.details["on_behalf_of_id"] == customer_b.id
+
+    def test_admin_can_file_on_any_customer_loan(
+        self, admin_user, customer_b, loan_b
+    ):
+        client = APIClient()
+        client.force_authenticate(user=admin_user)
+
+        response = client.post(COMPLAINTS_URL, _payload(loan_b.id), format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        audit = AuditLog.objects.get(action="complaint_filed")
+        assert audit.details["on_behalf_of_id"] == customer_b.id
+
+    def test_complaint_without_loan_application_still_allowed(
+        self, customer_a
+    ):
+        client = APIClient()
+        client.force_authenticate(user=customer_a)
+
+        response = client.post(COMPLAINTS_URL, _payload(None), format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        audit = AuditLog.objects.get(action="complaint_filed")
+        assert audit.details["loan_application_id"] is None
+        assert audit.details["on_behalf_of_id"] is None
+
+    def test_nonexistent_loan_id_rejected(self, customer_a):
+        import uuid
+
+        client = APIClient()
+        client.force_authenticate(user=customer_a)
+
+        response = client.post(
+            COMPLAINTS_URL, _payload(uuid.uuid4()), format="json"
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/backend/tests/test_complaint_tenant.py
+++ b/backend/tests/test_complaint_tenant.py
@@ -83,9 +83,7 @@ def _payload(loan_application_id):
 
 @pytest.mark.django_db
 class TestComplaintTenantValidation:
-    def test_customer_cannot_file_on_other_customers_loan(
-        self, customer_a, loan_b
-    ):
+    def test_customer_cannot_file_on_other_customers_loan(self, customer_a, loan_b):
         client = APIClient()
         client.force_authenticate(user=customer_a)
 
@@ -94,9 +92,7 @@ class TestComplaintTenantValidation:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         body = response.json()
         assert "loan_application" in body
-        assert "You can only file complaints on your own applications." in str(
-            body["loan_application"]
-        )
+        assert "You can only file complaints on your own applications." in str(body["loan_application"])
         assert Complaint.objects.count() == 0
         assert not AuditLog.objects.filter(action="complaint_filed").exists()
 
@@ -114,9 +110,7 @@ class TestComplaintTenantValidation:
         assert audit.details["loan_application_id"] == str(loan_a.id)
         assert audit.details["category"] == "decision"
 
-    def test_officer_can_file_on_any_customer_loan(
-        self, officer_user, customer_b, loan_b
-    ):
+    def test_officer_can_file_on_any_customer_loan(self, officer_user, customer_b, loan_b):
         client = APIClient()
         client.force_authenticate(user=officer_user)
 
@@ -128,9 +122,7 @@ class TestComplaintTenantValidation:
         assert audit.user == officer_user
         assert audit.details["on_behalf_of_id"] == customer_b.id
 
-    def test_admin_can_file_on_any_customer_loan(
-        self, admin_user, customer_b, loan_b
-    ):
+    def test_admin_can_file_on_any_customer_loan(self, admin_user, customer_b, loan_b):
         client = APIClient()
         client.force_authenticate(user=admin_user)
 
@@ -140,9 +132,7 @@ class TestComplaintTenantValidation:
         audit = AuditLog.objects.get(action="complaint_filed")
         assert audit.details["on_behalf_of_id"] == customer_b.id
 
-    def test_complaint_without_loan_application_still_allowed(
-        self, customer_a
-    ):
+    def test_complaint_without_loan_application_still_allowed(self, customer_a):
         client = APIClient()
         client.force_authenticate(user=customer_a)
 
@@ -159,8 +149,6 @@ class TestComplaintTenantValidation:
         client = APIClient()
         client.force_authenticate(user=customer_a)
 
-        response = client.post(
-            COMPLAINTS_URL, _payload(uuid.uuid4()), format="json"
-        )
+        response = client.post(COMPLAINTS_URL, _payload(uuid.uuid4()), format="json")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
## Summary
- `ComplaintSerializer` now rejects cross-tenant `loan_application` references from non-staff users (400)
- Staff (`admin`/`officer`) can still file on behalf of customers — recorded as `on_behalf_of_id` on a new `complaint_filed` audit entry
- Anonymous complaints (no `loan_application`) are unchanged

Addresses Codex adversarial review finding #3 (second pass).

## Test plan
- [x] `pytest tests/test_complaint_tenant.py` — all 6 new tests green
- [x] Loans/complaint/audit regression suite green (70 passed, 5 skipped)
- [ ] Manual: as customer A, attempt to file complaint with customer B's `loan_application` id → 400 with the exact error message

Generated with [Claude Code](https://claude.com/claude-code)