### PR TITLE
fix(security): scoped throttles on complaint filing + data export (v1.9.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v1.9.6 — Workstream B (partial): Throttle & Version Fixes (2026-04-18)
+
+### Security
+
+- Scoped throttle on `ComplaintViewSet.create` — `ComplaintFilingThrottle` (`complaint_filing` scope, 10/hour per user). Complaint filing was previously governed only by the default 60/min user throttle, which left the endpoint open to spam and potentially abusive complaint floods. List/retrieve paths are unaffected.
+- Scoped throttle on `CustomerDataExportView` — `DataExportThrottle` (`data_export` scope, 10/hour per user). Privacy Act APP-12 self-service export is inherently low-frequency; the view also performs a heavy `prefetch_related` across loans, decisions, emails, agent runs, bias reports, and marketing emails, so a tight cap is a modest hardening against accidental or deliberate resource exhaustion.
+- Three new tests in `backend/tests/test_security_throttles.py` assert 10 successful calls then 429 on the 11th, and that the filing cap does not affect complaint list access.
+
+### Housekeeping
+
+- Bumped `APP_VERSION` in `backend/config/settings/base.py` from `1.8.1` → `1.9.6` (was stale since v1.8.2). Surfaces in `/api/v1/health/` output.
+
+Deferred to future sweeps: CSP `REPORT_ONLY` → enforce (needs prod-report review first), `CustomerDataExportView` field allowlist (current reflective `_meta.get_fields()` is APP-12-safe but fragile).
+
 ## v1.9.5 — Workstream D: Dead-Code Cleanup (2026-04-18)
 
 ### Housekeeping

--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -9,7 +9,7 @@ from django.utils.html import escape
 from rest_framework import generics, status
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.throttling import AnonRateThrottle
+from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.tokens import RefreshToken
 
@@ -454,10 +454,18 @@ class StaffCustomerActivityView(generics.GenericAPIView):
         )
 
 
+class DataExportThrottle(UserRateThrottle):
+    """Low cap on data exports — heavy endpoint + Privacy Act APP-12 is low-frequency."""
+
+    scope = "data_export"
+    rate = "10/hour"
+
+
 class CustomerDataExportView(generics.GenericAPIView):
     """Export all customer data (APP 12 — Australian Privacy Act 1988)."""
 
     permission_classes = (IsAuthenticated,)
+    throttle_classes = (DataExportThrottle,)
 
     def get(self, request):
         user = request.user

--- a/backend/apps/loans/views.py
+++ b/backend/apps/loans/views.py
@@ -5,6 +5,7 @@ from django.db import models, transaction
 from rest_framework import permissions, viewsets
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.response import Response
+from rest_framework.throttling import UserRateThrottle
 from rest_framework.views import APIView
 from rest_framework.viewsets import GenericViewSet
 
@@ -256,6 +257,13 @@ class DashboardStatsView(APIView):
         }
 
 
+class ComplaintFilingThrottle(UserRateThrottle):
+    """Tight cap on complaint filing — sensitive + spam vector."""
+
+    scope = "complaint_filing"
+    rate = "10/hour"
+
+
 class ComplaintViewSet(viewsets.ModelViewSet):
     """Complaint management: customers create/view own, staff view/update all."""
 
@@ -272,3 +280,8 @@ class ComplaintViewSet(viewsets.ModelViewSet):
         if self.action in ("update", "partial_update", "destroy"):
             return [permissions.IsAuthenticated(), IsAdminOrOfficer()]
         return [permissions.IsAuthenticated()]
+
+    def get_throttles(self):
+        if self.action == "create":
+            return [ComplaintFilingThrottle()]
+        return super().get_throttles()

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -11,7 +11,7 @@ import sentry_sdk
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 # Application version (synced with CHANGELOG.md)
-APP_VERSION = "1.8.1"
+APP_VERSION = "1.9.6"
 
 DEBUG = os.environ.get("DJANGO_DEBUG", "False").lower() in ("true", "1", "yes")
 

--- a/backend/tests/test_security_throttles.py
+++ b/backend/tests/test_security_throttles.py
@@ -1,0 +1,119 @@
+"""Throttle coverage tests for v1.9.6 security sweep.
+
+Verifies the new scoped throttles on sensitive endpoints:
+- ComplaintFilingThrottle = 10/hour on ComplaintViewSet.create
+- DataExportThrottle     = 10/hour on CustomerDataExportView
+
+Both are user-scoped UserRateThrottle subclasses. The tests clear the
+throttle cache first so prior tests don't poison the counter.
+"""
+
+from decimal import Decimal
+
+import pytest
+from django.core.cache import cache
+from rest_framework.test import APIClient
+
+from apps.accounts.models import CustomUser
+from apps.loans.models import LoanApplication
+
+COMPLAINTS_URL = "/api/v1/loans/complaints/"
+DATA_EXPORT_URL = "/api/v1/auth/me/data-export/"
+
+
+def _make_customer(username="throttle_user"):
+    return CustomUser.objects.create_user(
+        username=username,
+        email=f"{username}@test.com",
+        password="testpass123",
+        role="customer",
+        first_name=username.title(),
+        last_name="User",
+    )
+
+
+def _make_loan(applicant):
+    return LoanApplication.objects.create(
+        applicant=applicant,
+        annual_income=Decimal("75000.00"),
+        credit_score=720,
+        loan_amount=Decimal("25000.00"),
+        loan_term_months=36,
+        debt_to_income=Decimal("1.50"),
+        employment_length=5,
+        purpose="personal",
+        home_ownership="rent",
+        has_cosigner=False,
+        monthly_expenses=Decimal("2200.00"),
+        existing_credit_card_limit=Decimal("8000.00"),
+        number_of_dependants=0,
+        employment_type="payg_permanent",
+        applicant_type="single",
+        has_hecs=False,
+        has_bankruptcy=False,
+        state="NSW",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_throttle_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.mark.django_db
+class TestComplaintFilingThrottle:
+    def test_tenth_succeeds_eleventh_rate_limited(self, settings):
+        user = _make_customer("complaint_spammer")
+        loan = _make_loan(user)
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        payload = {
+            "loan_application": str(loan.id),
+            "category": "decision",
+            "subject": "Concern",
+            "description": "Please re-review.",
+        }
+
+        for i in range(10):
+            resp = client.post(COMPLAINTS_URL, payload, format="json")
+            assert resp.status_code == 201, f"call {i+1} unexpectedly failed: {resp.status_code} {resp.content!r}"
+
+        throttled = client.post(COMPLAINTS_URL, payload, format="json")
+        assert throttled.status_code == 429
+        assert "retry" in throttled.content.decode().lower() or "throttled" in throttled.content.decode().lower()
+
+    def test_list_is_not_throttled_by_filing_scope(self):
+        """GET /complaints/ uses default user scope (60/min), not the 10/hour filing cap."""
+        user = _make_customer("complaint_reader")
+        loan = _make_loan(user)
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        for _ in range(10):
+            client.post(COMPLAINTS_URL, {
+                "loan_application": str(loan.id),
+                "category": "decision",
+                "subject": "x",
+                "description": "y",
+            }, format="json")
+
+        resp = client.get(COMPLAINTS_URL)
+        assert resp.status_code == 200, "list should remain accessible after filing cap is hit"
+
+
+@pytest.mark.django_db
+class TestDataExportThrottle:
+    def test_tenth_succeeds_eleventh_rate_limited(self):
+        user = _make_customer("export_spammer")
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        for i in range(10):
+            resp = client.get(DATA_EXPORT_URL)
+            assert resp.status_code == 200, f"call {i+1} unexpectedly failed: {resp.status_code} {resp.content!r}"
+
+        throttled = client.get(DATA_EXPORT_URL)
+        assert throttled.status_code == 429

--- a/backend/tests/test_security_throttles.py
+++ b/backend/tests/test_security_throttles.py
@@ -79,7 +79,7 @@ class TestComplaintFilingThrottle:
 
         for i in range(10):
             resp = client.post(COMPLAINTS_URL, payload, format="json")
-            assert resp.status_code == 201, f"call {i+1} unexpectedly failed: {resp.status_code} {resp.content!r}"
+            assert resp.status_code == 201, f"call {i + 1} unexpectedly failed: {resp.status_code} {resp.content!r}"
 
         throttled = client.post(COMPLAINTS_URL, payload, format="json")
         assert throttled.status_code == 429
@@ -93,12 +93,16 @@ class TestComplaintFilingThrottle:
         client.force_authenticate(user=user)
 
         for _ in range(10):
-            client.post(COMPLAINTS_URL, {
-                "loan_application": str(loan.id),
-                "category": "decision",
-                "subject": "x",
-                "description": "y",
-            }, format="json")
+            client.post(
+                COMPLAINTS_URL,
+                {
+                    "loan_application": str(loan.id),
+                    "category": "decision",
+                    "subject": "x",
+                    "description": "y",
+                },
+                format="json",
+            )
 
         resp = client.get(COMPLAINTS_URL)
         assert resp.status_code == 200, "list should remain accessible after filing cap is hit"
@@ -113,7 +117,7 @@ class TestDataExportThrottle:
 
         for i in range(10):
             resp = client.get(DATA_EXPORT_URL)
-            assert resp.status_code == 200, f"call {i+1} unexpectedly failed: {resp.status_code} {resp.content!r}"
+            assert resp.status_code == 200, f"call {i + 1} unexpectedly failed: {resp.status_code} {resp.content!r}"
 
         throttled = client.get(DATA_EXPORT_URL)
         assert throttled.status_code == 429


### PR DESCRIPTION
## Summary

Workstream B (partial) — closes two findings from the post-v1.9.5 security sweep after Codex adversarial review hit its weekly usage limit.

## Changes

**Security**
- `ComplaintViewSet.create` → `ComplaintFilingThrottle` (scope `complaint_filing`, **10/hour per user**). Previously relied on default 60/min user throttle → open to spam/abusive complaint floods. List/retrieve paths unaffected.
- `CustomerDataExportView` → `DataExportThrottle` (scope `data_export`, **10/hour per user**). APP-12 export is low-frequency and does a heavy prefetch across loans/decisions/emails/agent runs/bias reports/marketing emails — tight cap is modest resource-exhaustion hardening.

**Housekeeping**
- `APP_VERSION` bumped `1.8.1 → 1.9.6` in `backend/config/settings/base.py` (stale since v1.8.2). Surfaces in `/api/v1/health/`.

## Tests

New file `backend/tests/test_security_throttles.py` (3 cases):
- `TestComplaintFilingThrottle.test_tenth_succeeds_eleventh_rate_limited` — 10× POST → 201, 11th → 429.
- `TestComplaintFilingThrottle.test_list_is_not_throttled_by_filing_scope` — GET works after filing cap hit.
- `TestDataExportThrottle.test_tenth_succeeds_eleventh_rate_limited` — 10× GET → 200, 11th → 429.

All tests auto-clear Django cache to isolate throttle counters. No regressions on the 40 adjacent tests (`health`, `version`, `throttle`, `batch_orchestrate`, `complaint`, `data_export`).

## Deferred

Explicitly NOT in this PR:
- CSP `REPORT_ONLY = True` → enforce mode — needs production-report review first so a prod flip doesn't break the frontend.
- `CustomerDataExportView` explicit field allowlist — current `_meta.get_fields()` + `str()` is APP-12-safe today but fragile against future encrypted-field additions.

## Test plan

- [x] Backend unit tests (`pytest tests/test_security_throttles.py`): 3/3 passing.
- [x] Adjacent regressions (`pytest -k "health or version or throttle or batch_orchestrate or complaint or data_export"`): 40/40 passing.
- [ ] CI (Backend Lint/Tests, Dependency Audit, Docker Build, Frontend Lint/Tests, Security Scan, secret-scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)