### PR TITLE
refactor(frontend): extract customer label maps to lib/customerLabels

### DIFF
--- a/frontend/src/app/dashboard/customers/[id]/page.tsx
+++ b/frontend/src/app/dashboard/customers/[id]/page.tsx
@@ -20,6 +20,16 @@ import { NextBestOfferCard } from '@/components/agents/NextBestOfferCard'
 import { MarketingEmailCard } from '@/components/agents/MarketingEmailCard'
 import { formatCurrency, formatDate, getStatusColor, getDisplayStatus } from '@/lib/utils'
 import {
+  tierColors,
+  residencyLabels,
+  idTypeLabels,
+  maritalLabels,
+  employmentStatusLabels,
+  housingSituationLabels,
+  industryLabels,
+  contactMethodLabels,
+} from '@/lib/customerLabels'
+import {
   ArrowLeft,
   UserCircle,
   CreditCard,
@@ -37,81 +47,6 @@ import {
   Save,
   X,
 } from 'lucide-react'
-
-const tierColors: Record<string, string> = {
-  standard: 'bg-gray-100 text-gray-800',
-  silver: 'bg-slate-200 text-slate-800',
-  gold: 'bg-yellow-100 text-yellow-800',
-  platinum: 'bg-purple-100 text-purple-800',
-}
-
-const residencyLabels: Record<string, string> = {
-  citizen: 'Australian Citizen',
-  permanent_resident: 'Permanent Resident',
-  temporary_visa: 'Temporary Visa Holder',
-  nz_citizen: 'New Zealand Citizen',
-}
-
-const idTypeLabels: Record<string, string> = {
-  drivers_licence: "Driver's Licence",
-  passport: 'Australian Passport',
-  medicare: 'Medicare Card',
-  immicard: 'ImmiCard',
-}
-
-const maritalLabels: Record<string, string> = {
-  single: 'Single',
-  married: 'Married',
-  de_facto: 'De Facto',
-  divorced: 'Divorced',
-  widowed: 'Widowed',
-}
-
-const employmentStatusLabels: Record<string, string> = {
-  payg_permanent: 'PAYG Permanent',
-  payg_casual: 'PAYG Casual',
-  self_employed: 'Self Employed',
-  contract: 'Contract',
-  retired: 'Retired',
-  unemployed: 'Unemployed',
-  home_duties: 'Home Duties',
-}
-
-const housingSituationLabels: Record<string, string> = {
-  own_outright: 'Own Outright',
-  mortgage: 'Mortgage',
-  renting: 'Renting',
-  boarding: 'Boarding',
-  living_with_parents: 'Living with Parents',
-}
-
-const industryLabels: Record<string, string> = {
-  agriculture: 'Agriculture',
-  mining: 'Mining',
-  manufacturing: 'Manufacturing',
-  utilities: 'Utilities',
-  construction: 'Construction',
-  wholesale_trade: 'Wholesale Trade',
-  retail_trade: 'Retail Trade',
-  accommodation_food: 'Accommodation & Food',
-  transport_postal: 'Transport & Postal',
-  information_media: 'Information & Media',
-  financial_insurance: 'Financial & Insurance',
-  property_services: 'Property Services',
-  professional_scientific: 'Professional & Scientific',
-  administrative: 'Administrative',
-  public_admin: 'Public Administration',
-  education_training: 'Education & Training',
-  healthcare_social: 'Healthcare & Social',
-  arts_recreation: 'Arts & Recreation',
-  other_services: 'Other Services',
-}
-
-const contactMethodLabels: Record<string, string> = {
-  email: 'Email',
-  phone: 'Phone',
-  sms: 'SMS',
-}
 
 function BoolIndicator({ value, label }: { value: boolean; label: string }) {
   return (

--- a/frontend/src/app/dashboard/profile/page.tsx
+++ b/frontend/src/app/dashboard/profile/page.tsx
@@ -14,6 +14,7 @@ import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Save, Shield, UserCircle, Building2, CreditCard, Briefcase, Landmark, Home } from 'lucide-react'
 import { toast } from 'sonner'
+import { tierColors } from '@/lib/customerLabels'
 
 export default function ProfilePage() {
   const { user } = useAuth()
@@ -114,13 +115,6 @@ export default function ProfilePage() {
         <Skeleton className="h-64 w-full" />
       </div>
     )
-  }
-
-  const tierColors: Record<string, string> = {
-    standard: 'bg-gray-100 text-gray-800',
-    silver: 'bg-slate-200 text-slate-800',
-    gold: 'bg-yellow-100 text-yellow-800',
-    platinum: 'bg-purple-100 text-purple-800',
   }
 
   return (

--- a/frontend/src/lib/customerLabels.ts
+++ b/frontend/src/lib/customerLabels.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared customer-choice label maps.
+ *
+ * Backend `TextChoices` enums (CustomerProfile.ResidencyStatus, IdType,
+ * MaritalStatus, EmploymentStatus, HousingSituation, Industry,
+ * ContactMethod, Tier) return wire-format values. These maps turn those
+ * values into display strings and tier-color tokens.
+ *
+ * Used by /dashboard/customers/[id] and /dashboard/profile. Mirror any
+ * backend TextChoices additions here.
+ */
+
+export const tierColors: Record<string, string> = {
+  standard: 'bg-gray-100 text-gray-800',
+  silver: 'bg-slate-200 text-slate-800',
+  gold: 'bg-yellow-100 text-yellow-800',
+  platinum: 'bg-purple-100 text-purple-800',
+}
+
+export const residencyLabels: Record<string, string> = {
+  citizen: 'Australian Citizen',
+  permanent_resident: 'Permanent Resident',
+  temporary_visa: 'Temporary Visa Holder',
+  nz_citizen: 'New Zealand Citizen',
+}
+
+export const idTypeLabels: Record<string, string> = {
+  drivers_licence: "Driver's Licence",
+  passport: 'Australian Passport',
+  medicare: 'Medicare Card',
+  immicard: 'ImmiCard',
+}
+
+export const maritalLabels: Record<string, string> = {
+  single: 'Single',
+  married: 'Married',
+  de_facto: 'De Facto',
+  divorced: 'Divorced',
+  widowed: 'Widowed',
+}
+
+export const employmentStatusLabels: Record<string, string> = {
+  payg_permanent: 'PAYG Permanent',
+  payg_casual: 'PAYG Casual',
+  self_employed: 'Self Employed',
+  contract: 'Contract',
+  retired: 'Retired',
+  unemployed: 'Unemployed',
+  home_duties: 'Home Duties',
+}
+
+export const housingSituationLabels: Record<string, string> = {
+  own_outright: 'Own Outright',
+  mortgage: 'Mortgage',
+  renting: 'Renting',
+  boarding: 'Boarding',
+  living_with_parents: 'Living with Parents',
+}
+
+export const industryLabels: Record<string, string> = {
+  agriculture: 'Agriculture',
+  mining: 'Mining',
+  manufacturing: 'Manufacturing',
+  utilities: 'Utilities',
+  construction: 'Construction',
+  wholesale_trade: 'Wholesale Trade',
+  retail_trade: 'Retail Trade',
+  accommodation_food: 'Accommodation & Food',
+  transport_postal: 'Transport & Postal',
+  information_media: 'Information & Media',
+  financial_insurance: 'Financial & Insurance',
+  property_services: 'Property Services',
+  professional_scientific: 'Professional & Scientific',
+  administrative: 'Administrative',
+  public_admin: 'Public Administration',
+  education_training: 'Education & Training',
+  healthcare_social: 'Healthcare & Social',
+  arts_recreation: 'Arts & Recreation',
+  other_services: 'Other Services',
+}
+
+export const contactMethodLabels: Record<string, string> = {
+  email: 'Email',
+  phone: 'Phone',
+  sms: 'SMS',
+}


### PR DESCRIPTION
## Summary

Workstream C (SWE design) follow-up — the first DRY win surfaced by a file-size audit.

The 1020-line `dashboard/customers/[id]/page.tsx` held 8 inline `Record<string, string>` maps (tier colors, residency, ID type, marital, employment, housing, industry, contact method) mirroring the backend `TextChoices` enums. One of them (`tierColors`) was duplicated **verbatim** in `dashboard/profile/page.tsx`. Keeping them inline was dead weight and a latent drift risk — adding a new employment status or ID type to the backend would silently leave the UI rendering the raw snake_case value.

## Changes

**New file**
- `frontend/src/lib/customerLabels.ts` (86 lines) — all 8 maps as named exports with a one-line doc comment telling future devs to mirror backend TextChoices additions here.

**Refactored**
- `frontend/src/app/dashboard/customers/[id]/page.tsx` — 1020 → **955 lines** (-65). Removed 8 inline maps, added one grouped import.
- `frontend/src/app/dashboard/profile/page.tsx` — 609 → **603 lines** (-6). Dropped the duplicated `tierColors` and replaced with import.

Net: **+15 LOC** total but -71 LOC from the two pages, all shared and reusable going forward.

## Behaviour

Zero runtime change. Same keys, same display strings, same Tailwind classes. The two pages now reference identical label maps by reference instead of by copy.

## Not in this PR

Deferred larger Workstream C items (separate audit):
- Split `GuardrailChecker` (1275 lines) into patterns + rules + engine.
- `data_generator.py` (1505 lines) single-class monolith.
- `accounts/views.py` (641 lines) mixing auth + profile + customer detail + export.

## Test plan

- [x] Grep confirms no remaining inline definitions in either page, all usages resolve to imports.
- [ ] CI — Frontend Lint & Type Check, Frontend Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)