### PR TITLE
fix(ml): pin optuna so Train New Model works

### DIFF
--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -10,6 +10,7 @@ cryptography>=44.0
 scikit-learn>=1.6
 xgboost>=3.0
 shap>=0.46
+optuna>=4.0,<5
 pandas>=2.2
 numpy>=2.2
 joblib>=1.4

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 # Pinned dependencies — generated from requirements.in
 # To update: pip-compile requirements.in --output-file=requirements.txt
 # To add a dependency: add it to requirements.in, then recompile
+alembic==1.18.4
 amqp==5.3.1
 annotated-types==0.7.0
 anthropic==0.85.0
@@ -19,6 +20,7 @@ click-didyoumean==0.3.1
 click-plugins==1.1.1.2
 click-repl==0.3.0
 cloudpickle==3.1.2
+colorlog==6.10.1
 cryptography==46.0.7
 distro==1.9.0
 django[argon2]==5.2.13
@@ -33,6 +35,7 @@ djangorestframework-simplejwt==5.5.1
 docstring-parser==0.18.0
 drf-spectacular==0.29.0
 et-xmlfile==2.0.0
+greenlet==3.4.0
 gunicorn==25.3.0
 h11==0.16.0
 httpcore==1.0.9
@@ -45,10 +48,13 @@ jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
 kombu[redis]==5.6.2
 llvmlite==0.47.0
+mako==1.3.11
+markupsafe==3.0.3
 numba==0.65.0
 numpy==2.4.3
 nvidia-nccl-cu12==2.29.7
 openpyxl==3.1.5
+optuna==4.8.0
 packaging==26.1
 pandas==3.0.1
 prometheus-client==0.25.0
@@ -74,6 +80,7 @@ shap==0.51.0
 six==1.17.0
 slicer==0.0.8
 sniffio==1.3.1
+sqlalchemy==2.0.49
 sqlparse==0.5.5
 threadpoolctl==3.6.0
 tqdm==4.67.3


### PR DESCRIPTION
## Summary
- `optuna` was imported in `backend/apps/ml_engine/services/trainer.py` (`_train_xgb`) but missing from `requirements.in` / `requirements.txt`
- The Celery ML worker raised `ModuleNotFoundError: No module named 'optuna'` after CV completed, so the Model Metrics **Train New Model** button never produced a model
- Pin `optuna==4.8.0` + transitives (`alembic`, `colorlog`, `greenlet`, `mako`, `markupsafe`, `sqlalchemy`)

## Test plan
- [x] Requeue `train_model_task(algorithm='xgb')` — succeeded in 150.8s, AUC 0.8703, new `ModelVersion` persisted
- [ ] `docker compose build celery_worker_ml backend` picks up optuna from requirements
- [ ] UI: `/dashboard/model-metrics` → **Train New Model** (admin) → completes in 3-5 min, metrics refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)