### PR TITLE
chore(a11y): resolve metrics chart TODO with aria-label wrappers

### DIFF
--- a/frontend/src/components/metrics/FeatureImportance.tsx
+++ b/frontend/src/components/metrics/FeatureImportance.tsx
@@ -133,7 +133,7 @@ export function FeatureImportance({ features, title = 'Feature Importance' }: Fe
         <CardTitle className="text-base">{title}</CardTitle>
       </CardHeader>
       <CardContent>
-        {/* TODO: add proper aria labels */}
+        <div role="img" aria-label={`Bar chart of top ${data.length} features by importance: ${data.slice(0, 3).map((d) => `${d.name} ${(d.importance * 100).toFixed(1)}%`).join(', ')}`}>
         <ResponsiveContainer width="100%" height={Math.max(280, data.length * 36)}>
           <BarChart data={data} layout="vertical" margin={{ top: 5, right: 30, bottom: 5, left: 10 }}>
             <CartesianGrid strokeDasharray="3 3" opacity={0.4} horizontal={false} />
@@ -150,6 +150,7 @@ export function FeatureImportance({ features, title = 'Feature Importance' }: Fe
             <Bar dataKey="importance" fill="hsl(var(--primary))" radius={[0, 4, 4, 0]} />
           </BarChart>
         </ResponsiveContainer>
+        </div>
       </CardContent>
     </Card>
   )

--- a/frontend/src/components/metrics/ROCCurve.tsx
+++ b/frontend/src/components/metrics/ROCCurve.tsx
@@ -24,7 +24,7 @@ export function ROCCurve({ fpr, tpr, auc }: ROCCurveProps) {
         <CardDescription>AUC: {auc != null ? auc.toFixed(4) : '—'}</CardDescription>
       </CardHeader>
       <CardContent>
-        {/* TODO: add proper aria labels */}
+        <div role="img" aria-label={`ROC curve plotting true positive rate against false positive rate; AUC ${auc != null ? auc.toFixed(4) : 'unavailable'}. Higher AUC indicates better model discrimination.`}>
         <ResponsiveContainer width="100%" height={350}>
           <LineChart data={data} margin={{ top: 10, right: 20, bottom: 30, left: 20 }}>
             <CartesianGrid strokeDasharray="3 3" opacity={0.4} />
@@ -58,6 +58,7 @@ export function ROCCurve({ fpr, tpr, auc }: ROCCurveProps) {
             />
           </LineChart>
         </ResponsiveContainer>
+        </div>
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
## Summary
- FeatureImportance and ROCCurve had leftover `TODO: add proper aria labels` comments
- Recharts `ResponsiveContainer` doesn't accept `aria-*` props directly — wrap charts in a `role="img"` div with a summary aria-label (Recharts-recommended pattern)
- Screen readers now announce the feature importance ranking / ROC AUC value instead of silently rendering an unlabelled SVG

## Test plan
- [x] `npm run test:ci` — all tests pass, coverage within thresholds
- [x] `npx tsc --noEmit` clean

Co-Authored-By: Claude Opus 4.7