### PR TITLE
chore(ops): extend make clean + add clean-deep (v1.10.1 D2/6)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev down build test lint seed train logs health clean
+.PHONY: dev down build test lint seed train logs health clean clean-deep typecheck security verify deadcode
 
 # Development
 dev:                     ## Start all services
@@ -58,9 +58,20 @@ health:                  ## Check service health
 	@curl -s http://localhost:8000/api/v1/health/deep/ | python -m json.tool
 
 # Cleanup
-clean:                   ## Remove containers, volumes, and cached files
+clean:                   ## Nuke ephemerals (containers, caches, build output)
 	docker compose down -v
 	find backend -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+	find backend -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true
+	find . -name "*.pyc" -not -path "*/node_modules/*" -delete 2>/dev/null || true
+	rm -rf frontend/.next frontend/coverage frontend/playwright-report frontend/test-results
+	rm -rf backend/htmlcov backend/.coverage backend/.pytest_cache
+	rm -f frontend/tsconfig.tsbuildinfo
+	@echo "Clean complete. Re-run 'make build' then 'make dev' to restart."
+
+clean-deep:              ## clean + remove node_modules + .venv (forces reinstall)
+	$(MAKE) clean
+	rm -rf frontend/node_modules backend/.venv
+	@echo "Deep-clean complete. Expect re-install before next run."
 
 help:                    ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -192,6 +192,22 @@ A separate `watchdog` service runs in the core stack at all times. It polls ever
 
 ~1000 tests across 66 files. 60% backend coverage floor enforced in CI. CI pipeline runs Ruff, Bandit SAST, gitleaks, npm audit, OWASP ZAP DAST, k6 load test, and Trivy container scanning.
 
+## Housekeeping
+
+Local development accumulates build artifacts, test caches, and trained model files. To reclaim disk:
+
+```bash
+make clean       # ephemerals (containers, .next, coverage, __pycache__, tsbuildinfo)
+make clean-deep  # also removes node_modules and backend/.venv (forces reinstall)
+```
+
+To prune stale trained-model `.joblib` artifacts from `backend/ml_models/` (after many training iterations):
+
+```bash
+docker compose exec backend python manage.py prune_model_artifacts --dry-run  # preview
+docker compose exec backend python manage.py prune_model_artifacts            # delete
+```
+
 ## Limitations and honest caveats
 
 - **Trained on synthetic data.** The data generator is calibrated against ATO, ABS, APRA, and Equifax published statistics and runs the labels through a 1000-line rules-based underwriting engine plus a separate loan-performance simulator, so the learning task is non-trivial. It does not capture real-world feedback loops, fraud patterns, broker channel effects, or lender-specific heuristics. A production rollout would retrain on real historical data before trusting the outputs.


### PR DESCRIPTION
## Summary

- Extends the `make clean` target to reclaim ephemeral disk:
  - Removes `__pycache__`, `.pytest_cache`, `*.pyc`
  - Removes `frontend/.next`, `coverage`, `playwright-report`, `test-results`
  - Removes `backend/htmlcov`, `.coverage`, `.pytest_cache`
  - Removes `frontend/tsconfig.tsbuildinfo`
- Adds `make clean-deep` that additionally removes `node_modules` and `backend/.venv`.
- Reserves `typecheck`, `security`, `verify`, `deadcode` in `.PHONY` (implemented in D4/D5).
- README gains a Housekeeping section documenting both targets and the upcoming `prune_model_artifacts` command.

## Why

Local dev accumulates ~1.3 GB of ephemeral artifacts (frontend/.next 515M, node_modules 717M, pycache, coverage). The original `clean` target only killed containers and pycache — insufficient. Users were manually `rm -rf`-ing; let's standardise.

## Test plan

- [x] `.gitignore` covers all clean targets (audit confirmed existing entries sufficient).
- [x] Makefile syntax valid (read-back confirms structure).
- [ ] `make clean` reclaims ≥500 MB on a built tree (local smoke — user verifies).

## Scope

PR 2 of 6 for v1.10.1 production hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)