### PR TITLE
feat(ml_engine): prune_model_artifacts command (v1.10.1 D3/6)

### DIFF
--- a/backend/apps/ml_engine/management/commands/prune_model_artifacts.py
+++ b/backend/apps/ml_engine/management/commands/prune_model_artifacts.py
@@ -75,11 +75,7 @@ class Command(BaseCommand):
                 joblib.unlink()
 
         mode = "(dry-run)" if dry_run else ""
-        self.stdout.write(
-            self.style.SUCCESS(
-                f"Done {mode}: {deleted} file(s); {reclaimed} bytes reclaimed."
-            )
-        )
+        self.stdout.write(self.style.SUCCESS(f"Done {mode}: {deleted} file(s); {reclaimed} bytes reclaimed."))
 
     def _compute_whitelist(self, keep_n: int) -> set[str]:
         keep: set[str] = set(ALWAYS_KEEP)
@@ -90,9 +86,7 @@ class Command(BaseCommand):
 
         per_segment: dict[str, list[ModelVersion]] = defaultdict(list)
         inactives: Iterable[ModelVersion] = (
-            ModelVersion.objects.filter(is_active=False)
-            .exclude(file_path="")
-            .order_by("-created_at")
+            ModelVersion.objects.filter(is_active=False).exclude(file_path="").order_by("-created_at")
         )
         for mv in inactives:
             per_segment[getattr(mv, "segment", "unified")].append(mv)

--- a/backend/apps/ml_engine/management/commands/prune_model_artifacts.py
+++ b/backend/apps/ml_engine/management/commands/prune_model_artifacts.py
@@ -1,0 +1,104 @@
+"""Prune stale `.joblib` artifacts from `backend/ml_models/`.
+
+Keeps: files referenced by any `is_active=True` ModelVersion, the N most
+recent inactive versions per segment (default N=1), `contract_test_model.joblib`,
+and any non-`.joblib` file (e.g. `golden_metrics.json`).
+
+Deletes: every other `.joblib` file in `ML_MODELS_DIR`, including orphan
+files with no ModelVersion row.
+
+Complements `cleanup_old_models` (which prunes DB rows first and cascades to
+files); this command prunes files first and leaves the DB alone, so it can
+reclaim disk from the large tail of orphan `.joblib` files left by past
+training experiments.
+
+Usage:
+    python manage.py prune_model_artifacts             # prune
+    python manage.py prune_model_artifacts --dry-run   # preview
+    python manage.py prune_model_artifacts --keep 2    # retain last 2 inactive per segment
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.ml_engine.models import ModelVersion
+
+ALWAYS_KEEP = frozenset({"contract_test_model.joblib"})
+
+
+class Command(BaseCommand):
+    help = "Prune stale .joblib artifacts from ML_MODELS_DIR."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Preview deletions without touching disk.",
+        )
+        parser.add_argument(
+            "--keep",
+            type=int,
+            default=1,
+            help="Number of most-recent inactive ModelVersions per segment to retain (default: 1).",
+        )
+
+    def handle(self, *args, **opts):
+        models_dir = Path(settings.ML_MODELS_DIR)
+        if not models_dir.is_dir():
+            raise CommandError(f"ML_MODELS_DIR not found: {models_dir}")
+
+        dry_run: bool = opts["dry_run"]
+        keep_n: int = max(0, int(opts["keep"]))
+
+        keep_basenames = self._compute_whitelist(keep_n)
+        self.stdout.write(f"Whitelist ({len(keep_basenames)} file(s)):")
+        for name in sorted(keep_basenames):
+            self.stdout.write(f"  KEEP  {name}")
+
+        reclaimed = 0
+        deleted = 0
+        for joblib in sorted(models_dir.glob("*.joblib")):
+            if joblib.name in keep_basenames:
+                continue
+            size = joblib.stat().st_size
+            reclaimed += size
+            deleted += 1
+            verb = "would delete" if dry_run else "deleting"
+            self.stdout.write(f"  {verb}  {joblib.name} ({size} bytes)")
+            if not dry_run:
+                joblib.unlink()
+
+        mode = "(dry-run)" if dry_run else ""
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Done {mode}: {deleted} file(s); {reclaimed} bytes reclaimed."
+            )
+        )
+
+    def _compute_whitelist(self, keep_n: int) -> set[str]:
+        keep: set[str] = set(ALWAYS_KEEP)
+
+        for mv in ModelVersion.objects.filter(is_active=True):
+            if mv.file_path:
+                keep.add(Path(mv.file_path).name)
+
+        per_segment: dict[str, list[ModelVersion]] = defaultdict(list)
+        inactives: Iterable[ModelVersion] = (
+            ModelVersion.objects.filter(is_active=False)
+            .exclude(file_path="")
+            .order_by("-created_at")
+        )
+        for mv in inactives:
+            per_segment[getattr(mv, "segment", "unified")].append(mv)
+
+        for _segment, versions in per_segment.items():
+            for mv in versions[:keep_n]:
+                keep.add(Path(mv.file_path).name)
+
+        return keep

--- a/backend/apps/ml_engine/tests/test_prune_model_artifacts.py
+++ b/backend/apps/ml_engine/tests/test_prune_model_artifacts.py
@@ -70,9 +70,7 @@ def test_prune_keeps_active_and_recent_versions(models_dir: Path):
     assert keep_1.exists(), "most recent inactive kept for rollback"
     assert not stale_1.exists(), "older inactive pruned"
     assert not stale_2.exists(), "older inactive pruned"
-    assert (models_dir / "contract_test_model.joblib").exists(), (
-        "contract_test_model.joblib is always whitelisted"
-    )
+    assert (models_dir / "contract_test_model.joblib").exists(), "contract_test_model.joblib is always whitelisted"
 
 
 def test_prune_dry_run_deletes_nothing(models_dir: Path):

--- a/backend/apps/ml_engine/tests/test_prune_model_artifacts.py
+++ b/backend/apps/ml_engine/tests/test_prune_model_artifacts.py
@@ -1,0 +1,117 @@
+"""Unit tests for the prune_model_artifacts management command.
+
+Covers safety whitelist (active ModelVersion, contract_test, non-joblib
+files), dry-run mode, and orphan-file handling.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from django.core.management import call_command
+
+from apps.ml_engine.models import ModelVersion
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def models_dir(tmp_path, settings):
+    """Sandbox ML_MODELS_DIR so the command operates on fresh fixtures."""
+    settings.ML_MODELS_DIR = str(tmp_path)
+    return tmp_path
+
+
+def _make_file(path: Path, size: int = 1024) -> Path:
+    path.write_bytes(b"\0" * size)
+    return path
+
+
+def _make_version(
+    *,
+    file_path: Path,
+    version: str,
+    is_active: bool = False,
+    segment: str = ModelVersion.SEGMENT_UNIFIED,
+    traffic_percentage: int = 100,
+) -> ModelVersion:
+    # Active per-segment traffic must cap at 100; tests stay within a single
+    # segment so the segment-active partial index is respected.
+    return ModelVersion.objects.create(
+        algorithm="xgb",
+        version=version,
+        file_path=str(file_path),
+        file_hash="a" * 64,
+        is_active=is_active,
+        segment=segment,
+        traffic_percentage=traffic_percentage if is_active else 0,
+    )
+
+
+def test_prune_keeps_active_and_recent_versions(models_dir: Path):
+    """Active ModelVersion file + N most-recent inactive per segment are kept."""
+    active = _make_file(models_dir / "xgb_active.joblib", 2048)
+    keep_1 = _make_file(models_dir / "xgb_keep.joblib", 2048)
+    stale_1 = _make_file(models_dir / "xgb_stale_1.joblib", 2048)
+    stale_2 = _make_file(models_dir / "xgb_stale_2.joblib", 2048)
+    _make_file(models_dir / "contract_test_model.joblib", 5)
+
+    _make_version(file_path=active, version="1.0.0-active", is_active=True)
+    _make_version(file_path=keep_1, version="1.0.0-keep")
+    _make_version(file_path=stale_1, version="1.0.0-stale1")
+    _make_version(file_path=stale_2, version="1.0.0-stale2")
+
+    out = StringIO()
+    call_command("prune_model_artifacts", "--keep", "1", stdout=out)
+
+    assert active.exists(), "active ModelVersion must never be deleted"
+    assert keep_1.exists(), "most recent inactive kept for rollback"
+    assert not stale_1.exists(), "older inactive pruned"
+    assert not stale_2.exists(), "older inactive pruned"
+    assert (models_dir / "contract_test_model.joblib").exists(), (
+        "contract_test_model.joblib is always whitelisted"
+    )
+
+
+def test_prune_dry_run_deletes_nothing(models_dir: Path):
+    """--dry-run reports what would be deleted but touches no files."""
+    stale = _make_file(models_dir / "xgb_stale.joblib", 2048)
+    _make_version(file_path=stale, version="1.0.0-stale")
+
+    out = StringIO()
+    call_command("prune_model_artifacts", "--dry-run", stdout=out)
+
+    assert stale.exists(), "dry-run must not delete anything"
+    assert "would delete" in out.getvalue().lower()
+
+
+def test_prune_handles_orphan_files_with_no_modelversion_row(models_dir: Path):
+    """A joblib with no ModelVersion row is safe to delete."""
+    orphan = _make_file(models_dir / "xgb_orphan.joblib", 2048)
+
+    call_command("prune_model_artifacts")
+
+    assert not orphan.exists(), "orphan files (no DB row) are deleted"
+
+
+def test_prune_protects_non_joblib_files(models_dir: Path):
+    """golden_metrics.json etc. are non-.joblib files — must not be touched."""
+    (models_dir / "golden_metrics.json").write_text('{"auc": 0.87}')
+    _make_file(models_dir / "xgb_stale.joblib", 2048)
+
+    call_command("prune_model_artifacts")
+
+    assert (models_dir / "golden_metrics.json").exists()
+
+
+def test_prune_reports_bytes_reclaimed(models_dir: Path):
+    """Command prints total bytes reclaimed for operator feedback."""
+    _make_file(models_dir / "xgb_orphan.joblib", 10_000)
+
+    out = StringIO()
+    call_command("prune_model_artifacts", stdout=out)
+
+    output = out.getvalue().lower()
+    assert "bytes reclaimed" in output or "bytes freed" in output

--- a/backend/apps/ml_engine/tests/test_prune_model_artifacts.py
+++ b/backend/apps/ml_engine/tests/test_prune_model_artifacts.py
@@ -53,15 +53,17 @@ def _make_version(
 def test_prune_keeps_active_and_recent_versions(models_dir: Path):
     """Active ModelVersion file + N most-recent inactive per segment are kept."""
     active = _make_file(models_dir / "xgb_active.joblib", 2048)
-    keep_1 = _make_file(models_dir / "xgb_keep.joblib", 2048)
     stale_1 = _make_file(models_dir / "xgb_stale_1.joblib", 2048)
     stale_2 = _make_file(models_dir / "xgb_stale_2.joblib", 2048)
+    keep_1 = _make_file(models_dir / "xgb_keep.joblib", 2048)
     _make_file(models_dir / "contract_test_model.joblib", 5)
 
+    # Creation order drives `order_by("-created_at")` — the version created
+    # last is the most-recent inactive and should be retained when --keep 1.
     _make_version(file_path=active, version="1.0.0-active", is_active=True)
-    _make_version(file_path=keep_1, version="1.0.0-keep")
     _make_version(file_path=stale_1, version="1.0.0-stale1")
     _make_version(file_path=stale_2, version="1.0.0-stale2")
+    _make_version(file_path=keep_1, version="1.0.0-keep")
 
     out = StringIO()
     call_command("prune_model_artifacts", "--keep", "1", stdout=out)
@@ -75,8 +77,9 @@ def test_prune_keeps_active_and_recent_versions(models_dir: Path):
 
 def test_prune_dry_run_deletes_nothing(models_dir: Path):
     """--dry-run reports what would be deleted but touches no files."""
+    # Orphan file (no ModelVersion row) — would normally be pruned, so the
+    # dry-run output must include the "would delete" notice.
     stale = _make_file(models_dir / "xgb_stale.joblib", 2048)
-    _make_version(file_path=stale, version="1.0.0-stale")
 
     out = StringIO()
     call_command("prune_model_artifacts", "--dry-run", stdout=out)

--- a/backend/docs/RUNBOOK.md
+++ b/backend/docs/RUNBOOK.md
@@ -388,6 +388,12 @@ from apps.ml_engine.models import ModelVersion
 for mv in ModelVersion.objects.order_by('-created_at')[:10]:
     print(f'{mv.version} | {mv.algorithm} | AUC: {mv.auc_roc:.4f} | Gini: {mv.gini_coefficient} | Active: {mv.is_active} | {mv.created_at}')
 "
+
+# Prune stale .joblib artifacts in backend/ml_models/
+# Keeps active ModelVersion + N recent inactive per segment + contract_test_model.joblib.
+# Use --dry-run first to preview.
+docker compose exec backend python manage.py prune_model_artifacts --dry-run
+docker compose exec backend python manage.py prune_model_artifacts --keep 2
 ```
 
 ### Service Management


### PR DESCRIPTION
## Summary

- New Django management command `prune_model_artifacts` that reclaims disk by deleting stale `.joblib` files from `ML_MODELS_DIR`.
- Safety whitelist: active ModelVersion + N most-recent inactive per segment (default N=1) + `contract_test_model.joblib` + all non-`.joblib` files.
- Defaults to destructive mode; `--dry-run` previews without touching disk.
- 5 pytest test cases covering whitelist, dry-run, orphans, non-joblib protection, byte accounting.
- RUNBOOK entry documents the dry-run-first workflow.

## Why

`cleanup_old_models` is row-first (prunes `ModelVersion` DB rows and cascades to files). The user's tree has ~140 orphan `.joblib` files from past training experiments that have no DB row at all — cleanup_old_models won't touch them. This command plugs that gap, making disk reclaim a one-liner.

## Test plan

- [x] `python -m py_compile` passes for both new files.
- [x] `ruff check` passes (UP035 fixed — Iterable imported from collections.abc).
- [ ] 5 new pytest cases green (CI will verify).
- [ ] No regressions in `apps/ml_engine/` test suite (CI).

## Scope

PR 3 of 6 for v1.10.1 production hardening. Independent of D2 (files disjoint); D2's README forward-references this command's name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)