### PR TITLE
chore(deadcode): add make deadcode + vulture baseline (v1.10.1 D4/6)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,12 @@ lint:                    ## Lint backend and frontend
 format:                  ## Auto-format backend code
 	cd backend && ruff format .
 
+deadcode:                ## Report unused code (ruff F401/F811/F841 + vulture)
+	cd backend && ruff check --select F401,F811,F841 apps config tests || true
+	cd backend && vulture apps --min-confidence 80 \
+		--ignore-names "_*,test_*,setUp,tearDown,Meta,sender,view,frame,expression,connection,signum,instance,kwargs" \
+		--exclude "*/migrations/*,*/tests/*"
+
 # Health
 health:                  ## Check service health
 	@curl -s http://localhost:8000/api/v1/health/ | python -m json.tool

--- a/backend/apps/ml_engine/services/outcome_tracker.py
+++ b/backend/apps/ml_engine/services/outcome_tracker.py
@@ -110,7 +110,7 @@ def compute_outcome_analysis(days=90):
     }
 
 
-def compute_vintage_analysis(months_back=12):
+def compute_vintage_analysis():
     """Track outcome rates by origination month (vintage curves).
 
     Returns list of dicts:

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -10,3 +10,5 @@ schemathesis>=3.36
 pre-commit>=4.0
 ruff>=0.8.6
 pip-audit>=2.7
+vulture>=2.13
+mypy>=1.13


### PR DESCRIPTION
## Summary

- New `make deadcode` target runs ruff F401/F811/F841 plus vulture (80% confidence) ignoring framework-protocol parameter names.
- Adds `vulture>=2.13` and `mypy>=1.13` to `requirements-dev.txt` (mypy reserved for D5).
- Fixes one real finding: `compute_vintage_analysis(months_back=12)` → `compute_vintage_analysis()` (parameter declared but never used).
- Baseline scan now returns zero findings.

## Why

Continuous dead-code detection catches drift before it accumulates. The v1.10.0 ship was clean on ruff F-codes; vulture adds a second lens (unused methods, variables) that ruff doesn't cover.

## Findings classification

| Count | Category | Action |
|---|---|---|
| 11 | Framework callback-protocol params (sender/view/frame/expression) | Ignored via `--ignore-names` |
| 1 | Unused function parameter in `outcome_tracker.compute_vintage_analysis` | **Deleted** (real finding) |
| 0 | Genuine dead functions/methods/classes | — |

## Branch-deletion work

The plan's Task D4.5 proposes cleaning up stale feature branches, but that step is destructive and requires per-branch user confirmation. Leaving for a follow-up interactive pass.

## Test plan

- [x] `make deadcode` returns zero findings (local verification).
- [x] Ruff suite remains green (`ruff check .` → all passed).
- [x] `compute_vintage_analysis` still callable (0-arg call sites untouched).
- [ ] Full pytest suite green (CI will verify).

## Scope

PR 4 of 6 for v1.10.1 production hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)