### PR TITLE
chore(v1.10.1 D6): smoke-e2e script + version bump to 1.10.1

### DIFF
--- a/.github/workflows/smoke-e2e.yml
+++ b/.github/workflows/smoke-e2e.yml
@@ -1,0 +1,55 @@
+name: smoke-e2e
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Create .env from example
+        run: |
+          cp .env.example .env
+          {
+            echo "DJANGO_SECRET_KEY=$(python3 -c 'import secrets; print(secrets.token_urlsafe(50))')"
+            echo "FIELD_ENCRYPTION_KEY=$(python3 -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')"
+          } >> .env
+
+      - name: Build + up
+        run: docker compose up -d
+
+      - name: Migrate + seed minimal dataset
+        run: |
+          docker compose exec -T backend python manage.py migrate
+          docker compose exec -T backend python manage.py generate_data --count 500
+          docker compose exec -T backend python manage.py train_model --algorithm xgb
+
+      - name: Run smoke script
+        run: tools/smoke_e2e.sh --keep-up
+
+      - name: Print backend + celery logs on failure
+        if: failure()
+        run: |
+          docker compose logs backend | tail -200
+          docker compose logs celery_worker_ml | tail -100
+
+      - name: Upload smoke result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-result
+          path: .tmp/smoke_result.json
+          if-no-files-found: warn
+
+      - name: Teardown
+        if: always()
+        run: docker compose down -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v1.10.1 — Production Hardening (2026-04-19)
+
+Six atomic deliverables that tighten the production surface without touching model behaviour:
+
+- **D1 — Hosted-demo scaffolding removed.** Stripped placeholder wizard / profile / about pages and associated fixtures; nothing rendered from them in the current build, and deleting them shrinks the bundle.
+- **D2 — Extended `make clean`.** `make clean` reclaims containers / build caches / test artifacts / tsbuildinfo; new `make clean-deep` also drops `node_modules` and `backend/.venv`. Documented under a new README "Housekeeping" section.
+- **D3 — Stale model artifact pruning.** New `manage.py prune_model_artifacts [--dry-run] [--keep N]` command cleans stale `.joblib` files under `backend/ml_models/` while keeping the active `ModelVersion` and the N most-recent inactive ones (default 3). Covered by 11 pytest cases.
+- **D4 — Dead-code sweep.** New `make deadcode` target combines `ruff --select F401,F811,F841` + `vulture --min-confidence 80`; removed one unused-parameter case surfaced by the sweep.
+- **D5 — Robustness audit.** New `backend/mypy.ini` + lightweight CI `mypy` job gate the 10 Arm C Phase 1 extraction modules; `make typecheck` / `make security` / `make verify` targets; `pip-audit --strict`, `npm audit --audit-level=high --omit=dev`, and bandit `-lll`. Frontend `lint:strict` + `typecheck` available as developer tools (not CI gate; 8 intentionally-demoted react-hooks warnings from the Next 16 upgrade block it).
+- **D6 — End-to-end smoke test.** New `tools/smoke_e2e.sh` (register → apply → orchestrate → decision → email) + deterministic applicant fixture + `workflow_dispatch`-only GitHub Actions job. Result written to `.tmp/smoke_result.json`.
+
+### Version bump
+
+`APP_VERSION` advances `1.10.0` → `1.10.1`. No data migrations. No trained-model invalidation.
+
 ## v1.10.0 — XGBoost AU Lender Parity (2026-04-18)
 
 Bundle of 8 deliverables bringing the unified champion XGBoost model to APRA / AU-big-4 production parity, plus a regression-gate JSON file so CI can catch silent metric decay after promotion. Target audit surfaces: APRA CPS 220 model validation, SR 11-7 MRM dossier, APS 112 credit policy overlay, APS 220 referral trail, AFCA 2023 hardship guidance, ASIC RG 209 responsible-lending capture, NCCP Act s.128 unsuitability screen.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,33 @@ A separate `watchdog` service runs in the core stack at all times. It polls ever
 
 ~1000 tests across 66 files. 60% backend coverage floor enforced in CI. CI pipeline runs Ruff, Bandit SAST, gitleaks, npm audit, OWASP ZAP DAST, k6 load test, and Trivy container scanning.
 
+## Verifying the build
+
+An end-to-end smoke script exercises the full pipeline (register → apply → orchestrate → decision → email) against a locally-running stack:
+
+```bash
+docker compose up -d
+make seed                     # generate data + train model
+tools/smoke_e2e.sh            # full cycle + teardown
+tools/smoke_e2e.sh --keep-up  # leave stack up for manual inspection
+```
+
+Result is written to `.tmp/smoke_result.json`:
+
+```json
+{
+  "started_at": "2026-04-19T12:34:56Z",
+  "finished_at": "2026-04-19T12:35:42Z",
+  "duration_ms": 46123,
+  "status": "success",
+  "reason": "ok",
+  "model_version_id": "<uuid>",
+  "email_subject_hash": "<sha256-prefix>"
+}
+```
+
+The same script runs as a manually-triggered GitHub Actions job under `smoke-e2e` (see `.github/workflows/smoke-e2e.yml`). The workflow is `workflow_dispatch`-only by design — cost-conscious default; add a cron once the signal is known stable.
+
 ## Housekeeping
 
 Local development accumulates build artifacts, test caches, and trained model files. To reclaim disk:

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -11,7 +11,7 @@ import sentry_sdk
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 # Application version (synced with CHANGELOG.md)
-APP_VERSION = "1.10.0"
+APP_VERSION = "1.10.1"
 
 DEBUG = os.environ.get("DJANGO_DEBUG", "False").lower() in ("true", "1", "yes")
 

--- a/tools/smoke_e2e.sh
+++ b/tools/smoke_e2e.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# End-to-end smoke verification for the loan approval pipeline.
+#
+# Up the docker stack, register a customer, submit an application,
+# wait for the orchestrator pipeline to produce a decision + email,
+# then write a machine-readable result file.
+#
+# Usage:
+#   tools/smoke_e2e.sh              # full cycle + teardown
+#   tools/smoke_e2e.sh --keep-up    # leave stack running for manual inspection
+
+set -euo pipefail
+
+KEEP_UP=false
+if [[ "${1:-}" == "--keep-up" ]]; then
+  KEEP_UP=true
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURE="${REPO_ROOT}/tools/smoke_fixtures/smoke_applicant.json"
+RESULT_FILE="${REPO_ROOT}/.tmp/smoke_result.json"
+API_BASE="http://localhost:8000/api/v1"
+
+mkdir -p "${REPO_ROOT}/.tmp"
+
+started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+start_ms=$(date +%s%3N)
+
+cleanup() {
+  if [[ "${KEEP_UP}" == "false" ]]; then
+    echo "[smoke] Tearing down docker compose stack..."
+    (cd "${REPO_ROOT}" && docker compose down) || true
+  else
+    echo "[smoke] --keep-up specified; leaving stack running."
+  fi
+}
+trap cleanup EXIT
+
+write_result() {
+  local status="$1"
+  local reason="$2"
+  local model_version="${3:-}"
+  local email_hash="${4:-}"
+  local end_ms
+  end_ms=$(date +%s%3N)
+  local duration=$((end_ms - start_ms))
+
+  cat > "${RESULT_FILE}" <<JSON
+{
+  "started_at": "${started_at}",
+  "finished_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "duration_ms": ${duration},
+  "status": "${status}",
+  "reason": "${reason}",
+  "model_version_id": "${model_version}",
+  "email_subject_hash": "${email_hash}"
+}
+JSON
+
+  echo "[smoke] Result written to ${RESULT_FILE}"
+  cat "${RESULT_FILE}"
+}
+
+echo "[smoke] Starting docker compose..."
+(cd "${REPO_ROOT}" && docker compose up -d)
+
+echo "[smoke] Waiting for /api/v1/health/ to return 200..."
+for i in {1..60}; do
+  if curl -fsS "${API_BASE}/health/" > /dev/null 2>&1; then
+    echo "[smoke] Backend healthy after ${i}s."
+    break
+  fi
+  if [[ "${i}" == "60" ]]; then
+    write_result "failure" "backend-healthcheck-timeout"
+    exit 1
+  fi
+  sleep 1
+done
+
+random=$(tr -dc 'a-z0-9' < /dev/urandom | head -c 8 || echo "smoke$(date +%s)")
+email=$(jq -r ".user.email" "${FIXTURE}" | sed "s/{{RANDOM}}/${random}/")
+password=$(jq -r ".user.password" "${FIXTURE}")
+first_name=$(jq -r ".user.first_name" "${FIXTURE}")
+last_name=$(jq -r ".user.last_name" "${FIXTURE}")
+
+echo "[smoke] Registering customer ${email}..."
+curl -fsS -X POST "${API_BASE}/auth/register/" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"${email}\",\"password\":\"${password}\",\"first_name\":\"${first_name}\",\"last_name\":\"${last_name}\",\"role\":\"customer\"}" \
+  > /dev/null || { write_result "failure" "register-failed"; exit 1; }
+
+echo "[smoke] Logging in..."
+login_response=$(curl -fsS -X POST "${API_BASE}/auth/login/" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"${email}\",\"password\":\"${password}\"}" \
+  || { write_result "failure" "login-failed"; exit 1; })
+access_token=$(echo "${login_response}" | jq -r ".access // .access_token // .token // empty")
+if [[ -z "${access_token}" ]]; then
+  write_result "failure" "no-access-token-returned"
+  exit 1
+fi
+
+echo "[smoke] Submitting loan application..."
+application_payload=$(jq -c ".application" "${FIXTURE}")
+application_response=$(curl -fsS -X POST "${API_BASE}/loans/" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${access_token}" \
+  -d "${application_payload}" \
+  || { write_result "failure" "application-submit-failed"; exit 1; })
+application_id=$(echo "${application_response}" | jq -r ".id // .uuid // empty")
+if [[ -z "${application_id}" ]]; then
+  write_result "failure" "no-application-id-returned"
+  exit 1
+fi
+echo "[smoke] Application ${application_id} submitted."
+
+echo "[smoke] Triggering orchestrator..."
+curl -fsS -X POST "${API_BASE}/agents/orchestrate/${application_id}/" \
+  -H "Authorization: Bearer ${access_token}" > /dev/null \
+  || { write_result "failure" "orchestrate-trigger-failed"; exit 1; }
+
+echo "[smoke] Polling for terminal decision (120s ceiling)..."
+decision=""
+app_detail=""
+for i in {1..120}; do
+  app_detail=$(curl -fsS "${API_BASE}/loans/${application_id}/" \
+    -H "Authorization: Bearer ${access_token}")
+  decision=$(echo "${app_detail}" | jq -r ".status // empty")
+  if [[ "${decision}" == "approved" || "${decision}" == "declined" || "${decision}" == "referred" ]]; then
+    echo "[smoke] Terminal decision reached after ${i}s: ${decision}"
+    break
+  fi
+  sleep 1
+done
+
+if [[ "${decision}" != "approved" && "${decision}" != "declined" && "${decision}" != "referred" ]]; then
+  write_result "failure" "no-terminal-decision-in-120s"
+  exit 1
+fi
+
+model_version=$(echo "${app_detail}" | jq -r ".model_version_id // .ml_prediction.model_version // .prediction.model_version_id // empty")
+
+echo "[smoke] Polling for generated email (30s ceiling)..."
+email_subject=""
+for i in {1..30}; do
+  email_detail=$(curl -fsS "${API_BASE}/emails/${application_id}/" \
+    -H "Authorization: Bearer ${access_token}" 2>/dev/null || echo "{}")
+  email_subject=$(echo "${email_detail}" | jq -r ".subject // empty")
+  if [[ -n "${email_subject}" ]]; then
+    break
+  fi
+  sleep 1
+done
+
+email_hash=""
+if [[ -n "${email_subject}" ]]; then
+  email_hash=$(printf "%s" "${email_subject}" | sha256sum | cut -c1-16)
+fi
+
+if [[ -z "${email_hash}" ]]; then
+  write_result "failure" "no-email-generated"
+  exit 1
+fi
+
+write_result "success" "ok" "${model_version}" "${email_hash}"
+echo "[smoke] SUCCESS."

--- a/tools/smoke_fixtures/smoke_applicant.json
+++ b/tools/smoke_fixtures/smoke_applicant.json
@@ -1,0 +1,32 @@
+{
+  "user": {
+    "email": "smoke-{{RANDOM}}@example.test",
+    "password": "SmokePass!2026",
+    "first_name": "Smoke",
+    "last_name": "Tester"
+  },
+  "application": {
+    "annual_income": 140000,
+    "credit_score": 780,
+    "loan_amount": 350000,
+    "loan_term_months": 360,
+    "debt_to_income": 0.25,
+    "employment_length": 60,
+    "purpose": "home",
+    "home_ownership": "mortgage",
+    "has_cosigner": false,
+    "has_hecs": false,
+    "has_bankruptcy": false,
+    "state": "NSW",
+    "property_value": 500000,
+    "deposit_amount": 150000,
+    "monthly_expenses": 3200,
+    "existing_credit_card_limit": 10000,
+    "number_of_dependants": 0,
+    "employment_type": "full_time",
+    "applicant_type": "owner_occupier",
+    "consumer_objectives": "Purchase principal place of residence for long-term owner-occupation.",
+    "consumer_requirements": "30-year principal and interest loan with ability to make extra repayments without penalty.",
+    "financial_situation_notes": "Stable full-time employment, no dependants, modest monthly expenses, substantial deposit."
+  }
+}


### PR DESCRIPTION
## Summary

Closes out v1.10.1 production hardening: end-to-end smoke-test script, workflow_dispatch CI job, and `APP_VERSION` bump.

- **`tools/smoke_e2e.sh`** — register → apply → orchestrate → decision → email, writes `.tmp/smoke_result.json`. Default teardown, `--keep-up` debug mode.
- **`tools/smoke_fixtures/smoke_applicant.json`** — deterministic owner-occupier applicant (credit 780, income 140k, DTI 0.25, $150k deposit on $500k property). Routes `home_owner_occupier` segment; `{{RANDOM}}` email placeholder avoids parallel-run collisions.
- **`.github/workflows/smoke-e2e.yml`** — `workflow_dispatch`-only; builds stack, seeds 500 rows, trains xgb, runs smoke, uploads result artifact, dumps logs on failure. 15-minute timeout. No cron by design (cost-conscious default).
- **`README.md`** — new "Verifying the build" section under Testing documents invocation + result schema + CI link.
- **`APP_VERSION`** — `1.10.0` → `1.10.1` in `backend/config/settings/base.py`.

## Verification

- [x] Scripts readable by `bash -n`; JSON fixture parses with `jq`.
- [x] Fixture fields match `LoanApplicationCreateSerializer` (verified via grep) — includes `debt_to_income`, `home_ownership`, `applicant_type` that earlier drafts omitted.
- [x] Auth URL corrected to `/api/v1/auth/` (not `/accounts/`) to match `backend/apps/accounts/urls.py` → `config/urls.py:226`.
- [ ] Local `tools/smoke_e2e.sh` run — **deferred**: Docker daemon unresponsive on the dev machine during the D6 push. The `smoke-e2e` `workflow_dispatch` job is the authoritative verification surface and runs against a fresh stack.
- [ ] `smoke-e2e` workflow — to be dispatched from this PR once CI is green.

## Spec + plan

- Spec: `docs/superpowers/specs/2026-04-19-v1-10-1-production-hardening-design.md` §D6
- Plan: `docs/superpowers/plans/2026-04-19-v1-10-1-production-hardening.md` Tasks D6.1–D6.7
- Delivered: D1 (#97), D2 (#98), D3 (#99), D4 (#100), D5 (#101), D6 (this PR)

## Post-merge

1. Tag `v1.10.1` on master.
2. Create GitHub release with CHANGELOG link.
3. Update MEMORY.md with v1.10.1 shipping fact.