### PR TITLE
fix(smoke): resolve 4 auth/profile/fixture bugs blocking e2e pipeline

### DIFF
--- a/tools/smoke_e2e.sh
+++ b/tools/smoke_e2e.sh
@@ -78,33 +78,53 @@ for i in {1..60}; do
 done
 
 random=$(tr -dc 'a-z0-9' < /dev/urandom | head -c 8 || echo "smoke$(date +%s)")
+username=$(jq -r ".user.username" "${FIXTURE}" | sed "s/{{RANDOM}}/${random}/")
 email=$(jq -r ".user.email" "${FIXTURE}" | sed "s/{{RANDOM}}/${random}/")
 password=$(jq -r ".user.password" "${FIXTURE}")
 first_name=$(jq -r ".user.first_name" "${FIXTURE}")
 last_name=$(jq -r ".user.last_name" "${FIXTURE}")
 
-echo "[smoke] Registering customer ${email}..."
+COOKIE_JAR="${REPO_ROOT}/.tmp/smoke_cookies_${random}.txt"
+trap 'rm -f "${COOKIE_JAR}"; cleanup' EXIT
+
+csrf_header() {
+  local token
+  token=$(awk '/csrftoken/ {print $NF}' "${COOKIE_JAR}" | tail -n 1)
+  echo "X-CSRFToken: ${token}"
+}
+
+echo "[smoke] Registering customer ${email} (username=${username})..."
 curl -fsS -X POST "${API_BASE}/auth/register/" \
   -H "Content-Type: application/json" \
-  -d "{\"email\":\"${email}\",\"password\":\"${password}\",\"first_name\":\"${first_name}\",\"last_name\":\"${last_name}\",\"role\":\"customer\"}" \
+  -d "{\"username\":\"${username}\",\"email\":\"${email}\",\"password\":\"${password}\",\"password2\":\"${password}\",\"first_name\":\"${first_name}\",\"last_name\":\"${last_name}\"}" \
   > /dev/null || { write_result "failure" "register-failed"; exit 1; }
 
-echo "[smoke] Logging in..."
-login_response=$(curl -fsS -X POST "${API_BASE}/auth/login/" \
+echo "[smoke] Logging in (cookie auth)..."
+curl -fsS -c "${COOKIE_JAR}" -X POST "${API_BASE}/auth/login/" \
   -H "Content-Type: application/json" \
-  -d "{\"email\":\"${email}\",\"password\":\"${password}\"}" \
-  || { write_result "failure" "login-failed"; exit 1; })
-access_token=$(echo "${login_response}" | jq -r ".access // .access_token // .token // empty")
-if [[ -z "${access_token}" ]]; then
-  write_result "failure" "no-access-token-returned"
+  -d "{\"username\":\"${username}\",\"password\":\"${password}\"}" \
+  > /dev/null || { write_result "failure" "login-failed"; exit 1; }
+
+if ! grep -q "csrftoken" "${COOKIE_JAR}"; then
+  write_result "failure" "no-csrf-cookie"
   exit 1
 fi
 
+echo "[smoke] Populating customer profile..."
+profile_payload=$(jq -c ".profile" "${FIXTURE}")
+curl -fsS -b "${COOKIE_JAR}" -X PATCH "${API_BASE}/auth/me/profile/" \
+  -H "Content-Type: application/json" \
+  -H "$(csrf_header)" \
+  -H "Referer: http://localhost:8000/" \
+  -d "${profile_payload}" \
+  > /dev/null || { write_result "failure" "profile-patch-failed"; exit 1; }
+
 echo "[smoke] Submitting loan application..."
 application_payload=$(jq -c ".application" "${FIXTURE}")
-application_response=$(curl -fsS -X POST "${API_BASE}/loans/" \
+application_response=$(curl -fsS -b "${COOKIE_JAR}" -X POST "${API_BASE}/loans/" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer ${access_token}" \
+  -H "$(csrf_header)" \
+  -H "Referer: http://localhost:8000/" \
   -d "${application_payload}" \
   || { write_result "failure" "application-submit-failed"; exit 1; })
 application_id=$(echo "${application_response}" | jq -r ".id // .uuid // empty")
@@ -115,16 +135,17 @@ fi
 echo "[smoke] Application ${application_id} submitted."
 
 echo "[smoke] Triggering orchestrator..."
-curl -fsS -X POST "${API_BASE}/agents/orchestrate/${application_id}/" \
-  -H "Authorization: Bearer ${access_token}" > /dev/null \
+curl -fsS -b "${COOKIE_JAR}" -X POST "${API_BASE}/agents/orchestrate/${application_id}/" \
+  -H "$(csrf_header)" \
+  -H "Referer: http://localhost:8000/" \
+  > /dev/null \
   || { write_result "failure" "orchestrate-trigger-failed"; exit 1; }
 
 echo "[smoke] Polling for terminal decision (120s ceiling)..."
 decision=""
 app_detail=""
 for i in {1..120}; do
-  app_detail=$(curl -fsS "${API_BASE}/loans/${application_id}/" \
-    -H "Authorization: Bearer ${access_token}")
+  app_detail=$(curl -fsS -b "${COOKIE_JAR}" "${API_BASE}/loans/${application_id}/")
   decision=$(echo "${app_detail}" | jq -r ".status // empty")
   if [[ "${decision}" == "approved" || "${decision}" == "declined" || "${decision}" == "referred" ]]; then
     echo "[smoke] Terminal decision reached after ${i}s: ${decision}"
@@ -143,8 +164,7 @@ model_version=$(echo "${app_detail}" | jq -r ".model_version_id // .ml_predictio
 echo "[smoke] Polling for generated email (30s ceiling)..."
 email_subject=""
 for i in {1..30}; do
-  email_detail=$(curl -fsS "${API_BASE}/emails/${application_id}/" \
-    -H "Authorization: Bearer ${access_token}" 2>/dev/null || echo "{}")
+  email_detail=$(curl -fsS -b "${COOKIE_JAR}" "${API_BASE}/emails/${application_id}/" 2>/dev/null || echo "{}")
   email_subject=$(echo "${email_detail}" | jq -r ".subject // empty")
   if [[ -n "${email_subject}" ]]; then
     break

--- a/tools/smoke_fixtures/smoke_applicant.json
+++ b/tools/smoke_fixtures/smoke_applicant.json
@@ -1,9 +1,24 @@
 {
   "user": {
+    "username": "smoke{{RANDOM}}",
     "email": "smoke-{{RANDOM}}@example.test",
     "password": "SmokePass!2026",
     "first_name": "Smoke",
     "last_name": "Tester"
+  },
+  "profile": {
+    "date_of_birth": "1990-06-15",
+    "phone": "+61 400 123 456",
+    "address_line_1": "12 George St",
+    "suburb": "Sydney",
+    "state": "NSW",
+    "postcode": "2000",
+    "residency_status": "citizen",
+    "primary_id_type": "drivers_licence",
+    "primary_id_number": "DL1234567",
+    "employment_status": "payg_permanent",
+    "gross_annual_income": 140000,
+    "housing_situation": "mortgage"
   },
   "application": {
     "annual_income": 140000,
@@ -23,8 +38,8 @@
     "monthly_expenses": 3200,
     "existing_credit_card_limit": 10000,
     "number_of_dependants": 0,
-    "employment_type": "full_time",
-    "applicant_type": "owner_occupier",
+    "employment_type": "payg_permanent",
+    "applicant_type": "single",
     "consumer_objectives": "Purchase principal place of residence for long-term owner-occupation.",
     "consumer_requirements": "30-year principal and interest loan with ability to make extra repayments without penalty.",
     "financial_situation_notes": "Stable full-time employment, no dependants, modest monthly expenses, substantial deposit."


### PR DESCRIPTION
## Summary
- Fix **4 critical bugs** in `tools/smoke_e2e.sh` + `smoke_applicant.json` that caused every run to fail.
- Live end-to-end verified against running stack: registered -> applied -> orchestrator approved (P=0.9682) -> email delivered via Gmail SMTP.
- Unblocks the `smoke-e2e` GitHub Actions workflow shipped in v1.10.1 (#102).

## Bugs fixed
1. **Register payload** missing `username` + `password2` (RegisterSerializer requires both).
2. **Login** was sending `email` but endpoint authenticates by `username`.
3. **Auth model** — switched from stale `Authorization: Bearer` header to cookie (`-b`) + `X-CSRFToken` + `Referer` to satisfy DRF CSRF.
4. **Fixture** — loan submit returned HTTP 400 `profile_incomplete` + invalid TextChoices (`full_time`, `owner_occupier`). Added PATCH `/auth/me/profile/` step and corrected choices to `payg_permanent` / `single`.

## Test plan
- [x] Live e2e against local docker stack passes: application id `731e721e-...`, status=approved, email delivered.
- [x] `bash -n tools/smoke_e2e.sh` — syntax clean.
- [ ] CI: trigger `smoke-e2e` workflow from Actions tab after merge.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>