### PR TITLE
fix(watchdog): replace missing requests dep with httpx (stop crashloop)

### DIFF
--- a/backend/apps/agents/management/commands/watchdog.py
+++ b/backend/apps/agents/management/commands/watchdog.py
@@ -18,8 +18,8 @@ import signal
 import sys
 import time
 
+import httpx
 import redis
-import requests
 from celery import Celery
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -110,7 +110,7 @@ class Command(BaseCommand):
         token = getattr(django_settings, "HEALTH_CHECK_TOKEN", "")
         headers = {"X-Health-Token": token} if token else {}
         try:
-            resp = requests.get(backend_url, timeout=10, headers=headers)
+            resp = httpx.get(backend_url, timeout=10, headers=headers)
             data = resp.json()
 
             db_ok = data.get("database") == "ok"
@@ -145,7 +145,7 @@ class Command(BaseCommand):
                     self.consecutive_failures,
                 )
 
-        except requests.RequestException as e:
+        except httpx.HTTPError as e:
             self.consecutive_failures += 1
             logger.error(
                 "Health check unreachable (failure %d/%d): %s",


### PR DESCRIPTION
## Summary
- Watchdog service crashlooped on start: \`ModuleNotFoundError: No module named 'requests'\` — \`requests\` was never added to \`backend/requirements.txt\`.
- Swapped to \`httpx\` (already vendored, used by 19 other modules) — no new dep.
- Verified live: watchdog container runs healthy cycles after fix.

## Why httpx over adding requests
Every other HTTP client in the backend already uses \`httpx\`. Adding a second HTTP library for one caller is unnecessary churn and extra supply-chain surface; the swap is a 3-line API-compatible change.

## Changes
- \`import requests\` -> \`import httpx\`
- \`requests.get(...)\` -> \`httpx.get(...)\` (signature identical for our usage)
- \`except requests.RequestException\` -> \`except httpx.HTTPError\`

## Test plan
- [x] Watchdog container restarts cleanly (\`docker compose restart watchdog\`)
- [x] Log shows \`Watchdog started\` + \`Cycle complete — status: healthy\` repeatedly
- [x] \`ruff check\` passes on the modified file
- [x] Full \`pytest\` suite still passes (1454 passed, 27 skipped)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>