### PR TITLE
fix(ml_engine): correct broken lazy import in CalibrationValidator

### DIFF
--- a/backend/apps/ml_engine/services/calibration_validator.py
+++ b/backend/apps/ml_engine/services/calibration_validator.py
@@ -44,7 +44,7 @@ class CalibrationValidator:
         if apra_benchmarks is not None:
             self._apra = apra_benchmarks
         else:
-            from backend.apps.ml_engine.services.macro_data_service import (
+            from apps.ml_engine.services.macro_data_service import (
                 MacroDataService,
             )
 


### PR DESCRIPTION
## Summary
- Fix latent \`ModuleNotFoundError: No module named 'backend'\` in \`CalibrationValidator.__init__\`'s fallback path.
- Import was \`from backend.apps.ml_engine.services.macro_data_service import ...\` but Django modules inside the container are rooted under \`apps.*\`, not \`backend.apps.*\`.

## Impact
- Only fires when \`CalibrationValidator()\` is constructed without \`apra_benchmarks\`.
- Sole in-tree caller (\`tests/test_apra_calibration.py:38\`) passes benchmarks explicitly, which is why tests didn't catch it.
- Any production caller (management command, orchestrator hook) would have blown up on first use.

## Verification
- Imported \`CalibrationValidator\` both with \`apra_benchmarks\` and without (using a stubbed \`MacroDataService\`) — both paths succeed.
- Ruff clean on the modified file.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>