### PR TITLE
chore(ml_engine): replace datetime.utcnow() with datetime.now(UTC)

### DIFF
--- a/backend/apps/ml_engine/services/calibration_validator.py
+++ b/backend/apps/ml_engine/services/calibration_validator.py
@@ -16,7 +16,7 @@ References:
 """
 
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 
 logger = logging.getLogger(__name__)
 
@@ -156,7 +156,7 @@ class CalibrationValidator:
             "recommendations": recommendations,
             "apra_quarter": apra_quarter,
             "apra_published_date": apra_published,
-            "validated_at": datetime.utcnow().isoformat() + "Z",
+            "validated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         }
 
         logger.info(
@@ -396,7 +396,7 @@ class CalibrationValidator:
         """
         report = {
             "report_type": "calibration_validation",
-            "generated_at": datetime.utcnow().isoformat() + "Z",
+            "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "apra_quarter": self._apra.get("quarter", "unknown"),
             "apra_published_date": self._apra.get("published_date", "unknown"),
             "total_applications": total_applications,

--- a/backend/apps/ml_engine/services/macro_data_service.py
+++ b/backend/apps/ml_engine/services/macro_data_service.py
@@ -10,7 +10,7 @@ These replace hardcoded lookup tables in the data generator with real government
 
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import httpx
 
@@ -156,7 +156,7 @@ class MacroDataService:
 
     def _fetch_with_cache(self, cache_key: str, fetch_fn, ttl_hours: int = _CACHE_TTL_HOURS):
         """Generic cache-or-fetch pattern with TTL."""
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         ts = self._cache_timestamps.get(cache_key)
         if ts and cache_key in self._cache:
             if (now - ts) < timedelta(hours=ttl_hours):

--- a/backend/apps/ml_engine/services/mrm_dossier.py
+++ b/backend/apps/ml_engine/services/mrm_dossier.py
@@ -25,7 +25,7 @@ the gap.
 from __future__ import annotations
 
 from collections.abc import Iterable
-from datetime import datetime
+from datetime import UTC, datetime
 
 # ---------------------------------------------------------------------------
 # Purpose statements per segment. Kept adjacent so a change to the training
@@ -348,7 +348,7 @@ def generate_dossier_markdown(mv) -> str:
     section headers (audit-visible evidence of gaps, rather than silent
     omission).
     """
-    generated_at = datetime.utcnow().isoformat(timespec="seconds") + "Z"
+    generated_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     sections: Iterable[str] = [
         f"# Model Risk Management Dossier — `{mv.id}`",
         f"_Generated {generated_at} — APRA CPS 220 / SR 11-7 alignment_",

--- a/backend/apps/ml_engine/services/plaid_patterns_service.py
+++ b/backend/apps/ml_engine/services/plaid_patterns_service.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import httpx
 
@@ -214,8 +214,8 @@ class PlaidPatternsService:
 
     def _get_transactions(self, access_token: str, days: int = 90) -> list | None:
         """Fetch transactions from sandbox account."""
-        end_date = datetime.utcnow().strftime("%Y-%m-%d")
-        start_date = (datetime.utcnow() - timedelta(days=days)).strftime("%Y-%m-%d")
+        end_date = datetime.now(UTC).strftime("%Y-%m-%d")
+        start_date = (datetime.now(UTC) - timedelta(days=days)).strftime("%Y-%m-%d")
 
         try:
             with httpx.Client(timeout=self.timeout) as client:

--- a/backend/apps/ml_engine/services/property_data_service.py
+++ b/backend/apps/ml_engine/services/property_data_service.py
@@ -18,7 +18,7 @@ multiplier adjusts within that state.
 import copy
 import logging
 import math
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import httpx
 import numpy as np
@@ -532,7 +532,7 @@ class PropertyDataService:
 
     def _get_cached(self, cache_key: str) -> dict | None:
         """Return cached value if still within TTL, else None."""
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         ts = self._cache_timestamps.get(cache_key)
         if ts and cache_key in self._cache:
             if (now - ts) < timedelta(hours=_CACHE_TTL_HOURS):
@@ -542,7 +542,7 @@ class PropertyDataService:
     def _set_cached(self, cache_key: str, value: dict) -> None:
         """Store value in cache with current timestamp."""
         self._cache[cache_key] = value
-        self._cache_timestamps[cache_key] = datetime.utcnow()
+        self._cache_timestamps[cache_key] = datetime.now(UTC)
 
     # ------------------------------------------------------------------
     # Public methods

--- a/backend/apps/ml_engine/services/real_world_benchmarks.py
+++ b/backend/apps/ml_engine/services/real_world_benchmarks.py
@@ -20,7 +20,7 @@ constants, so generation never breaks if APIs are unreachable.
 import csv
 import io
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import httpx
 
@@ -313,7 +313,7 @@ class RealWorldBenchmarks:
 
     def _fetch_with_cache(self, cache_key: str, fetch_fn, fallback, ttl_hours: int = _CACHE_TTL_HOURS):
         """Generic cache-or-fetch pattern with TTL and fallback."""
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         ts = self._cache_timestamps.get(cache_key)
         if ts and cache_key in self._cache:
             if (now - ts) < timedelta(hours=ttl_hours):
@@ -492,7 +492,7 @@ class RealWorldBenchmarks:
             "f6_rates": self.get_rba_f6_rates(),
             "help_debt_stats": self.get_help_debt_statistics(),
             "rba_household_debt": self.get_rba_household_debt(),
-            "fetched_at": datetime.utcnow().isoformat(),
+            "fetched_at": datetime.now(UTC).isoformat(),
         }
         logger.info(
             "Calibration snapshot assembled — sources: %s",

--- a/backend/tests/test_macro_data_service.py
+++ b/backend/tests/test_macro_data_service.py
@@ -4,7 +4,7 @@ All tests mock httpx so no real API calls are made.
 """
 
 import unittest
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 from apps.ml_engine.services.macro_data_service import (
@@ -267,7 +267,7 @@ class TestCaching(unittest.TestCase):
         svc.get_gdp_growth()
 
         # Manually expire cache
-        svc._cache_timestamps["gdp_growth"] = datetime.utcnow() - timedelta(hours=_CACHE_TTL_HOURS + 1)
+        svc._cache_timestamps["gdp_growth"] = datetime.now(UTC) - timedelta(hours=_CACHE_TTL_HOURS + 1)
         svc.get_gdp_growth()
 
         # Should have fetched twice
@@ -285,7 +285,7 @@ class TestCaching(unittest.TestCase):
         svc.get_gdp_growth()
 
         # Expire cache, then make API fail
-        svc._cache_timestamps["gdp_growth"] = datetime.utcnow() - timedelta(hours=_CACHE_TTL_HOURS + 1)
+        svc._cache_timestamps["gdp_growth"] = datetime.now(UTC) - timedelta(hours=_CACHE_TTL_HOURS + 1)
         mock_client_cls.side_effect = Exception("API down")
 
         result2 = svc.get_gdp_growth()

--- a/backend/tests/test_utcnow_deprecation.py
+++ b/backend/tests/test_utcnow_deprecation.py
@@ -1,0 +1,20 @@
+"""Guard test: no `datetime.utcnow()` in ml_engine services.
+
+Python 3.13 deprecates `datetime.utcnow()`; Python 3.14+ is scheduled to
+remove it. This test scans the services directory for the call and fails
+if any remain.
+"""
+from pathlib import Path
+
+
+def test_no_utcnow_in_ml_engine_services():
+    services_dir = Path(__file__).resolve().parents[1] / "apps" / "ml_engine" / "services"
+    offenders: list[str] = []
+    for py in services_dir.rglob("*.py"):
+        text = py.read_text(encoding="utf-8")
+        if "datetime.utcnow()" in text:
+            offenders.append(str(py.relative_to(services_dir.parent.parent.parent)))
+    assert not offenders, (
+        "datetime.utcnow() is deprecated in Python 3.13+; "
+        "use datetime.now(UTC) instead. Offenders: " + ", ".join(offenders)
+    )

--- a/backend/tests/test_utcnow_deprecation.py
+++ b/backend/tests/test_utcnow_deprecation.py
@@ -4,6 +4,7 @@ Python 3.13 deprecates `datetime.utcnow()`; Python 3.14+ is scheduled to
 remove it. This test scans the services directory for the call and fails
 if any remain.
 """
+
 from pathlib import Path
 
 


### PR DESCRIPTION
## Summary
- Replace 10 call sites of `datetime.utcnow()` across 6 `apps/ml_engine/services` modules with timezone-aware `datetime.now(UTC)`.
- Add guard test `tests/test_utcnow_deprecation.py` that fails if `datetime.utcnow()` reappears in services.
- Fix two collateral test-helper uses in `tests/test_macro_data_service.py`.
- ISO strings that previously appended a literal `Z` now use `strftime("%Y-%m-%dT%H:%M:%SZ")` to preserve wire format.

## Why
Python 3.13 emits `DeprecationWarning: datetime.datetime.utcnow() is deprecated`; the call is scheduled for removal. Shipping the fix now removes future-upgrade risk and silences warning noise.

## Test plan
- [x] `pytest tests/test_utcnow_deprecation.py -v` — new guard, passes.
- [x] `pytest tests/test_macro_data_service.py` — 33 pass (aware/aware subtraction works).
- [x] Full pytest suite — **1455 passed / 27 skipped** (1454 baseline + new guard test, no regressions).

Part of v1.10.2 consolidation release.