### PR TITLE
fix(seed): seed_profiles on_time_payment_pct scale 0-1 → 0-100

### DIFF
--- a/backend/apps/accounts/management/commands/seed_profiles.py
+++ b/backend/apps/accounts/management/commands/seed_profiles.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
             profile.has_credit_card = random.random() > 0.3
             profile.has_mortgage = random.random() > 0.6
             profile.has_auto_loan = random.random() > 0.7
-            profile.on_time_payment_pct = round(random.uniform(0.75, 1.0), 4)
+            profile.on_time_payment_pct = round(random.uniform(75.0, 100.0), 2)
             profile.previous_loans_repaid = random.randint(0, 5)
 
             # Loyalty tier based on tenure & products

--- a/backend/tests/test_seed_profiles_scale.py
+++ b/backend/tests/test_seed_profiles_scale.py
@@ -1,0 +1,44 @@
+"""Regression: seed_profiles writes on_time_payment_pct on the 0-100 scale.
+
+Bug history: prior to v1.10.2 the seed_profiles management command wrote
+random.uniform(0.75, 1.0) into on_time_payment_pct, but the field is a
+percentage in [0, 100] (enforced by validators in CustomerProfile).
+That mismatch produced near-zero percentages for every seeded customer
+and silently corrupted training data realism.
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+
+from apps.accounts.models import CustomerProfile
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_seed_profiles_on_time_payment_pct_is_on_0_to_100_scale():
+    User.objects.create_user(
+        username="seed_target",
+        email="seed_target@example.com",
+        password="x",
+        role="customer",
+    )
+
+    call_command("seed_profiles")
+
+    profiles = list(CustomerProfile.objects.all())
+    assert profiles, "seed_profiles should populate at least one CustomerProfile"
+
+    for profile in profiles:
+        pct = float(profile.on_time_payment_pct)
+        assert 0.0 <= pct <= 100.0, (
+            f"on_time_payment_pct={pct} outside the [0, 100] range "
+            f"for {profile.user.username}"
+        )
+        # Seeded range is uniform(75, 100); anything below 1.0 indicates
+        # the legacy 0-1 scale bug has regressed.
+        assert pct >= 1.0, (
+            f"on_time_payment_pct={pct} looks like the legacy 0-1 scale "
+            f"for {profile.user.username} — seed command must write percent units"
+        )

--- a/backend/tests/test_seed_profiles_scale.py
+++ b/backend/tests/test_seed_profiles_scale.py
@@ -32,10 +32,7 @@ def test_seed_profiles_on_time_payment_pct_is_on_0_to_100_scale():
 
     for profile in profiles:
         pct = float(profile.on_time_payment_pct)
-        assert 0.0 <= pct <= 100.0, (
-            f"on_time_payment_pct={pct} outside the [0, 100] range "
-            f"for {profile.user.username}"
-        )
+        assert 0.0 <= pct <= 100.0, f"on_time_payment_pct={pct} outside the [0, 100] range for {profile.user.username}"
         # Seeded range is uniform(75, 100); anything below 1.0 indicates
         # the legacy 0-1 scale bug has regressed.
         assert pct >= 1.0, (


### PR DESCRIPTION
## Summary

D2 of the v1.10.2 consolidation stack. The `seed_profiles` management command was writing `random.uniform(0.75, 1.0)` into `on_time_payment_pct`, but the field is a percent in [0, 100]. Every seeded customer had an on-time payment percent of ~0.9 (i.e. 0.9%), silently corrupting banking-relationship realism.

## Changes

- **`backend/apps/accounts/management/commands/seed_profiles.py:37`** — scale changed from `(0.75, 1.0)` → `(75.0, 100.0)`
- **`backend/tests/test_seed_profiles_scale.py`** — new regression guard asserts the field stays on the 0–100 scale

## Test plan

- [x] Regression test fails on master (red)
- [x] Regression test passes after fix (green)
- [x] Full suite green: 1455 passed, 27 skipped
- [ ] CI green on PR

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)