### PR TITLE
security(compose): require GRAFANA_ADMIN_PASSWORD, no changeme default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,12 @@ EMAIL_HOST_USER=
 EMAIL_HOST_PASSWORD=
 DEFAULT_FROM_EMAIL=aussieloanai@gmail.com
 
+# Grafana (required only when running the monitoring profile)
+# Compose refuses to start the monitoring stack without this; generate a strong password.
+# Uncomment COMPOSE_FILE below to make monitoring stack commands one-liner friendly.
+# COMPOSE_FILE=docker-compose.yml:docker-compose.monitoring.yml
+GRAFANA_ADMIN_PASSWORD=
+
 # Frontend
 NEXT_PUBLIC_API_URL=http://localhost:8000/api/v1
 NEXT_PUBLIC_SENTRY_DSN=

--- a/README.md
+++ b/README.md
@@ -172,13 +172,15 @@ JWT with HttpOnly cookies, 60-min access / 7-day refresh with rotation and black
 
 ## Monitoring and observability
 
-A full monitoring stack ships in the same compose file behind the `monitoring` profile — Prometheus, Grafana, Loki, Promtail, Alertmanager, a Celery exporter, and a Postgres exporter. Django exposes `/metrics` via `django-prometheus` with request latencies, ORM query counts, Celery task counters, and a custom training-duration histogram. Nothing runs by default, so the core stack stays small; you opt in when you want dashboards.
+A full monitoring stack ships behind the `monitoring` profile — Prometheus, Grafana, Loki, Promtail, Alertmanager, a Celery exporter, and a Postgres exporter. Django exposes `/metrics` via `django-prometheus` with request latencies, ORM query counts, Celery task counters, and a custom training-duration histogram. Nothing runs by default, so the core stack stays small; you opt in when you want dashboards.
 
-Launch it alongside the regular stack:
+Grafana lives in `docker-compose.monitoring.yml` so the main stack parses without a Grafana admin password. Before launching, set `GRAFANA_ADMIN_PASSWORD` in `.env` (compose refuses to start the monitoring profile without it — no silent fallback), then launch alongside the regular stack:
 
 ```bash
-docker compose --profile monitoring up -d
+docker compose -f docker-compose.yml -f docker-compose.monitoring.yml --profile monitoring up -d
 ```
+
+Or set `COMPOSE_FILE=docker-compose.yml:docker-compose.monitoring.yml` in `.env` to make both files the default, after which `docker compose --profile monitoring up -d` works as before.
 
 Then:
 

--- a/backend/tests/test_grafana_password_required.py
+++ b/backend/tests/test_grafana_password_required.py
@@ -1,0 +1,53 @@
+"""Guard: Grafana must not ship a default admin password.
+
+Issue #57 — we previously had `GRAFANA_ADMIN_PASSWORD:-changeme` in
+`docker-compose.yml` which silently gave every fresh clone the literal
+string `changeme` as the monitoring admin password. Grafana is now
+isolated in `docker-compose.monitoring.yml` with the `:?` required-env
+form so compose refuses to start the monitoring profile without an
+explicit secret.
+
+In CI the working directory is the repo root. When running inside the
+backend container (`/app`), the compose files are not mounted — we
+skip the test there since the invariant is already enforced by CI.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+def test_monitoring_compose_has_required_grafana_password():
+    repo_root = Path(__file__).resolve().parents[2]
+    monitoring_compose = repo_root / "docker-compose.monitoring.yml"
+
+    if not monitoring_compose.exists():
+        pytest.skip(f"{monitoring_compose} not reachable — guard enforced by CI runner")
+
+    compose = monitoring_compose.read_text(encoding="utf-8")
+
+    assert "GRAFANA_ADMIN_PASSWORD" in compose, "docker-compose.monitoring.yml should reference GRAFANA_ADMIN_PASSWORD"
+    assert ":-changeme" not in compose, (
+        "docker-compose.monitoring.yml still ships `:-changeme` fallback — "
+        "replace with `${GRAFANA_ADMIN_PASSWORD:?...}` so compose fails fast "
+        "when the env var is missing."
+    )
+    assert "GRAFANA_ADMIN_PASSWORD:?" in compose, (
+        "docker-compose.monitoring.yml should use `${GRAFANA_ADMIN_PASSWORD:?...}` "
+        "(required-env form) so compose fails fast when the secret is unset."
+    )
+
+
+def test_main_compose_does_not_ship_grafana_changeme_default():
+    repo_root = Path(__file__).resolve().parents[2]
+    main_compose = repo_root / "docker-compose.yml"
+
+    if not main_compose.exists():
+        pytest.skip(f"{main_compose} not reachable — guard enforced by CI runner")
+
+    compose = main_compose.read_text(encoding="utf-8")
+
+    assert "GRAFANA_ADMIN_PASSWORD:-changeme" not in compose, (
+        "docker-compose.yml must not re-introduce the :-changeme default. "
+        "Grafana belongs in docker-compose.monitoring.yml with the `:?` form."
+    )

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,47 @@
+# Grafana monitoring override.
+#
+# Grafana lives here rather than in the main docker-compose.yml so that
+# `docker compose up` (without monitoring) continues to parse even when
+# GRAFANA_ADMIN_PASSWORD is unset. When this file is included, compose
+# enforces the password via `:?` — no default, no surprises.
+#
+# Usage:
+#   export GRAFANA_ADMIN_PASSWORD='a strong secret'  # or set in .env
+#   docker compose -f docker-compose.yml -f docker-compose.monitoring.yml \
+#                  --profile monitoring up -d
+#
+# Or more conveniently, add to .env:
+#   COMPOSE_FILE=docker-compose.yml:docker-compose.monitoring.yml
+#   GRAFANA_ADMIN_PASSWORD=<your-secret>
+# and then `docker compose --profile monitoring up -d` picks up both files.
+
+services:
+  grafana:
+    image: grafana/grafana:latest
+    container_name: loan-approval-grafana
+    profiles: ["monitoring"]
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD in .env before starting the monitoring profile}
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
+      - grafana_data:/var/lib/grafana
+    ports:
+      - "127.0.0.1:3001:3000"
+    depends_on:
+      prometheus:
+        condition: service_started
+      loki:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - internal
+
+volumes:
+  grafana_data:
+
+networks:
+  internal:
+    external: true
+    name: loan-approval-ai-system_internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -296,27 +296,9 @@ services:
     networks:
       - internal
 
-  grafana:
-    image: grafana/grafana:latest
-    container_name: loan-approval-grafana
-    profiles: ["monitoring"]
-    environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-changeme}
-      - GF_USERS_ALLOW_SIGN_UP=false
-    volumes:
-      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
-      - grafana_data:/var/lib/grafana
-    ports:
-      - "127.0.0.1:3001:3000"
-    depends_on:
-      prometheus:
-        condition: service_started
-      loki:
-        condition: service_healthy
-    restart: unless-stopped
-    networks:
-      - internal
+  # grafana moved to docker-compose.monitoring.yml so the main stack parses
+  # without forcing GRAFANA_ADMIN_PASSWORD on developers who don't use the
+  # monitoring profile. See docker-compose.monitoring.yml for the service.
 
   loki:
     image: grafana/loki:3.4.2
@@ -416,6 +398,6 @@ volumes:
   redis_data:
   loki_data:
   prometheus_data:
-  grafana_data:
+  # grafana_data is declared in docker-compose.monitoring.yml
   frontend_next:
   frontend_node_modules:


### PR DESCRIPTION
## Summary

D4 of the v1.10.2 consolidation stack. Closes #57.

Previously `docker-compose.yml` shipped `GRAFANA_ADMIN_PASSWORD:-changeme`, meaning any fresh clone running the monitoring profile got the literal `changeme` as the Grafana admin password. That's a ship-with-default vulnerability.

Switching inline to `:?` wasn't viable — Docker Compose interpolates env vars for every service at parse time, including profile-gated ones, so the guard would fire on plain `docker compose up`. Instead Grafana now lives in `docker-compose.monitoring.yml` with the required-env form. Main compose parses cleanly without the secret; the monitoring profile fails fast without it.

## Changes

- **`docker-compose.yml`** — grafana service + grafana_data volume removed (pointer comment left behind)
- **`docker-compose.monitoring.yml`** (new) — grafana + volume + internal network re-declared with `\${GRAFANA_ADMIN_PASSWORD:?...}`
- **`README.md`** — documents the two-file invocation and the `COMPOSE_FILE` one-liner trick
- **`.env.example`** — adds commented-out `COMPOSE_FILE` and `GRAFANA_ADMIN_PASSWORD`
- **`backend/tests/test_grafana_password_required.py`** (new) — regression guards against re-introducing a default password in either file

## Migration

Users running the monitoring profile must:

1. Add `GRAFANA_ADMIN_PASSWORD=<strong-secret>` to their `.env`
2. Either invoke with both files explicitly, or add `COMPOSE_FILE=docker-compose.yml:docker-compose.monitoring.yml` to `.env`

## Test plan

- [x] `docker compose config` parses without `GRAFANA_ADMIN_PASSWORD`
- [x] `docker compose -f docker-compose.yml -f docker-compose.monitoring.yml --profile monitoring config` fails without the var
- [x] Same command succeeds when `GRAFANA_ADMIN_PASSWORD` is set
- [x] Full backend suite: 1454 passed, 29 skipped (2 new grafana guards skip in container, enforced by CI runner)
- [ ] CI green

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)