### PR TITLE
refactor(ml): remove dead DiCE callpath

### DIFF
--- a/backend/apps/ml_engine/services/counterfactual_engine.py
+++ b/backend/apps/ml_engine/services/counterfactual_engine.py
@@ -1,64 +1,21 @@
-"""CounterfactualEngine — DiCE-based counterfactual explanation generator.
+"""CounterfactualEngine — binary-search counterfactual explanation generator.
 
 Generates actionable "what-if" suggestions for denied loan applicants by
 varying only applicant-controllable features (loan_amount, loan_term_months,
-has_cosigner).  Falls back to binary-search when DiCE times out or returns
-no valid counterfactuals.
+has_cosigner). Uses deterministic binary search on loan_amount with term
+extension and cosigner toggling as secondary strategies.
 """
 
 from __future__ import annotations
 
 import logging
-import platform
-import signal
-from contextlib import contextmanager
 from typing import Any
 
-import numpy as np
 import pandas as pd
 
 logger = logging.getLogger(__name__)
 
-# Features the applicant can realistically change on a re-application
 PERMITTED_FEATURES = ["loan_amount", "loan_term_months", "has_cosigner"]
-
-
-# ---------------------------------------------------------------------------
-# Timeout helper (cross-platform)
-# ---------------------------------------------------------------------------
-
-
-@contextmanager
-def _timeout_ctx(seconds: int):
-    """Context manager that raises TimeoutError after *seconds*.
-
-    On Windows (no SIGALRM), if seconds <= 0 we raise immediately; otherwise
-    we simply yield without enforcing a timeout — the Celery task-level
-    time limit provides the safety net in production.
-    """
-    if seconds <= 0:
-        raise TimeoutError("timeout_seconds <= 0: immediate timeout")
-
-    if platform.system() != "Windows" and hasattr(signal, "SIGALRM"):
-
-        def _handler(signum, frame):
-            raise TimeoutError(f"Counterfactual generation exceeded {seconds}s")
-
-        old_handler = signal.signal(signal.SIGALRM, _handler)
-        signal.alarm(seconds)
-        try:
-            yield
-        finally:
-            signal.alarm(0)
-            signal.signal(signal.SIGALRM, old_handler)
-    else:
-        # Windows — no SIGALRM; just yield
-        yield
-
-
-# ---------------------------------------------------------------------------
-# CounterfactualEngine
-# ---------------------------------------------------------------------------
 
 
 class CounterfactualEngine:
@@ -72,19 +29,17 @@ class CounterfactualEngine:
         these are the fully-transformed columns (one-hot + engineered
         interactions), not the raw applicant input fields.
     training_data : pd.DataFrame
-        Representative sample used by DiCE for range estimation. Treated as
-        *raw* (pre-transform) features — the engine applies ``transform_fn``
-        before handing rows to the model.
+        Representative sample kept for API compatibility (the DiCE path used
+        it; the binary-search path ignores it).
     threshold : float
         Probability threshold above which the model considers an application
-        approved.  Defaults to 0.5.
+        approved. Defaults to 0.5.
     transform_fn : callable, optional
         Function mapping a raw-features DataFrame to the model's feature
         space (one-hot, scaling, engineered interactions). Defaults to
-        identity, which is fine for unit tests that use a model trained
-        directly on raw columns but wrong in production — the orchestrator
-        MUST pass ``predictor._transform`` so candidate values are scored
-        through the same pipeline as live predictions.
+        identity. The orchestrator passes ``predictor._transform`` so
+        candidate values are scored through the same pipeline as live
+        predictions.
     """
 
     def __init__(
@@ -112,177 +67,19 @@ class CounterfactualEngine:
             transformed = raw_df
         return float(self.model.predict_proba(transformed[self.feature_cols])[0][1])
 
-    # ------------------------------------------------------------------
-    # Public API
-    # ------------------------------------------------------------------
-
-    def generate(
-        self,
-        features_df: pd.DataFrame,
-        original_loan_amount: float,
-        timeout_seconds: int = 20,
-    ) -> list[dict]:
+    def generate(self, features_df: pd.DataFrame, original_loan_amount: float) -> list[dict]:
         """Return up to 3 counterfactual suggestions for a denied applicant.
 
         Returns ``[]`` if the applicant is already predicted as approved.
         """
-        # Check if already approved — nothing to explain
         prob = self._predict_prob(features_df)
         if prob >= self.threshold:
             return []
 
-        # DiCE requires a model that predicts on the same feature space as
-        # the Data object. When a transform_fn is supplied (production path),
-        # the model's input space differs from the raw-features space DiCE
-        # operates in — running DiCE would need a custom wrapper and is
-        # deferred to a future spec. Skip straight to the fallback.
-        if self._transform_fn is None:
-            try:
-                with _timeout_ctx(timeout_seconds):
-                    cfs = self._dice_counterfactuals(features_df, original_loan_amount)
-                    if cfs:
-                        return cfs
-            except (TimeoutError, Exception) as exc:
-                logger.info("DiCE counterfactuals failed/timed-out: %s — using fallback", exc)
-
         return self._fallback_binary_search(features_df, original_loan_amount)
 
-    # ------------------------------------------------------------------
-    # DiCE approach
-    # ------------------------------------------------------------------
-
-    def _build_dice_dataset(self, features_df: pd.DataFrame) -> pd.DataFrame:
-        """Return a training-like dataset DiCE can use to estimate feature
-        distributions.
-
-        If ``self.training_data`` already has enough rows (>= 50), use it with
-        an appended ``_dice_outcome`` column. Otherwise synthesise 200 rows
-        around the query by perturbing ``features_df`` and scoring with the
-        live model — DiCE only needs the distribution, not ground-truth labels.
-        """
-
-        if self.training_data is not None and len(self.training_data) >= 50:
-            df = self.training_data[self.feature_cols].copy()
-        else:
-            rng = np.random.default_rng(42)
-            base = features_df[self.feature_cols].iloc[0]
-            rows: list[dict] = []
-            for _ in range(200):
-                row: dict = {}
-                for col in self.feature_cols:
-                    val = base[col]
-                    if col == "has_cosigner":
-                        row[col] = int(rng.integers(0, 2))
-                    elif col == "loan_term_months":
-                        row[col] = int(rng.choice([12, 24, 36, 48, 60]))
-                    elif isinstance(val, (int, float, np.integer, np.floating)):
-                        # ±50% jitter around the current value; clamp to >= 0
-                        jitter = rng.uniform(0.5, 1.5)
-                        row[col] = max(0.0, float(val) * jitter)
-                    else:
-                        row[col] = val
-                rows.append(row)
-            df = pd.DataFrame(rows)
-
-        # Label rows with the model's prediction so DiCE sees both classes.
-        probs = self.model.predict_proba(df[self.feature_cols])[:, 1]
-        df = df.copy()
-        df["_dice_outcome"] = (probs >= self.threshold).astype(int)
-        return df
-
-    def _dice_counterfactuals(self, features_df: pd.DataFrame, original_loan_amount: float) -> list[dict]:
-        import dice_ml
-
-        # DiCE's Data object needs a distribution with an outcome column.
-        # If training_data is too small (e.g. a single applicant row passed
-        # from the orchestrator), synthesise one by perturbing the query.
-        dice_df = self._build_dice_dataset(features_df)
-
-        continuous_features = [c for c in self.feature_cols if c != "has_cosigner"]
-
-        d = dice_ml.Data(
-            dataframe=dice_df,
-            continuous_features=continuous_features,
-            outcome_name="_dice_outcome",
-        )
-
-        m = dice_ml.Model(model=self.model, backend="sklearn")
-
-        exp = dice_ml.Dice(d, m, method="genetic")
-
-        # Permitted ranges for the features we allow to vary
-        permitted_range = {
-            "loan_amount": [5000.0, original_loan_amount],
-            "loan_term_months": [12, 60],
-            "has_cosigner": [0, 1],
-        }
-
-        # Features to keep frozen (everything except permitted)
-        features_to_vary = PERMITTED_FEATURES
-
-        query = features_df[self.feature_cols].copy()
-
-        cf_result = exp.generate_counterfactuals(
-            query,
-            total_CFs=3,
-            desired_class="opposite",
-            features_to_vary=features_to_vary,
-            permitted_range=permitted_range,
-        )
-
-        return self._parse_dice_result(cf_result, features_df, original_loan_amount)
-
-    def _parse_dice_result(self, cf_result, features_df: pd.DataFrame, original_loan_amount: float) -> list[dict]:
-        """Extract the top-3-smallest-change CFs from a DiCE result."""
-        if cf_result.cf_examples_list is None or len(cf_result.cf_examples_list) == 0:
-            return []
-
-        cf_df = cf_result.cf_examples_list[0].final_cfs_df
-        if cf_df is None or cf_df.empty:
-            return []
-
-        original = features_df[self.feature_cols].iloc[0]
-        scored: list[tuple[float, dict]] = []
-
-        for _, row in cf_df.iterrows():
-            changes: dict[str, Any] = {}
-            total_change = 0.0
-
-            for feat in PERMITTED_FEATURES:
-                orig_val = original[feat]
-                new_val = row[feat]
-
-                if feat == "has_cosigner":
-                    if int(new_val) != int(orig_val):
-                        changes[feat] = int(new_val)
-                        total_change += 1.0
-                elif feat == "loan_amount":
-                    new_val = float(new_val)
-                    new_val = max(5000.0, min(new_val, original_loan_amount))
-                    if abs(new_val - float(orig_val)) > 1.0:
-                        changes[feat] = round(new_val, 2)
-                        total_change += abs(new_val - float(orig_val)) / max(float(orig_val), 1.0)
-                elif feat == "loan_term_months":
-                    new_val = int(round(float(new_val)))
-                    new_val = max(12, min(new_val, 60))
-                    if new_val != int(orig_val):
-                        changes[feat] = new_val
-                        total_change += abs(new_val - int(orig_val)) / 60.0
-
-            if changes:
-                statement = self._format_statement(changes, features_df)
-                scored.append((total_change, {"changes": changes, "statement": statement}))
-
-        # Sort by smallest total change, take top 3
-        scored.sort(key=lambda x: x[0])
-        return [item[1] for item in scored[:3]]
-
-    # ------------------------------------------------------------------
-    # Binary-search fallback
-    # ------------------------------------------------------------------
-
     def _fallback_binary_search(self, features_df: pd.DataFrame, original_loan_amount: float) -> list[dict]:
-        """Deterministic fallback: binary-search on loan_amount, then try
+        """Deterministic search: binary-search on loan_amount, then try
         loan_term extension and cosigner toggle.
 
         Reads raw feature values from features_df (not indexed by feature_cols,
@@ -290,9 +87,6 @@ class CounterfactualEngine:
         string columns like state/purpose).
         """
         results: list[dict] = []
-        # Read raw values directly — features_df is the applicant's raw row,
-        # which has loan_amount / loan_term_months / has_cosigner even when
-        # feature_cols describes the transformed model input space.
         original = features_df.iloc[0]
 
         # --- 1. Binary-search on loan_amount ---
@@ -391,7 +185,6 @@ class CounterfactualEngine:
                 best_changes["loan_term_months"] = 60
             if int(original["has_cosigner"]) == 0:
                 best_changes["has_cosigner"] = 1
-            # Ensure we have at least loan_amount reduction
             if not best_changes and current_amount > 5000:
                 best_changes["loan_amount"] = 5000.0
             if best_changes:
@@ -412,8 +205,8 @@ class CounterfactualEngine:
         high: float,
         iterations: int = 30,
     ) -> float | None:
-        """Binary-search for the smallest value of *feature* that flips the
-        prediction to approved."""
+        """Binary-search for the largest value of *feature* that still flips
+        the prediction to approved (closest to the applicant's original)."""
         flip_value = None
         for _ in range(iterations):
             mid = (low + high) / 2
@@ -423,18 +216,12 @@ class CounterfactualEngine:
                 prob = self._predict_prob(test_df)
                 if prob >= self.threshold:
                     flip_value = mid
-                    # We want the *largest* value that still flips (closest
-                    # to original), so move low upward
                     low = mid
                 else:
                     high = mid
             except Exception:
                 break
         return flip_value
-
-    # ------------------------------------------------------------------
-    # Statement formatting
-    # ------------------------------------------------------------------
 
     def _format_statement(self, changes: dict, features_df: pd.DataFrame) -> str:
         """Produce a human-readable sentence describing the changes."""

--- a/backend/apps/ml_engine/tests/test_counterfactual_engine.py
+++ b/backend/apps/ml_engine/tests/test_counterfactual_engine.py
@@ -84,14 +84,6 @@ class TestCounterfactualEngine:
             assert isinstance(cf["statement"], str)
             assert len(cf["statement"]) > 0
 
-    def test_fallback_on_timeout(self):
-        engine = self._make_engine()
-        result = engine.generate(self._denied_applicant(), original_loan_amount=200000.0, timeout_seconds=0)
-        assert isinstance(result, list)
-        assert len(result) >= 1
-        for cf in result:
-            assert "statement" in cf
-
     def test_returns_empty_for_approved_applicant(self):
         engine = self._make_engine()
         approved = pd.DataFrame(
@@ -113,18 +105,20 @@ class TestCounterfactualEngine:
         assert result == []
 
 
-def test_generate_default_timeout_is_20_seconds():
-    """B1: caller/callee timeout mismatch fix — generate() defaults to 20s."""
+def test_generate_signature_has_no_timeout_param():
+    """D5 (v1.10.2): DiCE removal also drops the no-op timeout knob."""
     from apps.ml_engine.services.counterfactual_engine import CounterfactualEngine
 
     sig = inspect.signature(CounterfactualEngine.generate)
-    param = sig.parameters["timeout_seconds"]
-    assert param.default == 20, f"generate() default timeout should be 20s after B1 fix; got {param.default}"
+    assert "timeout_seconds" not in sig.parameters, (
+        "generate() no longer takes timeout_seconds after DiCE removal — binary search is deterministic and fast."
+    )
 
 
-def test_dice_total_cfs_is_three():
-    """B1: total_CFs reduced 5→3 to cut DiCE wall time."""
-    from apps.ml_engine.services.counterfactual_engine import CounterfactualEngine
+def test_no_dice_ml_in_module_source():
+    """D5 (v1.10.2): the DiCE callpath was dead code; removal is irreversible."""
+    from apps.ml_engine.services import counterfactual_engine
 
-    src = inspect.getsource(CounterfactualEngine._dice_counterfactuals)
-    assert "total_CFs=3" in src or "total_CFs = 3" in src, "DiCE call should use total_CFs=3 after B1 fix"
+    src = inspect.getsource(counterfactual_engine)
+    assert "dice_ml" not in src, "counterfactual_engine.py must not reference dice_ml after D5"
+    assert "_dice_counterfactuals" not in src, "_dice_counterfactuals must be removed after D5"

--- a/backend/apps/ml_engine/tests/test_counterfactual_engine_with_transform.py
+++ b/backend/apps/ml_engine/tests/test_counterfactual_engine_with_transform.py
@@ -101,7 +101,7 @@ def test_engine_runs_against_transforming_model():
 
     # Must not raise. Previously would raise
     # ``KeyError: '[purpose_home, ..., state_QLD] not in index'``.
-    results = engine.generate(raw_query, original_loan_amount=300000.0, timeout_seconds=2)
+    results = engine.generate(raw_query, original_loan_amount=300000.0)
 
     # Binary-search fallback should produce at least one suggestion
     assert isinstance(results, list)
@@ -149,6 +149,6 @@ def test_engine_without_transform_still_works():
         threshold=0.5,
         # No transform_fn — identity path
     )
-    results = engine.generate(query, original_loan_amount=250000.0, timeout_seconds=2)
+    results = engine.generate(query, original_loan_amount=250000.0)
     assert isinstance(results, list)
     assert len(results) >= 1

--- a/backend/tests/test_no_dice_ml_dependency.py
+++ b/backend/tests/test_no_dice_ml_dependency.py
@@ -13,7 +13,6 @@ source file under `apps/ml_engine` references `dice_ml`.
 import ast
 from pathlib import Path
 
-
 _BANNED_NAMES = {"_dice_counterfactuals", "_build_dice_dataset", "_parse_dice_result"}
 
 

--- a/backend/tests/test_no_dice_ml_dependency.py
+++ b/backend/tests/test_no_dice_ml_dependency.py
@@ -1,0 +1,62 @@
+"""Guard: `dice_ml` must not be imported anywhere in ml_engine.
+
+The `_dice_counterfactuals` call path was never actually wired up — in
+production the orchestrator always passes `transform_fn=predictor._transform`,
+which sends `generate()` straight to the binary-search fallback. `dice_ml`
+was never added to requirements.txt, so even the one unguarded call path
+(no transform_fn) raised ImportError and fell through to fallback.
+
+This test locks in the D5 removal of the dead DiCE code by asserting no
+source file under `apps/ml_engine` references `dice_ml`.
+"""
+
+import ast
+from pathlib import Path
+
+
+_BANNED_NAMES = {"_dice_counterfactuals", "_build_dice_dataset", "_parse_dice_result"}
+
+
+def _has_dice_code(path: Path) -> bool:
+    """True if *path* has a dice_ml import, dice_ml.X attribute access, or
+    a def/call of the banned DiCE helper methods.
+
+    String mentions in docstrings or assertion messages don't count — only
+    executable references that would fire at import/call time.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return False
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(alias.name == "dice_ml" or alias.name.startswith("dice_ml.") for alias in node.names):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            if node.module == "dice_ml" or (node.module or "").startswith("dice_ml."):
+                return True
+        elif isinstance(node, ast.Attribute):
+            if isinstance(node.value, ast.Name) and node.value.id == "dice_ml":
+                return True
+        elif isinstance(node, ast.FunctionDef):
+            if node.name in _BANNED_NAMES:
+                return True
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Attribute) and func.attr in _BANNED_NAMES:
+                return True
+            if isinstance(func, ast.Name) and func.id in _BANNED_NAMES:
+                return True
+    return False
+
+
+def test_no_dice_ml_references_in_ml_engine():
+    ml_engine = Path(__file__).resolve().parents[1] / "apps" / "ml_engine"
+    offenders = [str(py.relative_to(ml_engine.parent.parent)) for py in ml_engine.rglob("*.py") if _has_dice_code(py)]
+
+    assert not offenders, (
+        "Dead DiCE code still present. The `_dice_counterfactuals` callpath "
+        "was never wired up (dice_ml is not in requirements) and production "
+        "always takes the binary-search fallback. Offenders: " + ", ".join(offenders)
+    )


### PR DESCRIPTION
## Summary

D5 of the v1.10.2 consolidation release. Removes the entire DiCE (Diverse Counterfactual Explanations) callpath from `ml_engine/services/counterfactual_engine.py` — it was dead code that never ran in production.

**Evidence this path was dead:**
- `dice_ml` is not in `requirements.txt` — the `import dice_ml` statement would always raise `ImportError`
- The orchestrator (`orchestrator.py`) always passes `transform_fn=predictor._transform` to `CounterfactualEngine`, which routes `generate()` directly to the binary-search fallback
- The only callpath that would have attempted DiCE was `transform_fn is None`, which nothing in production exercises — and even that path caught `ImportError` and fell through to the fallback

**What's removed:**
- `_dice_counterfactuals`, `_build_dice_dataset`, `_parse_dice_result` methods
- `_timeout_ctx` context manager + `platform`/`signal` imports
- `timeout_seconds` parameter on `generate()` (was a no-op in the fallback path — binary search is deterministic and fast)

**What stays:**
- `CounterfactualEngine` public API (minus the dead `timeout_seconds` kwarg)
- Binary-search fallback — the path actually used in production
- All permitted-features logic (`loan_amount`, `loan_term_months`, `has_cosigner`)

**Net diff:** `counterfactual_engine.py` goes from ~458 to ~230 lines.

## Guards

Two new guard tests lock in the removal:

1. `backend/tests/test_no_dice_ml_dependency.py` — AST-based scan of `apps/ml_engine` that distinguishes real code references (`import dice_ml`, `dice_ml.foo`, `def _dice_counterfactuals`) from string mentions in docstrings/assertions. Uses the AST so future docstring archaeology doesn't false-positive.
2. `backend/apps/ml_engine/tests/test_counterfactual_engine.py::test_generate_signature_has_no_timeout_param` — asserts the `timeout_seconds` kwarg is permanently gone from `generate()`.
3. `backend/apps/ml_engine/tests/test_counterfactual_engine.py::test_no_dice_ml_in_module_source` — a second, simpler string-based check on the module source.

## Test plan

- [x] Full backend pytest suite: `1455 passed, 27 skipped` (baseline maintained)
- [x] Existing `TestCounterfactualEngine` class still passes (6 tests green)
- [x] `test_engine_runs_against_transforming_model` regression still green (KeyError fix from earlier PR preserved)
- [x] `test_engine_without_transform_still_works` still green (backwards compat)
- [x] Ruff format clean
- [ ] CI (backend-lint, backend-test, frontend-test) to verify

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)