### PR TITLE
chore(make): split clean → clean-soft (preserve DB) + clean (full wipe)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev down build test lint seed train logs health clean clean-deep typecheck security verify deadcode
+.PHONY: dev down build test lint seed train logs health clean clean-soft clean-deep typecheck security verify deadcode
 
 # Development
 dev:                     ## Start all services
@@ -90,15 +90,19 @@ health:                  ## Check service health
 	@curl -s http://localhost:8000/api/v1/health/deep/ | python -m json.tool
 
 # Cleanup
-clean:                   ## Nuke ephemerals (containers, caches, build output)
-	docker compose down -v
+clean-soft:              ## Clear caches + build output; KEEPS docker volumes (DB, redis, etc.)
 	find backend -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 	find backend -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true
 	find . -name "*.pyc" -not -path "*/node_modules/*" -delete 2>/dev/null || true
 	rm -rf frontend/.next frontend/coverage frontend/playwright-report frontend/test-results
 	rm -rf backend/htmlcov backend/.coverage backend/.pytest_cache
 	rm -f frontend/tsconfig.tsbuildinfo
-	@echo "Clean complete. Re-run 'make build' then 'make dev' to restart."
+	@echo "Soft-clean complete. Docker volumes preserved (postgres/redis data intact)."
+
+clean:                   ## FULL wipe: containers + volumes + caches. Use clean-soft day-to-day.
+	docker compose down -v
+	$(MAKE) clean-soft
+	@echo "Full clean complete. Re-run 'make build' then 'make dev' to restart. DB was wiped."
 
 clean-deep:              ## clean + remove node_modules + .venv (forces reinstall)
 	$(MAKE) clean

--- a/README.md
+++ b/README.md
@@ -226,9 +226,12 @@ The same script runs as a manually-triggered GitHub Actions job under `smoke-e2e
 Local development accumulates build artifacts, test caches, and trained model files. To reclaim disk:
 
 ```bash
-make clean       # ephemerals (containers, .next, coverage, __pycache__, tsbuildinfo)
-make clean-deep  # also removes node_modules and backend/.venv (forces reinstall)
+make clean-soft  # caches + build output ONLY — docker volumes (DB, redis) preserved
+make clean       # FULL wipe: containers + volumes + caches (DB is wiped — use sparingly)
+make clean-deep  # clean + removes node_modules and backend/.venv (forces reinstall)
 ```
+
+Day-to-day, `make clean-soft` is the right default — it reclaims several hundred MB of Python/Next.js caches without touching the Postgres volume. Reserve `make clean` for "I want a fresh-from-seed DB".
 
 To prune stale trained-model `.joblib` artifacts from `backend/ml_models/` (after many training iterations):
 

--- a/backend/tests/test_makefile_clean_targets.py
+++ b/backend/tests/test_makefile_clean_targets.py
@@ -1,0 +1,67 @@
+"""Guard: `make clean-soft` must exist and must NOT delete Docker volumes.
+
+The old `make clean` ran `docker compose down -v` which nuked the Postgres
+volume along with caches/build output. That's fine for a fresh start but
+devastating when a developer just wants to drop Python caches. D6 adds
+`clean-soft` as the non-destructive default and keeps `clean` for the
+full wipe.
+
+This test locks in the split so a future refactor doesn't accidentally
+re-introduce volume deletion into the soft-clean path.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+def _makefile_path() -> Path:
+    return Path(__file__).resolve().parents[2] / "Makefile"
+
+
+def _makefile_text() -> str:
+    path = _makefile_path()
+    if not path.is_file():
+        pytest.skip(f"Makefile not mounted at {path} (CI runs from host; Docker exec skips)")
+    return path.read_text(encoding="utf-8")
+
+
+def _target_body(text: str, target: str) -> str:
+    """Return the recipe lines for *target* (lines until the next non-indented line)."""
+    lines = text.splitlines()
+    body: list[str] = []
+    in_target = False
+    for line in lines:
+        if line.startswith(f"{target}:"):
+            in_target = True
+            continue
+        if in_target:
+            if line.startswith("\t") or line.strip() == "" or line.startswith(" "):
+                body.append(line)
+            else:
+                break
+    return "\n".join(body)
+
+
+def test_clean_soft_target_exists():
+    text = _makefile_text()
+    assert "clean-soft:" in text, "make clean-soft must exist (D6)"
+
+
+def test_clean_soft_does_not_delete_volumes():
+    body = _target_body(_makefile_text(), "clean-soft")
+    assert "down -v" not in body, "clean-soft must NOT run `docker compose down -v` — that nukes the DB"
+    assert "docker volume rm" not in body, "clean-soft must not remove docker volumes"
+
+
+def test_clean_still_wipes_volumes():
+    """Full wipe stays available under `make clean`."""
+    body = _target_body(_makefile_text(), "clean")
+    assert "down -v" in body, "`make clean` should still perform the full wipe"
+
+
+def test_phony_declaration_includes_clean_soft():
+    text = _makefile_text()
+    phony_lines = [ln for ln in text.splitlines() if ln.startswith(".PHONY:")]
+    phony_targets = " ".join(phony_lines)
+    assert "clean-soft" in phony_targets, "clean-soft must appear in .PHONY"


### PR DESCRIPTION
## Summary

D6 of the v1.10.2 consolidation release. Splits `make clean` into two targets so developers have a safe day-to-day cache-clearing command that does not destroy the Postgres volume.

### Before

```bash
make clean    # docker compose down -v  ⚠️  DB wiped
              # + clears caches/build output
```

One target with two jobs. Developers ran it to clear Python caches and lost their seeded DB.

### After

```bash
make clean-soft  # NEW: caches + build output only — volumes preserved
make clean       # FULL wipe: down -v + clean-soft (renamed semantics)
make clean-deep  # clean + node_modules + .venv (unchanged)
```

`make clean-soft` is now the recommended day-to-day default. `make clean` is preserved for the from-seed-reset case and internally calls `clean-soft` for the cache sweep (DRY).

## Guards

`backend/tests/test_makefile_clean_targets.py` locks in:

- `clean-soft:` target exists
- `clean-soft` body contains no `docker compose down -v` or `docker volume rm`
- `clean:` still runs `down -v` (full wipe remains available)
- `.PHONY:` declares `clean-soft`

The test skips cleanly in Docker-exec contexts (Makefile not mounted) and runs on CI where the repo root is visible.

## Test plan

- [x] Static guards (`test_makefile_clean_targets.py`) pass on host
- [x] Tests skip cleanly when Makefile not accessible (Docker-exec compat)
- [x] README updated to document `clean-soft` as the preferred default
- [ ] CI (backend-lint, backend-test) to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)