### PR TITLE
chore(infra): harden compose env + pin monitoring images + tighten deploy gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,9 @@ DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
 # Database
 POSTGRES_DB=loan_approval
 POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
+# Required — compose refuses to start without this.
+# Generate: `openssl rand -base64 24` (or any strong secret).
+POSTGRES_PASSWORD=change-me-to-a-strong-password
 POSTGRES_HOST=db
 POSTGRES_PORT=5432
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,7 +208,7 @@ jobs:
     # Relies on branch-protection rules to require green Lint / Test / Security
     # workflow conclusions before a push reaches master. See
     # docs/runbooks/ci-deployment.md for the required-checks list.
-    if: always() && github.ref == 'refs/heads/master' && github.event_name == 'push' && !contains(needs.docker-build.result, 'failure') && !contains(needs.dast-scan.result, 'failure')
+    if: always() && github.ref == 'refs/heads/master' && github.event_name == 'push' && needs.docker-build.result == 'success' && needs.dast-scan.result == 'success'
     steps:
       - uses: actions/checkout@v6
 

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -17,7 +17,7 @@
 
 services:
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:11.5.1
     container_name: loan-approval-grafana
     profiles: ["monitoring"]
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,9 @@ services:
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-loan_approval}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      # No default password — compose refuses to start unless set in .env.
+      # Prevents shipping a known-weak credential to any environment.
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env before starting the stack}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 15s
@@ -60,7 +62,7 @@ services:
       POSTGRES_HOST: db
       POSTGRES_DB: ${POSTGRES_DB:-loan_approval}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env before starting the stack}
       DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE:-config.settings.development}
       DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-}
       DJANGO_DEBUG: ${DJANGO_DEBUG:-}
@@ -104,7 +106,7 @@ services:
         required: false
     environment:
       POSTGRES_HOST: db
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env before starting the stack}
       DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE:-config.settings.development}
       DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-}
       CELERY_BROKER_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
@@ -153,7 +155,7 @@ services:
         required: false
     environment:
       POSTGRES_HOST: db
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env before starting the stack}
       DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE:-config.settings.development}
       DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-}
       CELERY_BROKER_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
@@ -193,7 +195,7 @@ services:
         required: false
     environment:
       POSTGRES_HOST: db
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env before starting the stack}
       DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE:-config.settings.development}
       DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-}
       CELERY_BROKER_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
@@ -227,7 +229,7 @@ services:
         required: false
     environment:
       POSTGRES_HOST: db
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env before starting the stack}
       DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE:-config.settings.development}
       DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-}
       CELERY_BROKER_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
@@ -280,7 +282,7 @@ services:
 
   # --- Monitoring stack (opt-in via: docker compose --profile monitoring up) ---
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.1.0
     container_name: loan-approval-prometheus
     profiles: ["monitoring"]
     volumes:
@@ -346,7 +348,7 @@ services:
       - internal
 
   alertmanager:
-    image: prom/alertmanager:latest
+    image: prom/alertmanager:v0.28.0
     container_name: loan-approval-alertmanager
     profiles: ["monitoring"]
     restart: unless-stopped
@@ -360,7 +362,7 @@ services:
       - internal
 
   celery-exporter:
-    image: danihodovic/celery-exporter:latest
+    image: danihodovic/celery-exporter:0.10.13
     container_name: loan-approval-celery-exporter
     profiles: ["monitoring"]
     restart: unless-stopped
@@ -375,7 +377,7 @@ services:
       - internal
 
   postgres-exporter:
-    image: prometheuscommunity/postgres-exporter:latest
+    image: prometheuscommunity/postgres-exporter:v0.17.1
     container_name: loan-approval-postgres-exporter
     profiles: ["monitoring"]
     restart: unless-stopped
@@ -385,7 +387,7 @@ services:
       db:
         condition: service_healthy
     environment:
-      DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-loan_approval}?sslmode=disable"
+      DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env before starting the stack}@db:5432/${POSTGRES_DB:-loan_approval}?sslmode=disable"
     networks:
       - internal
 


### PR DESCRIPTION
## Summary
Third PR in the senior code review cleanup series. Four infra/CI hardening fixes.

- **POSTGRES_PASSWORD `:?` guard** — Across db, backend, 3× celery workers, beat, watchdog, and postgres-exporter. Compose now refuses to start unless the secret is set in `.env`. Removes the `:-postgres` fallback that could ship a known-weak credential. Matches the existing `GRAFANA_ADMIN_PASSWORD:?` pattern.
- **Pin `:latest` monitoring images** — Prometheus, Alertmanager, celery-exporter, postgres-exporter, Grafana. All `profiles: ["monitoring"]` so opt-in only. `:latest` is a supply-chain footgun.
- **Tighten CI deploy gate** — `.github/workflows/build.yml:211` was `!contains(needs.X.result, 'failure')`. This silently permits `cancelled`/`skipped` to deploy — only `failure` blocked. Replaced with explicit `needs.X.result == 'success'`.
- **Update `.env.example`** — Remove the `POSTGRES_PASSWORD=postgres` default and document the `:?` requirement with a generation hint.

## Root causes
- Default passwords in compose fall through to any environment where `.env` is missing a key — production, staging, or a developer's laptop inheriting a lazy copy.
- `:latest` tags silently advance majors; supply-chain risk + dashboards break with no audit trail.
- `!contains(result, 'failure')` is a negated partial match: it returns true for `cancelled`, `skipped`, `` (empty). A skipped DAST scan would deploy.

## Test plan
- [x] `docker compose -f docker-compose.yml -f docker-compose.monitoring.yml config --quiet` passes with env vars set
- [x] Same command fails cleanly with clear error message when `POSTGRES_PASSWORD` unset
- [x] Existing `.env` already has `POSTGRES_PASSWORD` set — no dev disruption
- [ ] Post-merge: smoke the monitoring profile to confirm pinned versions boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)