### PR TITLE
refactor(frontend): TanStack Query polling, drop useEffect(setInterval)

### DIFF
--- a/frontend/src/app/apply/status/[id]/page.tsx
+++ b/frontend/src/app/apply/status/[id]/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useEffect } from 'react'
 import { useParams } from 'next/navigation'
 import Link from 'next/link'
 import { useApplication } from '@/hooks/useApplications'
@@ -184,19 +183,16 @@ function StatusPipeline({ status }: { status: string }) {
 
 export default function CustomerApplicationStatusPage() {
   const { id } = useParams<{ id: string }>()
-  const { data: application, isLoading, refetch } = useApplication(id)
-
-  // Poll every 5 seconds while the application is still being processed
-  useEffect(() => {
-    if (!application) return
-    if (application.status === 'pending' || application.status === 'processing') {
-      const interval = setInterval(() => {
-        refetch()
-      }, 5000)
-      return () => clearInterval(interval)
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- poll restart depends only on status change, not full application object
-  }, [application?.status, refetch])
+  const { data: application, isLoading } = useApplication(id, {
+    // Poll every 5s only while still being processed. Letting TanStack Query
+    // own the interval avoids stale closures / interval-leak races that the
+    // old useEffect(setInterval) pattern was prone to when the hook remounted
+    // faster than the cleanup timer fired.
+    refetchInterval: (query) => {
+      const status = query.state.data?.status
+      return status === 'pending' || status === 'processing' ? 5000 : false
+    },
+  })
 
   if (isLoading) {
     return (

--- a/frontend/src/hooks/useApplications.ts
+++ b/frontend/src/hooks/useApplications.ts
@@ -14,7 +14,10 @@ export function useApplications(params?: Record<string, any>) {
   })
 }
 
-export function useApplication(id: string) {
+export function useApplication(
+  id: string,
+  options?: { refetchInterval?: number | false | ((query: { state: { data?: LoanApplication } }) => number | false) },
+) {
   return useQuery<LoanApplication>({
     queryKey: ['application', id],
     queryFn: async () => {
@@ -22,6 +25,7 @@ export function useApplication(id: string) {
       return data
     },
     enabled: !!id,
+    refetchInterval: options?.refetchInterval,
   })
 }
 


### PR DESCRIPTION
## Summary
Fourth PR in the senior code review cleanup series. Single focused refactor.

- **Customer application status page** — Replace the `useEffect` + `setInterval` polling pattern with TanStack Query's `refetchInterval`. The function form returns `5000` while status is `pending`/`processing` and `false` otherwise, so TanStack owns the timer lifecycle (unmount handling, dedup, stale closures).
- **useApplication hook** — Accepts an optional `refetchInterval` option typed to the TanStack function-form signature.

## Root cause
`useEffect(setInterval)` is stale-closure-prone. When the hook remounts faster than the cleanup fires, the interval can leak. TanStack Query's `refetchInterval` is the idiomatic polling primitive and handles cleanup correctly.

## Scope note
The original PR-D scope from the review included (a) HTML-escape LLM-interpolated values in `emailHtmlRenderer.ts` and (b) URL protocol allowlist for the LLM-extracted unsubscribe URL. Both were **deferred**:
- The TS renderer has a byte-for-byte parity CI test against 15 Python snapshots. Escaping in TS without a matching Python change breaks CI; coordinated change + 15 snapshot regens is too wide a blast radius for a single "safe" PR.
- The preview already runs through DOMPurify in `HtmlEmailBody`, which enforces a default URI allowlist (strips `javascript:`/`data:`). Residual risk in the preview is zero; residual risk in the SMTP-delivered email is limited to malformed HTML in inboxes (clients strip scripts).

Follow-up work should land both changes together with regenerated snapshots.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/__tests__/lib/emailHtmlRenderer.test.ts` — 21/21 pass (parity intact)
- [x] `npx vitest run src/__tests__/hooks/useApplications.test.tsx` — 9/9 pass
- [ ] Manually verify polling stops when status transitions to approved/denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)