### PR TITLE
fix(ml): bump postcode_default_rate noise std 0.003 → 0.008

### DIFF
--- a/backend/apps/ml_engine/services/data_generator.py
+++ b/backend/apps/ml_engine/services/data_generator.py
@@ -1088,7 +1088,13 @@ class DataGenerator:
                     local_unemp = sa4_unemp.get(sa4_code, national_avg_unemp)
                     unemp_factor = 1.0 + 0.5 * (local_unemp - national_avg_unemp) / national_avg_unemp
                     base_default_rate[i] *= max(unemp_factor, 0.5)
-        geo_postcode_default_rate = base_default_rate + rng.normal(0, 0.003, size=n)
+        # Noise std 0.008 matches real Equifax/illion AU bureau correlation
+        # with SA4 unemployment (r ≈ 0.3-0.45). Tighter noise (0.003) would
+        # collapse the feature to a near-deterministic function of the same
+        # SA4 unemployment that drives the label via the underwriter, creating
+        # a synthetic-only shortcut that inflates AUC. See
+        # docs/experiments/synthetic_data_realism_audit.md for the audit trail.
+        geo_postcode_default_rate = base_default_rate + rng.normal(0, 0.008, size=n)
         geo_postcode_default_rate = np.clip(geo_postcode_default_rate, 0.002, 0.05).round(4)
 
         _high_risk_industries = {"A", "B", "E", "H"}

--- a/backend/tests/test_data_generator.py
+++ b/backend/tests/test_data_generator.py
@@ -202,6 +202,22 @@ class TestDataGenerator:
         thin_file = df[df["credit_history_months"] < 36]
         assert len(thin_file) > 0, "Should have thin-file applicants (credit_history < 36 months)"
 
+    def test_postcode_default_rate_correlation_realistic(self, df):
+        # Real Equifax / illion AU data shows bureau postcode-default-rate
+        # correlates with SA4 unemployment at r ≈ 0.3-0.45 — an informative
+        # signal, not a deterministic shortcut. The classifier trains on the
+        # binary `approved` label (see ModelTrainer._prepare_data). If
+        # postcode_default_rate's correlation with `approved` exceeds 0.25 in
+        # magnitude, the generator has re-introduced a synthetic-only leakage
+        # that will inflate AUC in ways that do not transfer to real data.
+        # Guards against regression of the noise-std fix (0.003 → 0.008).
+        corr = float(np.corrcoef(df["postcode_default_rate"].values, df["approved"].astype(float).values)[0, 1])
+        assert abs(corr) < 0.25, (
+            f"postcode_default_rate ↔ approved correlation {corr:.3f} looks "
+            "like synthetic-only leakage; expected |corr| < 0.25 for a "
+            "realistic bureau-style signal"
+        )
+
     def test_seasonal_quarter_distribution(self, generator):
         """Q4 quarters should have more records than Q2 (seasonal weighting)."""
         df_large = generator.generate(num_records=5000, random_seed=42)

--- a/tools/file_size_allowlist.json
+++ b/tools/file_size_allowlist.json
@@ -4,7 +4,7 @@
   "packages": {
     "backend/apps/ml_engine/services": {
       "files": {
-        "data_generator.py": 1559,
+        "data_generator.py": 1565,
         "real_world_benchmarks.py": 1378,
         "trainer.py": 1340,
         "metrics.py": 1018,


### PR DESCRIPTION
## Summary

Re-lands the substance of closed PR #93 as a fresh atomic change against current master.

`data_generator.py` currently generates `geo_postcode_default_rate = base_default_rate + rng.normal(0, 0.003)`. That noise std is too tight — it collapses the feature to a near-deterministic function of SA4 unemployment, which is the same variable the underwriter uses to drive the label. The classifier learned a synthetic-only shortcut that inflates AUC in ways that do not transfer to real data.

**Fix:** bump the noise std to `0.008`, matching real Equifax / illion AU bureau correlation with SA4 unemployment (r ≈ 0.3–0.45).

**Regression guard:** `test_postcode_default_rate_correlation_realistic` asserts `|corr(postcode_default_rate, approved)| < 0.25` so the leakage cannot be silently re-introduced.

## Non-goals

- No schema change
- No retraining required for existing deployments (the fix takes effect next time `DataGenerator.generate()` is run for training data)
- No model object promotion — this affects synthetic data used to train future models, not any in-flight ModelVersion

## Test plan

- [ ] All 72 `tests/test_data_generator.py` tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)