### PR TITLE
security(ci): generate ephemeral Fernet key at CI runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: testpass
           REDIS_PASSWORD: testpass
-          FIELD_ENCRYPTION_KEY: "kA6H1LGRC3JUszuqLoXUyvxw_IX5bjJSDJ6B57rdexU="
+          FIELD_ENCRYPTION_KEY: ${{ secrets.CI_FERNET_KEY }}
           ANTHROPIC_API_KEY: sk-ant-test-key
 
       - name: OWASP ZAP Baseline Scan
@@ -159,7 +159,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: testpass
           REDIS_PASSWORD: testpass
-          FIELD_ENCRYPTION_KEY: "kA6H1LGRC3JUszuqLoXUyvxw_IX5bjJSDJ6B57rdexU="
+          FIELD_ENCRYPTION_KEY: ${{ secrets.CI_FERNET_KEY }}
           ANTHROPIC_API_KEY: sk-ant-test-key
 
       - name: Seed test data

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Generate ephemeral Fernet key for CI
+        # Fernet keys for CI test stacks don't need to be secret — they
+        # just need to be valid. Generating at runtime avoids both a
+        # hardcoded key in source and a required repo secret.
+        run: |
+          python3 -c "import os,base64; print('FIELD_ENCRYPTION_KEY=' + base64.urlsafe_b64encode(os.urandom(32)).decode())" >> "$GITHUB_ENV"
+
       - name: Start application stack
         run: |
           docker compose build backend
@@ -95,7 +102,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: testpass
           REDIS_PASSWORD: testpass
-          FIELD_ENCRYPTION_KEY: ${{ secrets.CI_FERNET_KEY }}
+          FIELD_ENCRYPTION_KEY: ${{ env.FIELD_ENCRYPTION_KEY }}
           ANTHROPIC_API_KEY: sk-ant-test-key
 
       - name: OWASP ZAP Baseline Scan
@@ -125,6 +132,10 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v6
+
+      - name: Generate ephemeral Fernet key for CI
+        run: |
+          python3 -c "import os,base64; print('FIELD_ENCRYPTION_KEY=' + base64.urlsafe_b64encode(os.urandom(32)).decode())" >> "$GITHUB_ENV"
 
       - name: Start application stack
         run: |
@@ -159,7 +170,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: testpass
           REDIS_PASSWORD: testpass
-          FIELD_ENCRYPTION_KEY: ${{ secrets.CI_FERNET_KEY }}
+          FIELD_ENCRYPTION_KEY: ${{ env.FIELD_ENCRYPTION_KEY }}
           ANTHROPIC_API_KEY: sk-ant-test-key
 
       - name: Seed test data

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,6 @@ jobs:
       POSTGRES_HOST: localhost
       POSTGRES_PORT: 5432
       CELERY_BROKER_URL: redis://localhost:6379/0
-      FIELD_ENCRYPTION_KEY: ${{ secrets.CI_FERNET_KEY }}
       ANTHROPIC_API_KEY: sk-ant-test-key
     steps:
       - uses: actions/checkout@v6
@@ -69,6 +68,14 @@ jobs:
       - name: Install dependencies
         working-directory: backend
         run: pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Generate ephemeral Fernet key for CI
+        # Fernet keys for CI test DBs don't need to be secret — they just
+        # need to be valid. Generating at runtime avoids both a hardcoded
+        # key in source (security hygiene) and a required repo secret.
+        # Uses stdlib so no pip install is required.
+        run: |
+          python -c "import os,base64; print('FIELD_ENCRYPTION_KEY=' + base64.urlsafe_b64encode(os.urandom(32)).decode())" >> "$GITHUB_ENV"
 
       - name: Run migrations
         working-directory: backend

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
       POSTGRES_HOST: localhost
       POSTGRES_PORT: 5432
       CELERY_BROKER_URL: redis://localhost:6379/0
-      FIELD_ENCRYPTION_KEY: "kA6H1LGRC3JUszuqLoXUyvxw_IX5bjJSDJ6B57rdexU="
+      FIELD_ENCRYPTION_KEY: ${{ secrets.CI_FERNET_KEY }}
       ANTHROPIC_API_KEY: sk-ant-test-key
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Removes the hardcoded Fernet key committed in `.github/workflows/{test,build}.yml` and replaces it with a per-run generated key.

**Rationale:** A Fernet key committed in plaintext in CI workflows is a static credential in the repo — even if the CI test DB is ephemeral, it's a bad security hygiene signal (found in senior code review, issue #59).

**Approach:** Each CI job generates a fresh 32-byte urlsafe-base64 key via Python stdlib (`os.urandom(32)` + `base64.urlsafe_b64encode`) and exports it via `\$GITHUB_ENV`. The key only lives in the runner's env for the duration of one run. No repo secret required, no hardcoded key in source, no new dependency.

## Changes

- `.github/workflows/test.yml` — remove `FIELD_ENCRYPTION_KEY` from job env, add "Generate ephemeral Fernet key for CI" step before migrations
- `.github/workflows/build.yml` — same pattern applied to `dast-scan` and `load-test` jobs

## Why not GitHub Secrets?

Originally considered. Rejected because:
1. A CI test DB's Fernet key doesn't need to be confidential — it just needs to be valid
2. Adds friction for forks (secret isn't inherited)
3. Runtime generation is simpler and equally secure

## Test plan

- [x] Test.yml generates key before migrations, Backend Tests pass in CI
- [x] Build.yml generates key before compose up in both dast-scan and load-test
- [x] Snippet validated locally: `python -c "import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())"` returns a 44-char Fernet-compatible key
- [x] Python is stdlib only, no pip install needed on runner

Closes #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)