### PR TITLE
chore(ml): remove 10/hour rate limit on train endpoint

### DIFF
--- a/backend/apps/ml_engine/views.py
+++ b/backend/apps/ml_engine/views.py
@@ -85,13 +85,8 @@ class ModelMetricsView(APIView):
         )
 
 
-class TrainModelThrottle(UserRateThrottle):
-    rate = "10/hour"
-
-
 class TrainModelView(APIView):
     permission_classes = [IsAdmin]
-    throttle_classes = [TrainModelThrottle]
 
     TRAIN_LOCK_KEY = "train_model_lock"
 


### PR DESCRIPTION
## Summary
- Drop DRF `UserRateThrottle` (`10/hour`) from `TrainModelView`.
- Demo/dev iteration repeatedly hit 429 with ~59-minute cooldowns.
- Training remains gated by `IsAdmin` + Redis `train_model_lock` (409 on duplicate) + Celery `time_limit=1800`.

## Test plan
- [x] `python manage.py check` passes after restart
- [x] `backend/apps/ml_engine/tests/test_ml_views.py` concurrency tests unaffected (no throttle references)
- [ ] Verify `POST /api/v1/ml/models/train/` returns 202 repeatedly in the UI without 429
- [ ] Verify duplicate training still returns 409 while a job is in flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)