### PR TITLE
chore(docs): populate GitHub About + tag missing releases + badge row

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 ![Python 3.13](https://img.shields.io/badge/Python-3.13-3776AB?logo=python&logoColor=white)
 ![Django 5](https://img.shields.io/badge/Django-5-092E20?logo=django&logoColor=white)
+[![CI](https://github.com/zeroyuekun/loan-approval-ai-system/actions/workflows/test.yml/badge.svg)](https://github.com/zeroyuekun/loan-approval-ai-system/actions/workflows/test.yml)
+[![Latest release](https://img.shields.io/github/v/release/zeroyuekun/loan-approval-ai-system)](https://github.com/zeroyuekun/loan-approval-ai-system/releases)
+![Last commit](https://img.shields.io/github/last-commit/zeroyuekun/loan-approval-ai-system)
 ![License](https://img.shields.io/badge/License-MIT-yellow)
 
 Full-stack loan approval system built for Australian lending. ML scores applicants (XGBoost), Claude writes the decision emails, and an agent pipeline checks everything for bias before it goes out. The compliance layer — APRA serviceability buffers, NCCP Act responsible lending, Banking Code disclosure requirements — is where most of the work went.


### PR DESCRIPTION
## Summary

- GitHub About populated with description + 10 topics (done via `gh repo edit`, no diff here)
- v1.10.3 and v1.10.4 tagged as GitHub releases (done via `gh release create`, no diff here)
- README badge row expanded from 3 → 6 badges: Python, Django, CI status, latest release, last commit, License

## Test plan
- [ ] `gh repo view` shows description + 10 topics
- [ ] `gh release list` shows v1.10.4 as latest
- [ ] README renders with 6 badges on GitHub preview
- [ ] All badge URLs return 200

Part of the portfolio README polish push — see `docs/superpowers/plans/2026-04-20-portfolio-readme-polish.md`.