### PR TITLE
docs(readme): lead with unique hooks + collapse heavy sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,15 @@
 ![Last commit](https://img.shields.io/github/last-commit/zeroyuekun/loan-approval-ai-system)
 ![License](https://img.shields.io/badge/License-MIT-yellow)
 
-Full-stack loan approval system built for Australian lending. ML scores applicants (XGBoost), Claude writes the decision emails, and an agent pipeline checks everything for bias before it goes out. The compliance layer — APRA serviceability buffers, NCCP Act responsible lending, Banking Code disclosure requirements — is where most of the work went.
+Full-stack loan approval system for Australian lending. XGBoost scores applicants, Claude writes the decision emails, and an agent pipeline checks everything for bias before it ships.
+
+**What makes it different:**
+
+- **3-layer bias detection** — regex pre-screen → Claude review → human escalation, scored 0–100 per generated email
+- **15 deterministic guardrails** on every Claude message (prohibited language, hallucinated dollar amounts, aggressive tone, regulatory-element presence, and more)
+- **$5/day Claude spend cap** with template-first generation — production cost control built in, not an afterthought
+
+The compliance layer — APRA serviceability buffers, NCCP Act responsible lending, Banking Code disclosure — is where most of the work went.
 
 <details>
 <summary><strong>Screenshots</strong> (click to expand)</summary>

--- a/README.md
+++ b/README.md
@@ -269,14 +269,14 @@ docker compose exec backend python manage.py prune_model_artifacts            # 
 
 </details>
 
-## Limitations and honest caveats
+## Scope & limits
 
-- **Trained on synthetic data.** The data generator is calibrated against ATO, ABS, APRA, and Equifax published statistics and runs the labels through a 1000-line rules-based underwriting engine plus a separate loan-performance simulator, so the learning task is non-trivial. It does not capture real-world feedback loops, fraud patterns, broker channel effects, or lender-specific heuristics. A production rollout would retrain on real historical data before trusting the outputs.
-- **Reported AUC is on the synthetic pipeline.** XGBoost achieves 0.88 AUC on the synthetic holdout of the active `ModelVersion` (see `backend/docs/MODEL_CARD.md`). The TSTR validator estimates a real-world AUC around 0.82 with moderate confidence. The project also reports a walk-forward temporal CV AUC in `training_metadata.temporal_cv_auc_mean` so the drift gap against random CV is visible.
-- **XGBoost lift over a simple scorecard is measured, not assumed.** Every training run fits a logistic-regression baseline on `credit_score, annual_income, loan_amount, debt_to_income` and records `training_metadata.baseline_auc` plus `xgb_lift_over_baseline` so the main model's value-add is a specific number on the model card, not marketing copy.
-- **Email generation is template-first.** Claude is used for creative variations only, and there is a $5/day spend cap on the Anthropic API. The guardrail layer runs 15 deterministic checks on every LLM-generated message before it ships.
-- **Compliance framing is implemented, not audited.** APRA CPG 235, NCCP Act responsible lending, Banking Code disclosure, and the Australian regulatory language around adverse action are baked into the data model, email templates, and fairness gates. None of this has been independently reviewed by a compliance professional — it's a best-effort implementation for a portfolio project.
-- **Reliability is prototype-grade.** All eight core services ship with healthchecks, the watchdog auto-recovers stuck pipelines, and the monitoring stack exposes Prometheus metrics and Grafana dashboards. There is no paging, no multi-region failover, and no SLO enforcement. Good enough for a demo, not a fintech launch.
+- **Synthetic training data.** The data generator is calibrated against ATO, ABS, APRA, and Equifax published statistics, runs labels through a 1000-line rules-based underwriting engine, and adds a separate loan-performance simulator. It does not capture real-world feedback loops, fraud patterns, broker channel effects, or lender-specific heuristics. A production rollout would retrain on real historical data.
+- **Reported AUC is on the synthetic pipeline.** XGBoost achieves 0.88 AUC on the synthetic holdout of the active `ModelVersion` (see `backend/docs/MODEL_CARD.md`). The TSTR validator estimates real-world AUC around 0.82 with moderate confidence. Walk-forward temporal CV AUC is reported in `training_metadata.temporal_cv_auc_mean` so the drift gap against random CV is visible.
+- **XGBoost lift over a simple scorecard is a measured number.** Every training run fits a logistic-regression baseline on `credit_score, annual_income, loan_amount, debt_to_income` and records `training_metadata.baseline_auc` + `xgb_lift_over_baseline` on the model card.
+- **Email generation is template-first.** Claude is used for creative variations only, with a $5/day spend cap on the Anthropic API. The guardrail layer runs 15 deterministic checks on every LLM-generated message before it ships.
+- **Compliance framing is implemented, not audited.** APRA CPG 235, NCCP Act responsible lending, Banking Code disclosure, and adverse-action language are baked into the data model, email templates, and fairness gates. None of this has been independently reviewed by a compliance professional.
+- **Reliability is prototype-grade.** Eight core services ship with healthchecks, the watchdog auto-recovers stuck pipelines, and the monitoring stack exposes Prometheus metrics + Grafana dashboards. No paging, no multi-region failover, no SLO enforcement. Good enough for a demo, not a fintech launch.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ Then:
 
 Something broken? See [runbooks](docs/runbooks/).
 
-## Project layout
+<details>
+<summary><strong>Project layout</strong> (click to expand)</summary>
 
 ```
 backend/
@@ -120,6 +121,8 @@ tools/              # standalone training + evaluation scripts
 workflows/          # markdown SOPs for each pipeline stage
 ```
 
+</details>
+
 ## Design decisions
 
 | Decision | ADR |
@@ -133,7 +136,8 @@ workflows/          # markdown SOPs for each pipeline stage
 | WAT architecture (workflows, agents, tools) | [007](backend/docs/adr/007-wat-architecture.md) |
 | Security architecture | [008](backend/docs/adr/008-security-architecture.md) |
 
-## ML model
+<details>
+<summary><strong>ML model details</strong> (click to expand)</summary>
 
 XGBoost trained on synthetic Australian lending data. 71 raw applicant input fields (48 numeric + categoricals) with 31 engineered interactions, Optuna Bayesian hyperparameter optimisation, isotonic probability calibration, 21 monotonic constraints (higher income -> lower risk, etc.).
 
@@ -158,14 +162,17 @@ Every email Claude generates goes through 10 checks before sending:
 
 Three regeneration attempts, then human review.
 
-## Retraining the model
+### Retraining the model
 
 ```bash
 docker compose exec backend python manage.py generate_data --num-records 10000 --output .tmp/synthetic_loans.csv
 docker compose exec backend python manage.py train_model --algorithm xgb --data-path .tmp/synthetic_loans.csv
 ```
 
-## API
+</details>
+
+<details>
+<summary><strong>API reference</strong> (click to expand)</summary>
 
 Auth: `POST /api/v1/auth/{register,login,refresh,logout}/`, `GET /api/v1/auth/me/`
 
@@ -177,11 +184,14 @@ Emails: `POST /api/v1/emails/generate/{id}/`, `GET /api/v1/emails/{id}/`
 
 Agents: `POST /api/v1/agents/orchestrate/{id}/`, `GET /api/v1/agents/runs/{id}/`, `POST /api/v1/agents/review/{id}/`
 
+</details>
+
 ## Security
 
 JWT with HttpOnly cookies, 60-min access / 7-day refresh with rotation and blacklisting. Argon2 password hashing. Fernet field-level encryption for PII. Rate limiting (20/min anon, 60/min auth). CORS locked to frontend origin. Three roles with per-endpoint permission checks. Prompt injection defences on user text entering LLM prompts.
 
-## Monitoring and observability
+<details>
+<summary><strong>Monitoring and observability</strong> (click to expand)</summary>
 
 A full monitoring stack ships behind the `monitoring` profile — Prometheus, Grafana, Loki, Promtail, Alertmanager, a Celery exporter, and a Postgres exporter. Django exposes `/metrics` via `django-prometheus` with request latencies, ORM query counts, Celery task counters, and a custom training-duration histogram. Nothing runs by default, so the core stack stays small; you opt in when you want dashboards.
 
@@ -201,11 +211,14 @@ Then:
 
 A separate `watchdog` service runs in the core stack at all times. It polls every 30 seconds for loan applications stuck in the `pending` state for more than 5 minutes and re-queues their orchestration task — so transient worker or broker failures self-recover rather than leaving zombie applications in the queue.
 
+</details>
+
 ## Testing
 
 ~1000 tests across 66 files. 60% backend coverage floor enforced in CI. CI pipeline runs Ruff, Bandit SAST, gitleaks, npm audit, OWASP ZAP DAST, k6 load test, and Trivy container scanning.
 
-## Verifying the build
+<details>
+<summary><strong>Verifying the build</strong> (click to expand)</summary>
 
 An end-to-end smoke script exercises the full pipeline (register → apply → orchestrate → decision → email) against a locally-running stack:
 
@@ -232,7 +245,10 @@ Result is written to `.tmp/smoke_result.json`:
 
 The same script runs as a manually-triggered GitHub Actions job under `smoke-e2e` (see `.github/workflows/smoke-e2e.yml`). The workflow is `workflow_dispatch`-only by design — cost-conscious default; add a cron once the signal is known stable.
 
-## Housekeeping
+</details>
+
+<details>
+<summary><strong>Housekeeping</strong> (click to expand)</summary>
 
 Local development accumulates build artifacts, test caches, and trained model files. To reclaim disk:
 
@@ -250,6 +266,8 @@ To prune stale trained-model `.joblib` artifacts from `backend/ml_models/` (afte
 docker compose exec backend python manage.py prune_model_artifacts --dry-run  # preview
 docker compose exec backend python manage.py prune_model_artifacts            # delete
 ```
+
+</details>
 
 ## Limitations and honest caveats
 


### PR DESCRIPTION
## Summary

- Hero restructured: opens with what the system is, then **3 unique hooks** (bias pipeline, 15 guardrails, \$5/day budget cap) before the mermaid diagram
- Collapsed 6 sections behind `<details>` (Project layout, ML model details, API reference, Monitoring, Verifying the build, Housekeeping) — always-visible content is now Hero, Stack, Run locally, Design decisions, Email guardrails, Security, Testing, Scope & limits, License
- Renamed "Limitations and honest caveats" → "Scope & limits" with factual tone (no apology framing)

## Test plan
- [ ] README renders cleanly on GitHub preview
- [ ] First 3 screens above the fold show: title → badges → hero → 3 hooks → pipeline diagram
- [ ] All 7 \`<details>\` blocks open/close (Screenshots + 6 new)
- [ ] No "apology", "sorry", "unfortunately", "caveat", or "best-effort" phrases in README
- [ ] Mermaid diagram still renders

Part of the portfolio README polish push — see \`docs/superpowers/plans/2026-04-20-portfolio-readme-polish.md\`.