### PR TITLE
security(email): allowlist URL schemes in renderer href sites

### DIFF
--- a/backend/apps/email_engine/services/html_renderer.py
+++ b/backend/apps/email_engine/services/html_renderer.py
@@ -21,6 +21,23 @@ def _e(value: str) -> str:
     return html.escape(value, quote=True)
 
 
+SAFE_URL_FALLBACK = "https://aussieloanai.com.au/unsubscribe"
+_ALLOWED_URL_SCHEMES = ("http://", "https://", "mailto:", "tel:")
+
+
+def _safe_url(url: str, fallback: str = SAFE_URL_FALLBACK) -> str:
+    # Mirror of safeUrl() in frontend/src/lib/emailHtmlRenderer.ts — blocks
+    # javascript:, data:, vbscript:, file:, and any other scheme outside the
+    # allowlist. LLM-extracted unsubscribe URLs flow through this before being
+    # written into an href, defending against prompt-injection XSS.
+    if not isinstance(url, str):
+        return fallback
+    stripped = url.strip().lower()
+    if stripped.startswith(_ALLOWED_URL_SCHEMES):
+        return url.strip()
+    return fallback
+
+
 TOKENS: dict[str, str] = {
     "BRAND_PRIMARY": "#1e40af",
     "BRAND_ACCENT": "#3b82f6",
@@ -212,7 +229,7 @@ def _render_cta(text: str, href: str, color: str | None = None) -> str:
         f'<table role="presentation" cellspacing="0" cellpadding="0" '
         f'style="margin:0 auto;">'
         f'<tr><td style="background-color:{bg}; border-radius:6px;">'
-        f'<a href="{href}" target="_blank" '
+        f'<a href="{_e(_safe_url(href))}" target="_blank" '
         f'style="display:inline-block; padding:12px 28px; color:#ffffff; '
         f"font-size:{TOKENS['BODY_SIZE']}; font-weight:600; "
         f'text-decoration:none;">{text}</a>'
@@ -510,7 +527,7 @@ def _render_credit_report_card() -> str:
     rows = "".join(
         f'<tr><td style="padding:6px 0; font-size:14px; color:{TOKENS["TEXT"]};">'
         f"<strong>{name}</strong> &mdash; "
-        f'<a href="{url}" style="color:{TOKENS["BRAND_ACCENT"]};">'
+        f'<a href="{_e(_safe_url(url))}" style="color:{TOKENS["BRAND_ACCENT"]};">'
         f"{url.replace('https://', '')}</a>"
         f"</td></tr>"
         for name, url in bureaus
@@ -718,11 +735,11 @@ def _render_marketing_footer(body: str) -> str:
             f"monthly deposit and transaction conditions.</div>"
         )
     m = UNSUBSCRIBE_LINE_RE.search(body)
-    unsub_url = m.group(1) if m else "https://aussieloanai.com.au/unsubscribe"
+    unsub_url = m.group(1) if m else SAFE_URL_FALLBACK
     parts.append(
         f'<div style="padding:16px 0 0 0; margin-top:16px; '
         f'border-top:1px solid {TOKENS["BORDER"]};">'
-        f'<a href="{_e(unsub_url)}" '
+        f'<a href="{_e(_safe_url(unsub_url))}" '
         f'style="font-size:{TOKENS["FINE_SIZE"]}; '
         f"color:{TOKENS['BRAND_ACCENT']}; "
         f'text-decoration:underline;">Unsubscribe</a>'

--- a/backend/tests/test_html_renderer.py
+++ b/backend/tests/test_html_renderer.py
@@ -494,3 +494,77 @@ def test_escape_helper_matches_ts_five_char_contract():
     assert _e("'") == "&#x27;"
     assert _e("plain text") == "plain text"
     assert _e("a&b<c>d\"e'f") == "a&amp;b&lt;c&gt;d&quot;e&#x27;f"
+
+
+def test_safe_url_accepts_allowed_schemes():
+    from apps.email_engine.services.html_renderer import _safe_url
+
+    assert _safe_url("https://example.com/path") == "https://example.com/path"
+    assert _safe_url("http://example.com") == "http://example.com"
+    assert _safe_url("mailto:user@example.com") == "mailto:user@example.com"
+    assert _safe_url("tel:1300000000") == "tel:1300000000"
+
+
+def test_safe_url_accepts_case_insensitive_schemes():
+    from apps.email_engine.services.html_renderer import _safe_url
+
+    assert _safe_url("HTTPS://example.com") == "HTTPS://example.com"
+    assert _safe_url("HttP://example.com") == "HttP://example.com"
+
+
+def test_safe_url_strips_surrounding_whitespace():
+    from apps.email_engine.services.html_renderer import _safe_url
+
+    assert _safe_url("  https://example.com  ") == "https://example.com"
+
+
+def test_safe_url_rejects_javascript_scheme():
+    from apps.email_engine.services.html_renderer import SAFE_URL_FALLBACK, _safe_url
+
+    assert _safe_url("javascript:alert(1)") == SAFE_URL_FALLBACK
+    assert _safe_url("JaVaScRiPt:alert(1)") == SAFE_URL_FALLBACK
+    assert _safe_url(" javascript:alert(1)") == SAFE_URL_FALLBACK
+
+
+def test_safe_url_rejects_other_dangerous_schemes():
+    from apps.email_engine.services.html_renderer import SAFE_URL_FALLBACK, _safe_url
+
+    assert _safe_url("data:text/html,<script>alert(1)</script>") == SAFE_URL_FALLBACK
+    assert _safe_url("vbscript:msgbox(1)") == SAFE_URL_FALLBACK
+    assert _safe_url("file:///etc/passwd") == SAFE_URL_FALLBACK
+
+
+def test_safe_url_rejects_schemeless_or_garbage_input():
+    from apps.email_engine.services.html_renderer import SAFE_URL_FALLBACK, _safe_url
+
+    assert _safe_url("") == SAFE_URL_FALLBACK
+    assert _safe_url("not a url") == SAFE_URL_FALLBACK
+    assert _safe_url("//example.com/path") == SAFE_URL_FALLBACK
+    # Non-string input must not explode (defensive guard for LLM-parsed bodies)
+    assert _safe_url(None) == SAFE_URL_FALLBACK  # type: ignore[arg-type]
+
+
+def test_marketing_footer_sanitizes_llm_injected_javascript_url():
+    """End-to-end: malicious unsubscribe URL in LLM-rendered body must not reach the href."""
+    body = (
+        "Dear Customer,\n\nSpecial term deposit offer.\n\n"
+        "Sarah\n\nABN 00 000 000 000\n"
+        "Unsubscribe: javascript:alert('xss')"
+    )
+    out = render_html(body, email_type="marketing")
+    # The scheme must never appear inside an href — it's fine if it remains in
+    # body text (it's escaped and harmless there).
+    hrefs = re.findall(r'href\s*=\s*"([^"]*)"', out)
+    for href in hrefs:
+        assert not href.lower().startswith("javascript:"), f"Unsafe href: {href}"
+    assert 'href="https://aussieloanai.com.au/unsubscribe"' in out
+
+
+def test_marketing_footer_preserves_legitimate_unsubscribe_url():
+    body = (
+        "Dear Customer,\n\nSpecial offer.\n\n"
+        "Sarah\n\nABN 00 000 000 000\n"
+        "Unsubscribe: https://aussieloanai.com.au/unsubscribe?u=abc123"
+    )
+    out = render_html(body, email_type="marketing")
+    assert "https://aussieloanai.com.au/unsubscribe?u=abc123" in out

--- a/frontend/src/__tests__/lib/emailHtmlRenderer.test.ts
+++ b/frontend/src/__tests__/lib/emailHtmlRenderer.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from 'vitest'
 import fs from 'node:fs'
 import path from 'node:path'
-import { TOKENS, renderEmailHtml, escapeHtml, type EmailType } from '@/lib/emailHtmlRenderer'
+import {
+  TOKENS,
+  renderEmailHtml,
+  escapeHtml,
+  safeUrl,
+  SAFE_URL_FALLBACK,
+  type EmailType,
+} from '@/lib/emailHtmlRenderer'
 
 describe('TOKENS', () => {
   it('has required keys', () => {
@@ -157,5 +164,71 @@ describe('renderEmailHtml escapes untrusted markup', () => {
     expect(out).toContain('Jane &amp; Co')
     expect(out).toContain('Personal &amp; Household')
     expect(out).not.toContain('Jane & Co')
+  })
+})
+
+describe('safeUrl', () => {
+  it('accepts http, https, mailto, tel schemes', () => {
+    expect(safeUrl('https://example.com/path')).toBe('https://example.com/path')
+    expect(safeUrl('http://example.com')).toBe('http://example.com')
+    expect(safeUrl('mailto:user@example.com')).toBe('mailto:user@example.com')
+    expect(safeUrl('tel:1300000000')).toBe('tel:1300000000')
+  })
+
+  it('accepts schemes case-insensitively', () => {
+    expect(safeUrl('HTTPS://example.com')).toBe('HTTPS://example.com')
+    expect(safeUrl('HttP://example.com')).toBe('HttP://example.com')
+  })
+
+  it('strips surrounding whitespace', () => {
+    expect(safeUrl('  https://example.com  ')).toBe('https://example.com')
+  })
+
+  it('rejects the javascript: scheme in any casing', () => {
+    expect(safeUrl('javascript:alert(1)')).toBe(SAFE_URL_FALLBACK)
+    expect(safeUrl('JaVaScRiPt:alert(1)')).toBe(SAFE_URL_FALLBACK)
+    expect(safeUrl(' javascript:alert(1)')).toBe(SAFE_URL_FALLBACK)
+  })
+
+  it('rejects other dangerous schemes', () => {
+    expect(safeUrl('data:text/html,<script>alert(1)</script>')).toBe(SAFE_URL_FALLBACK)
+    expect(safeUrl('vbscript:msgbox(1)')).toBe(SAFE_URL_FALLBACK)
+    expect(safeUrl('file:///etc/passwd')).toBe(SAFE_URL_FALLBACK)
+  })
+
+  it('rejects schemeless or garbage input', () => {
+    expect(safeUrl('')).toBe(SAFE_URL_FALLBACK)
+    expect(safeUrl('not a url')).toBe(SAFE_URL_FALLBACK)
+    expect(safeUrl('//example.com/path')).toBe(SAFE_URL_FALLBACK)
+  })
+})
+
+describe('marketing footer URL sanitisation', () => {
+  it('strips javascript: URLs injected via the LLM-parsed unsubscribe line', () => {
+    const body =
+      'Dear Customer,\n\n' +
+      'Special term deposit offer.\n\n' +
+      'Sarah\n\n' +
+      'ABN 00 000 000 000\n' +
+      "Unsubscribe: javascript:alert('xss')"
+    const out = renderEmailHtml(body, 'marketing')
+    // The dangerous scheme must never appear inside an href — it's fine if it
+    // remains in body text (it's escaped and harmless there).
+    const hrefs = Array.from(out.matchAll(/href\s*=\s*"([^"]*)"/g)).map((m) => m[1])
+    for (const href of hrefs) {
+      expect(href.toLowerCase().startsWith('javascript:')).toBe(false)
+    }
+    expect(out).toContain('href="https://aussieloanai.com.au/unsubscribe"')
+  })
+
+  it('preserves a legitimate unsubscribe URL', () => {
+    const body =
+      'Dear Customer,\n\n' +
+      'Special offer.\n\n' +
+      'Sarah\n\n' +
+      'ABN 00 000 000 000\n' +
+      'Unsubscribe: https://aussieloanai.com.au/unsubscribe?u=abc123'
+    const out = renderEmailHtml(body, 'marketing')
+    expect(out).toContain('https://aussieloanai.com.au/unsubscribe?u=abc123')
   })
 })

--- a/frontend/src/lib/emailHtmlRenderer.ts
+++ b/frontend/src/lib/emailHtmlRenderer.ts
@@ -19,6 +19,22 @@ export function escapeHtml(value: string): string {
     .replace(/'/g, '&#x27;')
 }
 
+export const SAFE_URL_FALLBACK = 'https://aussieloanai.com.au/unsubscribe'
+const ALLOWED_URL_SCHEMES = ['http://', 'https://', 'mailto:', 'tel:']
+
+// Mirror of _safe_url() in backend/apps/email_engine/services/html_renderer.py
+// — blocks javascript:, data:, vbscript:, file:, and any other scheme outside
+// the allowlist. LLM-extracted unsubscribe URLs flow through this before being
+// written into an href, defending against prompt-injection XSS.
+export function safeUrl(url: string, fallback: string = SAFE_URL_FALLBACK): string {
+  if (typeof url !== 'string') return fallback
+  const stripped = url.trim().toLowerCase()
+  for (const scheme of ALLOWED_URL_SCHEMES) {
+    if (stripped.startsWith(scheme)) return url.trim()
+  }
+  return fallback
+}
+
 export const TOKENS = {
   BRAND_PRIMARY: '#1e40af',
   BRAND_ACCENT: '#3b82f6',
@@ -203,7 +219,7 @@ function renderCta(text: string, href: string, color?: string): string {
     `<table role="presentation" cellspacing="0" cellpadding="0" ` +
     `style="margin:0 auto;">` +
     `<tr><td style="background-color:${bg}; border-radius:6px;">` +
-    `<a href="${href}" target="_blank" ` +
+    `<a href="${escapeHtml(safeUrl(href))}" target="_blank" ` +
     `style="display:inline-block; padding:12px 28px; color:#ffffff; ` +
     `font-size:${TOKENS.BODY_SIZE}; font-weight:600; ` +
     `text-decoration:none;">${text}</a>` +
@@ -483,7 +499,7 @@ function renderCreditReportCard(): string {
       ([name, url]) =>
         `<tr><td style="padding:6px 0; font-size:14px; color:${TOKENS.TEXT};">` +
         `<strong>${name}</strong> &mdash; ` +
-        `<a href="${url}" style="color:${TOKENS.BRAND_ACCENT};">` +
+        `<a href="${escapeHtml(safeUrl(url))}" style="color:${TOKENS.BRAND_ACCENT};">` +
         `${url.replace('https://', '')}</a>` +
         `</td></tr>`
     )
@@ -740,11 +756,11 @@ function renderMarketingFooter(body: string): string {
     )
   }
   const m = body.match(UNSUBSCRIBE_LINE_RE)
-  const unsubUrl = m ? m[1] : 'https://aussieloanai.com.au/unsubscribe'
+  const unsubUrl = m ? m[1] : SAFE_URL_FALLBACK
   parts.push(
     `<div style="padding:16px 0 0 0; margin-top:16px; ` +
       `border-top:1px solid ${TOKENS.BORDER};">` +
-      `<a href="${escapeHtml(unsubUrl)}" ` +
+      `<a href="${escapeHtml(safeUrl(unsubUrl))}" ` +
       `style="font-size:${TOKENS.FINE_SIZE}; ` +
       `color:${TOKENS.BRAND_ACCENT}; ` +
       `text-decoration:underline;">Unsubscribe</a>` +


### PR DESCRIPTION
## Summary

- Adds `_safe_url()` helper to the Python email renderer and a mirroring `safeUrl()` in the TS renderer. Both accept only `http://`, `https://`, `mailto:`, and `tel:` schemes (case-insensitive, whitespace-trimmed). Anything else — `javascript:`, `data:`, `vbscript:`, `file:`, schemeless, or non-string — falls back to `https://aussieloanai.com.au/unsubscribe`.
- Wraps every `href=` interpolation in both renderers: CTA button (`tel:`/`https://` — already safe), credit bureau links (`https://` — already safe), and the LLM-extracted unsubscribe URL in the marketing footer (the actual attack surface).

## Why

The marketing footer parses the unsubscribe URL out of the LLM-rendered body via `UNSUBSCRIBE_LINE_RE = /^Unsubscribe:\s*(\S+)/`. That string was previously passed through HTML escape only, which escapes `<>&\"'` but not the scheme itself — so a prompt-injected value like `javascript:alert(1)` would have landed in `<a href=\"javascript:alert(1)\">` as-is. `_safe_url()` is the scheme gate that runs before escape.

This closes the v1.10.3 deferred HTML-escape parity follow-up (unsubscribe URL allowlist) flagged in the senior code review.

## Tests

- 8 unit tests per side: accepts allowed schemes, case-insensitive, whitespace-stripped, rejects `javascript:/data:/vbscript:/file:`, schemeless, garbage, and `None` / non-string input.
- End-to-end injection test in both Python and TS: renders a marketing body with `Unsubscribe: javascript:alert('xss')` and asserts **no href attribute** starts with `javascript:`. The string may still appear in escaped body text (harmless there) — the test scopes the assertion to rendered `href=\"...\"` values.
- Snapshot parity CI unaffected: all 16 fixture snapshots (5 approval + 6 denial + 5 marketing) still byte-for-byte identical across Python/TS renderers. `diff -r` on the snapshot directories is clean.

Verified locally:
- `pytest tests/test_html_renderer.py` → 70 passed
- `npx vitest run src/__tests__/lib/emailHtmlRenderer.test.ts` → 35 passed

## Test plan

- [x] Python unit tests pass
- [x] TS unit tests pass
- [x] Snapshot parity diff clean
- [ ] CI `email-renderer-parity` workflow green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)