### PR TITLE
fix(ml): MRM dossier honesty — overlay-mode wording, compliance status, drift URL

### DIFF
--- a/backend/apps/ml_engine/services/mrm_compliance.py
+++ b/backend/apps/ml_engine/services/mrm_compliance.py
@@ -1,0 +1,90 @@
+"""Compliance-status derivation for the MRM dossier.
+
+Pure-functional. Given a ModelVersion-like object with already-recorded gate
+evidence (fairness metrics, PSI by feature, ECE, decile calibration), returns
+a `(status, reasons)` tuple that `mrm_dossier._header_section` renders as the
+§1 Header banner.
+
+Lives in its own module so `mrm_dossier.py` stays under the ml_engine quality
+bar's 500-LOC global cap. The split is mechanical — no behavioural change.
+
+See `docs/superpowers/specs/2026-04-18-arm-c-ml-engine-quality-bar-design.md`
+for the file-size discipline this module respects.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Compliance thresholds — surface in the header banner when breached so an
+# auditor reading the first page sees gate failures, not a silent "Active:
+# True" line. Values match _psi_section's "significant drift" boundary and
+# the standard ECE acceptance ceiling for AU retail-credit scorecards.
+# ---------------------------------------------------------------------------
+
+PSI_FAIL_THRESHOLD = 0.25
+ECE_FAIL_THRESHOLD = 0.05
+
+
+def _compliance_status(mv) -> tuple[str, list[str]]:
+    """Derive the dossier compliance banner from gate evidence already
+    recorded on the ModelVersion. Returns (status, reasons).
+
+    Status decision (first match wins):
+      1. Any fairness gate `passes_80_percent_rule == False` → NON-COMPLIANT
+      2. Any feature PSI ≥ PSI_FAIL_THRESHOLD                → NON-COMPLIANT
+      3. ECE > ECE_FAIL_THRESHOLD                            → NON-COMPLIANT
+      4. Fairness / PSI / calibration evidence missing       → NEEDS REVIEW
+      5. Otherwise                                           → COMPLIANT
+
+    The reasons list is empty for COMPLIANT; for the other two it carries one
+    bullet per failure or missing-evidence reason so §1 Header can render the
+    sub-list. Pure function — no DB, no Django boot required.
+    """
+    reasons: list[str] = []
+
+    fairness = mv.fairness_metrics or {}
+    psi_map = (mv.training_metadata or {}).get("psi_by_feature") or {}
+    calibration = mv.calibration_data or {}
+    deciles = calibration.get("deciles") or calibration.get("decile_analysis") or []
+
+    failed_attrs: list[str] = []
+    for attr, data in fairness.items():
+        if isinstance(data, dict) and data.get("passes_80_percent_rule") is False:
+            failed_attrs.append(attr)
+    if failed_attrs:
+        reasons.append(f"Fairness 80%-rule fails on: {', '.join(sorted(failed_attrs))}")
+
+    breached_psi: list[tuple[str, float]] = []
+    for feat, value in psi_map.items():
+        try:
+            v = float(value)
+        except (TypeError, ValueError):
+            continue
+        if v >= PSI_FAIL_THRESHOLD:
+            breached_psi.append((feat, v))
+    if breached_psi:
+        breached_psi.sort(key=lambda kv: -kv[1])
+        details = ", ".join(f"{f} (PSI={v:.2f})" for f, v in breached_psi)
+        reasons.append(f"PSI ≥ {PSI_FAIL_THRESHOLD} on: {details}")
+
+    ece = mv.ece
+    if isinstance(ece, (int, float)) and ece > ECE_FAIL_THRESHOLD:
+        reasons.append(f"ECE {ece:.4f} exceeds ceiling of {ECE_FAIL_THRESHOLD}")
+
+    if reasons:
+        return ("NON-COMPLIANT", reasons)
+
+    missing: list[str] = []
+    if not fairness:
+        missing.append("fairness metrics")
+    if not psi_map:
+        missing.append("PSI by feature")
+    if not deciles:
+        missing.append("decile calibration")
+    if missing:
+        return (
+            "NEEDS REVIEW",
+            [f"Missing evidence: {', '.join(missing)}"],
+        )
+
+    return ("COMPLIANT", [])

--- a/backend/apps/ml_engine/services/mrm_dossier.py
+++ b/backend/apps/ml_engine/services/mrm_dossier.py
@@ -161,8 +161,48 @@ def _header_section(mv) -> str:
     return "\n".join(lines)
 
 
+_OUT_OF_SCOPE_BY_OVERLAY_MODE = {
+    "off": (
+        "No policy overlay is active in this deployment. Out-of-scope predictions "
+        "are not flagged or blocked at runtime — manual scope review is required at "
+        "intake (see §9)."
+    ),
+    "shadow": (
+        "The policy overlay runs in `shadow` (observational) mode in this deployment. "
+        "Out-of-scope predictions are flagged for monitoring but **not blocked**; "
+        "manual underwriter review depends on operator workflow rather than automated "
+        "routing (see §9)."
+    ),
+    "enforce": (
+        "The policy overlay runs in `enforce` mode in this deployment. Out-of-scope "
+        "predictions are blocked by the overlay and routed to manual underwriter "
+        "review (see §9 P-codes)."
+    ),
+}
+
+
 def _purpose_section(mv) -> str:
-    """§2 — Purpose & limitations."""
+    """§2 — Purpose & limitations.
+
+    The closing paragraph used to assert that out-of-scope predictions "must be
+    treated as advisory only and referred to human underwriter review" — but
+    that referral is only enforced by the policy overlay in `enforce` mode
+    (`credit_policy.py:418-425`). The default deployment mode is `shadow`,
+    which is observational. Read the effective mode at generation time and
+    emit the wording that matches actual runtime behaviour.
+    """
+    # Deferred import keeps the module importable in unit tests that fake the
+    # ModelVersion without booting Django (existing test pattern).
+    try:
+        from django.conf import settings
+
+        mode = getattr(settings, "CREDIT_POLICY_OVERLAY_MODE", "shadow")
+    except Exception:
+        mode = "shadow"
+    if mode not in _OUT_OF_SCOPE_BY_OVERLAY_MODE:
+        # Mirrors credit_policy.py:405 — unknown values default to shadow.
+        mode = "shadow"
+
     purpose = _SEGMENT_PURPOSE.get(mv.segment, "Segment-specific purpose statement not yet registered.")
     return "\n".join(
         [
@@ -170,9 +210,7 @@ def _purpose_section(mv) -> str:
             "",
             purpose,
             "",
-            "All scope boundaries above reflect the training distribution. "
-            "Predictions on applications outside scope must be treated as advisory "
-            "only and referred to human underwriter review (see §9 policy overlay).",
+            "All scope boundaries above reflect the training distribution. " + _OUT_OF_SCOPE_BY_OVERLAY_MODE[mode],
         ]
     )
 

--- a/backend/apps/ml_engine/services/mrm_dossier.py
+++ b/backend/apps/ml_engine/services/mrm_dossier.py
@@ -28,6 +28,17 @@ from collections.abc import Iterable
 from datetime import UTC, datetime
 
 # ---------------------------------------------------------------------------
+# Compliance thresholds — surface in the header banner when breached so an
+# auditor reading the first page sees gate failures, not a silent "Active:
+# True" line. Values match _psi_section's "significant drift" boundary and
+# the standard ECE acceptance ceiling for AU retail-credit scorecards.
+# ---------------------------------------------------------------------------
+
+PSI_FAIL_THRESHOLD = 0.25
+ECE_FAIL_THRESHOLD = 0.05
+
+
+# ---------------------------------------------------------------------------
 # Purpose statements per segment. Kept adjacent so a change to the training
 # scope is one place, not scattered across templates.
 # ---------------------------------------------------------------------------
@@ -59,27 +70,95 @@ _SEGMENT_PURPOSE = {
 }
 
 
+def _compliance_status(mv) -> tuple[str, list[str]]:
+    """Derive the dossier compliance banner from gate evidence already
+    recorded on the ModelVersion. Returns (status, reasons).
+
+    Status decision (first match wins):
+      1. Any fairness gate `passes_80_percent_rule == False` → NON-COMPLIANT
+      2. Any feature PSI ≥ PSI_FAIL_THRESHOLD                → NON-COMPLIANT
+      3. ECE > ECE_FAIL_THRESHOLD                            → NON-COMPLIANT
+      4. Fairness / PSI / calibration evidence missing       → NEEDS REVIEW
+      5. Otherwise                                           → COMPLIANT
+
+    The reasons list is empty for COMPLIANT; for the other two it carries one
+    bullet per failure or missing-evidence reason so §1 Header can render the
+    sub-list. Pure function — no DB, no Django boot required.
+    """
+    reasons: list[str] = []
+
+    fairness = mv.fairness_metrics or {}
+    psi_map = (mv.training_metadata or {}).get("psi_by_feature") or {}
+    calibration = mv.calibration_data or {}
+    deciles = calibration.get("deciles") or calibration.get("decile_analysis") or []
+
+    failed_attrs: list[str] = []
+    for attr, data in fairness.items():
+        if isinstance(data, dict) and data.get("passes_80_percent_rule") is False:
+            failed_attrs.append(attr)
+    if failed_attrs:
+        reasons.append(f"Fairness 80%-rule fails on: {', '.join(sorted(failed_attrs))}")
+
+    breached_psi: list[tuple[str, float]] = []
+    for feat, value in psi_map.items():
+        try:
+            v = float(value)
+        except (TypeError, ValueError):
+            continue
+        if v >= PSI_FAIL_THRESHOLD:
+            breached_psi.append((feat, v))
+    if breached_psi:
+        breached_psi.sort(key=lambda kv: -kv[1])
+        details = ", ".join(f"{f} (PSI={v:.2f})" for f, v in breached_psi)
+        reasons.append(f"PSI ≥ {PSI_FAIL_THRESHOLD} on: {details}")
+
+    ece = mv.ece
+    if isinstance(ece, (int, float)) and ece > ECE_FAIL_THRESHOLD:
+        reasons.append(f"ECE {ece:.4f} exceeds ceiling of {ECE_FAIL_THRESHOLD}")
+
+    if reasons:
+        return ("NON-COMPLIANT", reasons)
+
+    missing: list[str] = []
+    if not fairness:
+        missing.append("fairness metrics")
+    if not psi_map:
+        missing.append("PSI by feature")
+    if not deciles:
+        missing.append("decile calibration")
+    if missing:
+        return (
+            "NEEDS REVIEW",
+            [f"Missing evidence: {', '.join(missing)}"],
+        )
+
+    return ("COMPLIANT", [])
+
+
 def _header_section(mv) -> str:
     """§1 — Header."""
     trained_at = getattr(mv, "created_at", None)
     algorithm_display = mv.get_algorithm_display() if hasattr(mv, "get_algorithm_display") else mv.algorithm
     training_meta = mv.training_metadata or {}
-    return "\n".join(
-        [
-            "## 1. Header",
-            "",
-            f"- **Model ID:** `{mv.id}`",
-            f"- **Algorithm:** {algorithm_display}",
-            f"- **Version:** {mv.version}",
-            f"- **Segment:** `{mv.segment}`",
-            f"- **Trained at:** {trained_at.isoformat() if trained_at else 'unknown'}",
-            f"- **Training duration:** {training_meta.get('training_seconds', 'unknown')}s",
-            f"- **Training samples:** {training_meta.get('n_training_samples', 'unknown')}",
-            f"- **Class balance (positive rate):** {training_meta.get('positive_rate', 'unknown')}",
-            f"- **Active:** {mv.is_active}",
-            f"- **File hash (SHA-256):** `{mv.file_hash or 'not recorded'}`",
-        ]
-    )
+    status, reasons = _compliance_status(mv)
+    lines = [
+        "## 1. Header",
+        "",
+        f"- **Model ID:** `{mv.id}`",
+        f"- **Algorithm:** {algorithm_display}",
+        f"- **Version:** {mv.version}",
+        f"- **Segment:** `{mv.segment}`",
+        f"- **Trained at:** {trained_at.isoformat() if trained_at else 'unknown'}",
+        f"- **Training duration:** {training_meta.get('training_seconds', 'unknown')}s",
+        f"- **Training samples:** {training_meta.get('n_training_samples', 'unknown')}",
+        f"- **Class balance (positive rate):** {training_meta.get('positive_rate', 'unknown')}",
+        f"- **Active:** {mv.is_active}",
+        f"- **Compliance status:** {status}",
+    ]
+    for reason in reasons:
+        lines.append(f"  - {reason}")
+    lines.append(f"- **File hash (SHA-256):** `{mv.file_hash or 'not recorded'}`")
+    return "\n".join(lines)
 
 
 def _purpose_section(mv) -> str:
@@ -351,7 +430,7 @@ def generate_dossier_markdown(mv) -> str:
     generated_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     sections: Iterable[str] = [
         f"# Model Risk Management Dossier — `{mv.id}`",
-        f"_Generated {generated_at} — APRA CPS 220 / SR 11-7 alignment_",
+        f"_Generated {generated_at} — Format: APRA CPS 220 / SR 11-7_",
         "",
         _header_section(mv),
         "",

--- a/backend/apps/ml_engine/services/mrm_dossier.py
+++ b/backend/apps/ml_engine/services/mrm_dossier.py
@@ -293,7 +293,10 @@ def _performance_section(mv) -> str:
             "",
             "KS > 0.30 and AUC > 0.75 are the regulator-expected performance floor "
             "for AU retail-credit scorecards. Champion-challenger promotion gates "
-            "(see model_selector.py) enforce these + PSI and calibration ceilings.",
+            "exist in `model_selector.py` (PSI, calibration, KS); the current "
+            "activation path in `tasks.py` activates new models directly, so "
+            "confirm pre-promotion review for production deployments before "
+            "relying on these gates.",
         ]
     )
 
@@ -412,7 +415,7 @@ def _monitoring_section(mv) -> str:
             "- **ECE re-validation cadence:** quarterly.",
             "- **KS regression trigger:** drop > 5pp vs champion baseline triggers retrain.",
             "- **Fairness audit cadence:** every training run pre-promotion (see fairness_gate.py).",
-            "- **Drift dashboard:** `/api/ml-engine/drift/` (weekly DriftReport cron).",
+            "- **Drift dashboard:** `/api/v1/ml/models/active/drift/` (weekly DriftReport cron).",
         ]
     )
 

--- a/backend/apps/ml_engine/services/mrm_dossier.py
+++ b/backend/apps/ml_engine/services/mrm_dossier.py
@@ -27,16 +27,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from datetime import UTC, datetime
 
-# ---------------------------------------------------------------------------
-# Compliance thresholds — surface in the header banner when breached so an
-# auditor reading the first page sees gate failures, not a silent "Active:
-# True" line. Values match _psi_section's "significant drift" boundary and
-# the standard ECE acceptance ceiling for AU retail-credit scorecards.
-# ---------------------------------------------------------------------------
-
-PSI_FAIL_THRESHOLD = 0.25
-ECE_FAIL_THRESHOLD = 0.05
-
+from apps.ml_engine.services.mrm_compliance import _compliance_status
 
 # ---------------------------------------------------------------------------
 # Purpose statements per segment. Kept adjacent so a change to the training
@@ -68,71 +59,6 @@ _SEGMENT_PURPOSE = {
         "business personal loans, loans to undischarged bankrupts."
     ),
 }
-
-
-def _compliance_status(mv) -> tuple[str, list[str]]:
-    """Derive the dossier compliance banner from gate evidence already
-    recorded on the ModelVersion. Returns (status, reasons).
-
-    Status decision (first match wins):
-      1. Any fairness gate `passes_80_percent_rule == False` → NON-COMPLIANT
-      2. Any feature PSI ≥ PSI_FAIL_THRESHOLD                → NON-COMPLIANT
-      3. ECE > ECE_FAIL_THRESHOLD                            → NON-COMPLIANT
-      4. Fairness / PSI / calibration evidence missing       → NEEDS REVIEW
-      5. Otherwise                                           → COMPLIANT
-
-    The reasons list is empty for COMPLIANT; for the other two it carries one
-    bullet per failure or missing-evidence reason so §1 Header can render the
-    sub-list. Pure function — no DB, no Django boot required.
-    """
-    reasons: list[str] = []
-
-    fairness = mv.fairness_metrics or {}
-    psi_map = (mv.training_metadata or {}).get("psi_by_feature") or {}
-    calibration = mv.calibration_data or {}
-    deciles = calibration.get("deciles") or calibration.get("decile_analysis") or []
-
-    failed_attrs: list[str] = []
-    for attr, data in fairness.items():
-        if isinstance(data, dict) and data.get("passes_80_percent_rule") is False:
-            failed_attrs.append(attr)
-    if failed_attrs:
-        reasons.append(f"Fairness 80%-rule fails on: {', '.join(sorted(failed_attrs))}")
-
-    breached_psi: list[tuple[str, float]] = []
-    for feat, value in psi_map.items():
-        try:
-            v = float(value)
-        except (TypeError, ValueError):
-            continue
-        if v >= PSI_FAIL_THRESHOLD:
-            breached_psi.append((feat, v))
-    if breached_psi:
-        breached_psi.sort(key=lambda kv: -kv[1])
-        details = ", ".join(f"{f} (PSI={v:.2f})" for f, v in breached_psi)
-        reasons.append(f"PSI ≥ {PSI_FAIL_THRESHOLD} on: {details}")
-
-    ece = mv.ece
-    if isinstance(ece, (int, float)) and ece > ECE_FAIL_THRESHOLD:
-        reasons.append(f"ECE {ece:.4f} exceeds ceiling of {ECE_FAIL_THRESHOLD}")
-
-    if reasons:
-        return ("NON-COMPLIANT", reasons)
-
-    missing: list[str] = []
-    if not fairness:
-        missing.append("fairness metrics")
-    if not psi_map:
-        missing.append("PSI by feature")
-    if not deciles:
-        missing.append("decile calibration")
-    if missing:
-        return (
-            "NEEDS REVIEW",
-            [f"Missing evidence: {', '.join(missing)}"],
-        )
-
-    return ("COMPLIANT", [])
 
 
 def _header_section(mv) -> str:

--- a/backend/apps/ml_engine/tests/test_mrm_dossier.py
+++ b/backend/apps/ml_engine/tests/test_mrm_dossier.py
@@ -223,6 +223,45 @@ def test_policy_section_enumerates_all_p_codes():
 
 
 # ---------------------------------------------------------------------------
+# Performance section: dossier should not assert champion-challenger gates
+# are *enforced* on activation (they are not — tasks.py:82-88 activates
+# directly). (Codex 2026-05-06 finding 3a.)
+# ---------------------------------------------------------------------------
+
+
+def test_performance_section_no_longer_claims_gates_are_enforced():
+    from apps.ml_engine.services.mrm_dossier import generate_dossier_markdown
+
+    with patch("apps.ml_engine.services.mrm_dossier._changelog_section") as _cl:
+        _cl.return_value = "## 11. Change log\n\n(stub)"
+        md = generate_dossier_markdown(_make_compliant_mv())
+
+    # Regression guard for the original overstated language.
+    assert "enforce these" not in md
+    # Honest replacement language must be present.
+    assert "gates exist" in md.lower() or "exist in `model_selector.py`" in md
+    assert "confirm pre-promotion review" in md
+
+
+# ---------------------------------------------------------------------------
+# Monitoring drift URL must point at a real route. (Codex 2026-05-06
+# finding 3b — the original /api/ml-engine/drift/ was a 404.)
+# ---------------------------------------------------------------------------
+
+
+def test_monitoring_drift_url_uses_actual_route():
+    from apps.ml_engine.services.mrm_dossier import generate_dossier_markdown
+
+    with patch("apps.ml_engine.services.mrm_dossier._changelog_section") as _cl:
+        _cl.return_value = "## 11. Change log\n\n(stub)"
+        md = generate_dossier_markdown(_make_compliant_mv())
+
+    assert "/api/v1/ml/models/active/drift/" in md
+    # Regression guard against the dead legacy URL.
+    assert "/api/ml-engine/drift/" not in md
+
+
+# ---------------------------------------------------------------------------
 # Out-of-scope wording is conditional on the runtime overlay mode.
 # (Codex 2026-05-06 finding 1 — the dossier used to claim mandatory referral
 # unconditionally, but the runtime only enforces it in `enforce` mode.)

--- a/backend/apps/ml_engine/tests/test_mrm_dossier.py
+++ b/backend/apps/ml_engine/tests/test_mrm_dossier.py
@@ -365,7 +365,7 @@ def _make_compliant_mv(**overrides):
 
 
 def test_compliance_status_compliant_when_all_gates_pass_and_evidence_present():
-    from apps.ml_engine.services.mrm_dossier import _compliance_status
+    from apps.ml_engine.services.mrm_compliance import _compliance_status
 
     status, reasons = _compliance_status(_make_compliant_mv())
     assert status == "COMPLIANT"
@@ -373,7 +373,7 @@ def test_compliance_status_compliant_when_all_gates_pass_and_evidence_present():
 
 
 def test_compliance_status_non_compliant_on_failed_fairness():
-    from apps.ml_engine.services.mrm_dossier import _compliance_status
+    from apps.ml_engine.services.mrm_compliance import _compliance_status
 
     mv = _make_compliant_mv(
         fairness_metrics={
@@ -388,7 +388,7 @@ def test_compliance_status_non_compliant_on_failed_fairness():
 
 
 def test_compliance_status_non_compliant_on_high_psi():
-    from apps.ml_engine.services.mrm_dossier import _compliance_status
+    from apps.ml_engine.services.mrm_compliance import _compliance_status
 
     mv = _make_compliant_mv(
         training_metadata={
@@ -401,7 +401,7 @@ def test_compliance_status_non_compliant_on_high_psi():
 
 
 def test_compliance_status_non_compliant_on_high_ece():
-    from apps.ml_engine.services.mrm_dossier import _compliance_status
+    from apps.ml_engine.services.mrm_compliance import _compliance_status
 
     mv = _make_compliant_mv(ece=0.08)
     status, reasons = _compliance_status(mv)
@@ -410,7 +410,7 @@ def test_compliance_status_non_compliant_on_high_ece():
 
 
 def test_compliance_status_needs_review_when_fairness_evidence_missing():
-    from apps.ml_engine.services.mrm_dossier import _compliance_status
+    from apps.ml_engine.services.mrm_compliance import _compliance_status
 
     mv = _make_compliant_mv(fairness_metrics={})
     status, reasons = _compliance_status(mv)
@@ -419,7 +419,7 @@ def test_compliance_status_needs_review_when_fairness_evidence_missing():
 
 
 def test_compliance_status_needs_review_when_psi_missing():
-    from apps.ml_engine.services.mrm_dossier import _compliance_status
+    from apps.ml_engine.services.mrm_compliance import _compliance_status
 
     mv = _make_compliant_mv(training_metadata={"psi_by_feature": {}})
     status, reasons = _compliance_status(mv)
@@ -428,7 +428,7 @@ def test_compliance_status_needs_review_when_psi_missing():
 
 
 def test_compliance_status_needs_review_when_calibration_missing():
-    from apps.ml_engine.services.mrm_dossier import _compliance_status
+    from apps.ml_engine.services.mrm_compliance import _compliance_status
 
     mv = _make_compliant_mv(calibration_data={})
     status, reasons = _compliance_status(mv)

--- a/backend/apps/ml_engine/tests/test_mrm_dossier.py
+++ b/backend/apps/ml_engine/tests/test_mrm_dossier.py
@@ -223,6 +223,77 @@ def test_policy_section_enumerates_all_p_codes():
 
 
 # ---------------------------------------------------------------------------
+# Out-of-scope wording is conditional on the runtime overlay mode.
+# (Codex 2026-05-06 finding 1 — the dossier used to claim mandatory referral
+# unconditionally, but the runtime only enforces it in `enforce` mode.)
+# ---------------------------------------------------------------------------
+
+
+def test_purpose_section_default_mode_emits_shadow_wording():
+    """Default settings (no env override) → shadow wording, **not blocked**."""
+    from apps.ml_engine.services.mrm_dossier import generate_dossier_markdown
+
+    with patch("apps.ml_engine.services.mrm_dossier._changelog_section") as _cl:
+        _cl.return_value = "## 11. Change log\n\n(stub)"
+        md = generate_dossier_markdown(_make_compliant_mv())
+
+    assert "shadow" in md.lower()
+    assert "not blocked" in md
+    # The old unconditional mandate must not appear in shadow mode.
+    assert "must be treated as advisory" not in md
+
+
+def test_purpose_section_enforce_mode_emits_mandatory_referral():
+    from django.test import override_settings
+
+    from apps.ml_engine.services.mrm_dossier import generate_dossier_markdown
+
+    with (
+        override_settings(CREDIT_POLICY_OVERLAY_MODE="enforce"),
+        patch("apps.ml_engine.services.mrm_dossier._changelog_section") as _cl,
+    ):
+        _cl.return_value = "## 11. Change log\n\n(stub)"
+        md = generate_dossier_markdown(_make_compliant_mv())
+
+    assert "`enforce` mode" in md
+    assert "blocked by the overlay" in md
+    assert "routed to manual underwriter review" in md
+
+
+def test_purpose_section_off_mode_emits_no_overlay_message():
+    from django.test import override_settings
+
+    from apps.ml_engine.services.mrm_dossier import generate_dossier_markdown
+
+    with (
+        override_settings(CREDIT_POLICY_OVERLAY_MODE="off"),
+        patch("apps.ml_engine.services.mrm_dossier._changelog_section") as _cl,
+    ):
+        _cl.return_value = "## 11. Change log\n\n(stub)"
+        md = generate_dossier_markdown(_make_compliant_mv())
+
+    assert "No policy overlay is active" in md
+    assert "manual scope review is required at intake" in md
+
+
+def test_purpose_section_unknown_mode_falls_through_to_shadow():
+    """Mirrors credit_policy.py:405 — unknown values default to shadow."""
+    from django.test import override_settings
+
+    from apps.ml_engine.services.mrm_dossier import generate_dossier_markdown
+
+    with (
+        override_settings(CREDIT_POLICY_OVERLAY_MODE="bogus_value"),
+        patch("apps.ml_engine.services.mrm_dossier._changelog_section") as _cl,
+    ):
+        _cl.return_value = "## 11. Change log\n\n(stub)"
+        md = generate_dossier_markdown(_make_compliant_mv())
+
+    assert "`shadow` (observational) mode" in md
+    assert "not blocked" in md
+
+
+# ---------------------------------------------------------------------------
 # Compliance status banner — derived from gate evidence so an auditor reads
 # the failure on the first page rather than digging through §8 / §7 / §6.
 # (Codex 2026-05-06 finding 2.)

--- a/backend/apps/ml_engine/tests/test_mrm_dossier.py
+++ b/backend/apps/ml_engine/tests/test_mrm_dossier.py
@@ -222,6 +222,155 @@ def test_policy_section_enumerates_all_p_codes():
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Compliance status banner — derived from gate evidence so an auditor reads
+# the failure on the first page rather than digging through §8 / §7 / §6.
+# (Codex 2026-05-06 finding 2.)
+# ---------------------------------------------------------------------------
+
+
+def _make_compliant_mv(**overrides):
+    """Default `_make_mv` is intentionally NON-COMPLIANT (failed age_group +
+    PSI on dti). For positive-path tests build a clean MV here. Overrides
+    take precedence over the clean defaults so callers can flip individual
+    fields without wrestling with duplicate-kwarg errors."""
+    defaults = {
+        "fairness_metrics": {
+            "gender": {"disparate_impact_ratio": 0.92, "passes_80_percent_rule": True},
+            "age_group": {"disparate_impact_ratio": 0.88, "passes_80_percent_rule": True},
+        },
+        "training_metadata": {
+            "training_seconds": 45,
+            "n_training_samples": 10000,
+            "positive_rate": 0.22,
+            "psi_by_feature": {"credit_score": 0.05, "annual_income": 0.12, "dti": 0.18},
+            "data_source": "synthetic + GMSC",
+            "temporal_start": "2024-01-01",
+            "temporal_end": "2026-04-01",
+        },
+        "ece": 0.02,
+    }
+    defaults.update(overrides)
+    return _make_mv(**defaults)
+
+
+def test_compliance_status_compliant_when_all_gates_pass_and_evidence_present():
+    from apps.ml_engine.services.mrm_dossier import _compliance_status
+
+    status, reasons = _compliance_status(_make_compliant_mv())
+    assert status == "COMPLIANT"
+    assert reasons == []
+
+
+def test_compliance_status_non_compliant_on_failed_fairness():
+    from apps.ml_engine.services.mrm_dossier import _compliance_status
+
+    mv = _make_compliant_mv(
+        fairness_metrics={
+            "gender": {"disparate_impact_ratio": 0.92, "passes_80_percent_rule": True},
+            "age_group": {"disparate_impact_ratio": 0.78, "passes_80_percent_rule": False},
+        }
+    )
+    status, reasons = _compliance_status(mv)
+    assert status == "NON-COMPLIANT"
+    assert any("age_group" in r for r in reasons)
+    assert any("80%-rule" in r for r in reasons)
+
+
+def test_compliance_status_non_compliant_on_high_psi():
+    from apps.ml_engine.services.mrm_dossier import _compliance_status
+
+    mv = _make_compliant_mv(
+        training_metadata={
+            "psi_by_feature": {"credit_score": 0.05, "dti": 0.30},
+        }
+    )
+    status, reasons = _compliance_status(mv)
+    assert status == "NON-COMPLIANT"
+    assert any("PSI" in r and "dti" in r for r in reasons)
+
+
+def test_compliance_status_non_compliant_on_high_ece():
+    from apps.ml_engine.services.mrm_dossier import _compliance_status
+
+    mv = _make_compliant_mv(ece=0.08)
+    status, reasons = _compliance_status(mv)
+    assert status == "NON-COMPLIANT"
+    assert any("ECE" in r for r in reasons)
+
+
+def test_compliance_status_needs_review_when_fairness_evidence_missing():
+    from apps.ml_engine.services.mrm_dossier import _compliance_status
+
+    mv = _make_compliant_mv(fairness_metrics={})
+    status, reasons = _compliance_status(mv)
+    assert status == "NEEDS REVIEW"
+    assert any("fairness metrics" in r for r in reasons)
+
+
+def test_compliance_status_needs_review_when_psi_missing():
+    from apps.ml_engine.services.mrm_dossier import _compliance_status
+
+    mv = _make_compliant_mv(training_metadata={"psi_by_feature": {}})
+    status, reasons = _compliance_status(mv)
+    assert status == "NEEDS REVIEW"
+    assert any("PSI" in r for r in reasons)
+
+
+def test_compliance_status_needs_review_when_calibration_missing():
+    from apps.ml_engine.services.mrm_dossier import _compliance_status
+
+    mv = _make_compliant_mv(calibration_data={})
+    status, reasons = _compliance_status(mv)
+    assert status == "NEEDS REVIEW"
+    assert any("calibration" in r for r in reasons)
+
+
+def test_header_renders_non_compliant_status_when_fairness_fails():
+    """Even with is_active=True, a failed fairness gate must surface in §1."""
+    from apps.ml_engine.services.mrm_dossier import generate_dossier_markdown
+
+    mv = _make_mv(is_active=True)  # default has age_group failing
+    with patch("apps.ml_engine.services.mrm_dossier._changelog_section") as _cl:
+        _cl.return_value = "## 11. Change log\n\n(stub)"
+        md = generate_dossier_markdown(mv)
+
+    assert "**Compliance status:** NON-COMPLIANT" in md
+    assert "age_group" in md  # named reason surfaces in the header sub-list
+
+
+def test_header_renders_compliant_status_when_clean():
+    from apps.ml_engine.services.mrm_dossier import generate_dossier_markdown
+
+    with patch("apps.ml_engine.services.mrm_dossier._changelog_section") as _cl:
+        _cl.return_value = "## 11. Change log\n\n(stub)"
+        md = generate_dossier_markdown(_make_compliant_mv())
+
+    assert "**Compliance status:** COMPLIANT" in md
+
+
+def test_document_subtitle_drops_alignment_keeps_format_reference():
+    """Regression guard for the implicit-claim removal (Codex finding 2)."""
+    from apps.ml_engine.services.mrm_dossier import generate_dossier_markdown
+
+    with patch("apps.ml_engine.services.mrm_dossier._changelog_section") as _cl:
+        _cl.return_value = "## 11. Change log\n\n(stub)"
+        md = generate_dossier_markdown(_make_compliant_mv())
+
+    # Locate the subtitle line (second line of the document).
+    lines = md.splitlines()
+    subtitle = next((ln for ln in lines[:5] if ln.startswith("_Generated")), "")
+    assert subtitle, "Document subtitle line not found"
+    assert "alignment" not in subtitle, f"Subtitle still implies alignment: {subtitle!r}"
+    assert "APRA CPS 220 / SR 11-7" in subtitle
+    assert "Format:" in subtitle
+
+
+# ---------------------------------------------------------------------------
+# File-write helper
+# ---------------------------------------------------------------------------
+
+
 def test_write_dossier_creates_file_at_expected_path():
     from apps.ml_engine.services.mrm_dossier import write_dossier
 

--- a/docs/superpowers/specs/2026-05-07-mrm-dossier-honesty-design.md
+++ b/docs/superpowers/specs/2026-05-07-mrm-dossier-honesty-design.md
@@ -1,0 +1,136 @@
+# MRM Dossier Honesty — post-Codex content fix
+
+**Date:** 2026-05-07
+**Status:** Approved design, pending implementation plan
+**Scope:** Three findings from the 2026-05-06 Codex adversarial review of `backend/ml_models/7556578d-…/mrm.md`. All fixes land in the dossier generator; no runtime behaviour changes.
+
+## Context
+
+A Codex adversarial review of an orphan MRM dossier surfaced three correctness defects in the dossier *generator* (not the dossier file directly — the file is just the symptom). The dossier was claiming controls the runtime does not actually enforce, branding a model with failed fairness gates as APRA-aligned, and pointing operators at a 404 drift URL.
+
+The runtime issues the review also touches on (fairness failure not blocking activation, policy overlay defaulting to `shadow`, champion-challenger gates not invoked on activation) are deliberately **out of scope** for this spec — they are larger architectural changes with real blast radius. The dossier becomes the truth-teller in the meantime, which is consistent with the existing module docstring's stance: "audit-visible evidence of gaps, rather than silent omission."
+
+## Findings at a glance
+
+| # | Codex severity | Surface | Fix shape |
+|---|---|---|---|
+| 1 | high | `mrm.md:21` ↔ `credit_policy.py:418-425` | `_purpose_section` reads `settings.CREDIT_POLICY_OVERLAY_MODE` and emits one of three explicit out-of-scope wordings (`off`/`shadow`/`enforce`) instead of an unconditional "must be referred". |
+| 2 | high | `mrm.md:2-14` ↔ `tasks.py:126-133` | Drop "alignment" from the document subtitle; introduce a new `Compliance status:` line in §1 Header (COMPLIANT / NEEDS REVIEW / NON-COMPLIANT) computed from gate evidence. Failed fairness can no longer be hidden behind an active+aligned banner. |
+| 3 | medium | `mrm.md:128, 175` ↔ `tasks.py:82-88`, `urls.py:8` | `_performance_section` softens "enforce these + PSI/calibration ceilings" to "exist; confirm pre-promotion review". `_monitoring_section` drift URL changes from `/api/ml-engine/drift/` to the actual `/api/v1/ml/models/active/drift/`. |
+
+## Finding 1 — Conditional out-of-scope wording
+
+**Problem.** `_purpose_section` (lines 94–96 of `mrm_dossier.py`) emits an unconditional "Predictions on applications outside scope **must be treated as advisory only and referred** to human underwriter review". `apply_overlay_to_decision()` only changes decisions in `enforce` mode (`credit_policy.py:418-425`); the documented default is `shadow`, which is observational. The dossier is asserting a control that is off by default.
+
+**Chosen approach.** Read the effective overlay mode at dossier-generation time and emit an explicit, mode-specific paragraph. The §9 policy section already mentions the three-mode contract — make §2 consistent with it.
+
+**Design.**
+
+- Inside `_purpose_section`, deferred import: `from django.conf import settings` and read `getattr(settings, "CREDIT_POLICY_OVERLAY_MODE", "shadow")`.
+- Three-way switch on the read value; unknown modes fall through to the `shadow` wording (matches `credit_policy.py:405` warning behaviour).
+
+  | Mode | Rendered paragraph |
+  |---|---|
+  | `off` | "No policy overlay is active in this deployment. Out-of-scope predictions are not flagged or blocked at runtime — manual scope review is required at intake." |
+  | `shadow` | "The policy overlay runs in `shadow` (observational) mode in this deployment. Out-of-scope predictions are flagged for monitoring but **not blocked**; manual underwriter review depends on operator workflow rather than automated routing (see §9)." |
+  | `enforce` | "The policy overlay runs in `enforce` mode in this deployment. Out-of-scope predictions are blocked by the overlay and routed to manual underwriter review (see §9 P-codes)." |
+
+- The `must be referred` mandate now appears **only** in the `enforce` rendering. The `shadow` wording is the new default.
+
+**Alternative considered.** Add a `--mode-override` CLI flag to the generator. Rejected — generator should reflect actual deployment, not a hypothesis. If an operator wants to preview the `enforce` paragraph, they can run with `CREDIT_POLICY_OVERLAY_MODE=enforce` env override before invoking the management command.
+
+**Tests.**
+- Default settings (no env override) → output contains `shadow` wording, contains "**not blocked**", does not contain "must be treated".
+- `@override_settings(CREDIT_POLICY_OVERLAY_MODE="enforce")` → output contains `enforce` wording with the original "blocked by the overlay" mandate.
+- `@override_settings(CREDIT_POLICY_OVERLAY_MODE="off")` → output contains "No policy overlay is active".
+- `@override_settings(CREDIT_POLICY_OVERLAY_MODE="bogus")` → falls through to `shadow` wording.
+
+## Finding 2 — Compliance status banner
+
+**Problem.** The document subtitle (built in `generate_dossier_markdown` at line 354) reads `_Generated … — APRA CPS 220 / SR 11-7 alignment_`. Combined with `**Active:** True` in §1, the dossier reads as a sign-off artifact. The fairness section can show two `passes_80_percent_rule: false` rows and the document still brands itself as "aligned". The runtime activation path leaves these models active anyway (`tasks.py:126-133`), so the dossier becomes the only line of defence — and it's currently silent.
+
+**Chosen approach.** Demote the subtitle to neutral framing and surface a **prominent compliance status line** in §1 Header that any auditor sees on the first page. The status is derived purely from already-recorded evidence on the `ModelVersion`.
+
+**Design.**
+
+- New pure helper `_compliance_status(mv) -> tuple[str, list[str]]` returning a status code and a list of reasons (empty when COMPLIANT).
+
+  Status decision (in order; first match wins):
+
+  | Trigger | Status |
+  |---|---|
+  | Any `mv.fairness_metrics[*].passes_80_percent_rule == False` | **NON-COMPLIANT** |
+  | Any feature in `mv.training_metadata.psi_by_feature` ≥ 0.25 | **NON-COMPLIANT** |
+  | `mv.ece is not None and mv.ece > 0.05` | **NON-COMPLIANT** |
+  | Any of `fairness_metrics`, `psi_by_feature`, `calibration_data.deciles` is missing/empty | **NEEDS REVIEW** |
+  | Otherwise | **COMPLIANT** |
+
+  Thresholds (`0.25` PSI, `0.05` ECE) match the existing `_psi_section` "significant drift" boundary and the standard ECE acceptance ceiling — kept as module-level constants `PSI_FAIL_THRESHOLD = 0.25`, `ECE_FAIL_THRESHOLD = 0.05` for visibility.
+
+- Document subtitle becomes `_Generated {ts} — Format: APRA CPS 220 / SR 11-7_`. The word `alignment` is removed.
+
+- §1 Header gains two new bullets, after `**Active:**`:
+  - `- **Compliance status:** {STATUS}`
+  - When status is not COMPLIANT, append a sub-list of reasons (one bullet per failure or missing-evidence reason).
+
+- Status string is intentionally not colour-coded with emoji or HTML — markdown renders consistently across GitHub/auditor PDF/local preview, and grep-ability matters for audit tooling.
+
+**Alternative considered.** Refuse to generate the dossier at all when `is_active=True` and any fairness gate fails. Rejected — the existing `mrm_dossier` module philosophy is "missing data degrades gracefully ... explicit 'Unavailable' line rather than silently omitting, so the auditor sees the gap." Refusing to generate would hide the gap rather than surface it.
+
+**Tests.**
+- `_compliance_status` returns `("COMPLIANT", [])` when fairness all pass + PSI all <0.25 + ECE ≤ 0.05 + calibration deciles present.
+- `_compliance_status` returns `NON-COMPLIANT` with a reason mentioning the failing protected attribute when any `passes_80_percent_rule` is False.
+- `_compliance_status` returns `NON-COMPLIANT` when any PSI ≥ 0.25 or `mv.ece > 0.05`, with reason naming the threshold breached.
+- `_compliance_status` returns `NEEDS REVIEW` (not NON-COMPLIANT) when `fairness_metrics` is empty/missing.
+- Header rendering includes `Compliance status: NON-COMPLIANT` when fairness fails, even with `is_active=True`.
+- Document subtitle does not contain the word `alignment` (regression guard).
+- Document subtitle still contains `APRA CPS 220 / SR 11-7` (we keep the format reference).
+
+## Finding 3 — Promotion-gate honesty + drift URL
+
+**Problem.** Two sub-issues bundled by Codex.
+
+(a) `_performance_section` lines 177–179 say "Champion-challenger promotion gates (see model_selector.py) **enforce** these + PSI and calibration ceilings." But the activation path in `tasks.py:82-88` creates the new model with `is_active=True` directly without invoking those gates. The dossier overstates the runtime control.
+
+(b) `_monitoring_section` line 298 points to `Drift dashboard: /api/ml-engine/drift/`. The actual route is `/api/v1/ml/models/active/drift/` (`urls.py:8` mounted at `api/v1/ml/` in `config/urls.py:228`). Operators following the dossier in an incident hit a 404.
+
+**Chosen approach.** Two string changes, two regression-guard tests.
+
+**Design.**
+
+- `_performance_section`: replace the trailing block with:
+  > "KS > 0.30 and AUC > 0.75 are the regulator-expected performance floor for AU retail-credit scorecards. Champion-challenger promotion gates **exist** in `model_selector.py` (PSI, calibration, KS); the current activation path in `tasks.py` activates new models directly, so confirm pre-promotion review for production deployments before relying on these gates."
+- `_monitoring_section`: change `Drift dashboard: /api/ml-engine/drift/` → `Drift dashboard: /api/v1/ml/models/active/drift/`.
+
+**Alternative considered.** Wire `tasks.py` activation through `model_selector` so the gates are actually enforced, making the original dossier text true. Rejected — runtime change, scope creep, separate workstream.
+
+**Tests.**
+- `_performance_section` does not contain the substring `enforce these`.
+- `_performance_section` contains `gates exist` and `confirm pre-promotion review`.
+- `_monitoring_section` contains exactly `/api/v1/ml/models/active/drift/`.
+- `_monitoring_section` does not contain the legacy `/api/ml-engine/drift/` substring (regression guard).
+
+## Out of scope
+
+- **Runtime activation gating.** Making fairness failure block `tasks.py` activation, or routing activation through `model_selector` champion-challenger gates, is a separate workstream with migration concerns (currently-active models with failed fairness would need explicit deactivation paths). Track separately if pursued.
+- **Overlay default change.** Switching `CREDIT_POLICY_OVERLAY_MODE` default from `shadow` to `enforce` is a deployment policy change, not a dossier change.
+- **The orphan `backend/ml_models/7556578d-…/mrm.md`.** File is local-only / untracked. After this spec ships, manually choose: `rm -rf` the directory, or run `python manage.py generate_mrm_dossier 7556578d-8768-44a7-a84f-a1ad0f052cb7` to regenerate it against the live DB and inspect the new banner. Not part of the implementation plan.
+
+## Test surface summary
+
+All new tests live in `backend/apps/ml_engine/tests/test_mrm_dossier.py`. Existing 240 LOC of tests must still pass unchanged (regression floor). New tests use plain object fakes — same pattern as the existing `_FakeModelVersion` helper in that file — so no DB or Django boot is required.
+
+Estimated test additions: ~12 new test functions, ~150 LOC.
+
+## Implementation footprint
+
+- Single touch file in `services/`: `backend/apps/ml_engine/services/mrm_dossier.py` (~50 LOC added: 1 new pure helper, 2 new module-level constants, edits to 3 sections + the document subtitle).
+- Single touch file in `tests/`: `backend/apps/ml_engine/tests/test_mrm_dossier.py` (~150 LOC added).
+- Zero touches anywhere else: no settings changes, no migrations, no URL changes, no runtime path edits, no frontend changes.
+
+## Branch + PR shape
+
+- Branch: `fix/mrm-dossier-honesty-after-codex-review`
+- Single squash-merge PR. Title: `fix(ml): MRM dossier honesty — overlay-mode wording, compliance status, drift URL`.
+- Commit message + PR body cite all three Codex finding tags ([high]/[high]/[medium]) and link the original review comment (PR #161 thread).
+- Mirrors the project's atomic-PR pattern (cf. PRs #80–#82 for v1.9.4, #97–#102 for v1.10.1).


### PR DESCRIPTION
## Summary

Closes the three findings from the [2026-05-06 Codex adversarial review](https://github.com/zeroyuekun/loan-approval-ai-system/pull/161) of the orphan `backend/ml_models/7556578d-…/mrm.md` dossier. All fixes land in the dossier *generator* (`backend/apps/ml_engine/services/mrm_dossier.py`); zero runtime path changes.

The runtime issues the review also touches on (fairness failure not blocking activation, policy overlay defaulting to `shadow`, champion-challenger gates not invoked on activation) are deliberately out of scope — see the design spec under "Out of scope" — they are larger architectural changes with real blast radius. The dossier becomes the truth-teller in the meantime, consistent with the existing module philosophy: "audit-visible evidence of gaps, rather than silent omission."

## Findings addressed

| # | Codex severity | Commit | What changed |
|---|---|---|---|
| 1 | high | `a9a6454` | `_purpose_section` reads `settings.CREDIT_POLICY_OVERLAY_MODE` and emits one of three explicit out-of-scope paragraphs (`off` / `shadow` / `enforce`) instead of an unconditional "must be referred". The mandatory-referral wording now appears only in `enforce`. |
| 2 | high | `d18b68c` | New `_compliance_status` helper derived from gate evidence (fairness 80%-rule, PSI ≥ 0.25, ECE > 0.05). §1 Header gains a `Compliance status:` line with sub-list of reasons. Document subtitle drops "alignment" — keeps the format reference. |
| 3 | medium | `4476ac2` | `_performance_section` no longer claims gates "enforce" — softened to "exist; confirm pre-promotion review". `_monitoring_section` drift URL fixed: `/api/ml-engine/drift/` → `/api/v1/ml/models/active/drift/`. |

Design spec at `docs/superpowers/specs/2026-05-07-mrm-dossier-honesty-design.md` (`340013b`).

## Test plan

- [x] `python -m pytest apps/ml_engine/tests/test_mrm_dossier.py` — **26/26** pass (10 new + 4 new + 2 new on top of 10 existing). Each new test ties back to a specific Codex finding.
- [x] `python -m pytest apps/ml_engine/` — 346 passing; 7 errors are DB-bound integration tests (env, not code — same pattern as the prior #161 run; `mrm_dossier` is pure-functional and isolated).
- [x] `ruff check backend/` — clean
- [x] `ruff format --check backend/` — 358 files already formatted
- [x] mypy gate not applicable — `mrm_dossier.py` is not in the Arm C extraction list (`.github/workflows/lint.yml`)
- [x] Default fake `_make_mv()` is intentionally NON-COMPLIANT (failed `age_group` + PSI on `dti`); new positive-path tests use a `_make_compliant_mv()` helper to avoid duplicate-kwarg regressions

## Out of scope (called out in the spec, deliberately deferred)

- Routing `tasks.py` activation through `model_selector` champion-challenger gates so the gates are actually enforced.
- Making fairness failure a blocking activation gate (currently-active models with failed fairness would need an explicit deactivation migration).
- Switching `CREDIT_POLICY_OVERLAY_MODE` default from `shadow` to `enforce` (deployment policy change).
- The orphan `backend/ml_models/7556578d-…/mrm.md` file itself — local-only, untracked. After merge: `rm -rf` it, or `python manage.py generate_mrm_dossier 7556578d-…` to regenerate against your DB and inspect the new banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)