### PR TITLE
feat(ml): add ML_PROMOTION_GATE_MODE setting (warn/block/off) wiring promote_if_eligible into activation

### DIFF
--- a/backend/apps/ml_engine/services/promotion_gate_mode.py
+++ b/backend/apps/ml_engine/services/promotion_gate_mode.py
@@ -1,0 +1,99 @@
+"""Mode dispatcher for the pre-activation champion-challenger promotion gate.
+
+Wraps `apps.ml_engine.services.model_selector.promote_if_eligible` (KS, PSI,
+ECE, AUC regression gates) with a three-mode policy: warn (gates run, decision
+recorded, model activates regardless — current behaviour byte-identical since
+the gates were never invoked from production paths before), block (refuse
+activation when any gate fails; old segment models keep serving), off (skip
+the check entirely).
+
+The dispatcher itself is pure-functional and unit-testable without Django ORM
+boot — it takes the mode as an argument and returns a structured decision.
+Only `tasks.py` reads the `ML_PROMOTION_GATE_MODE` setting and delegates here.
+
+Sibling to `fairness_gate_mode.py`. The two dispatchers are intentionally
+parallel so operators learn one mode pattern that applies to both gates.
+
+See `docs/superpowers/specs/2026-05-07-ml-promotion-gate-mode-design.md`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from apps.ml_engine.services.model_selector import PromotionDecision
+
+logger = logging.getLogger(__name__)
+
+
+VALID_MODES = ("warn", "block", "off")
+DEFAULT_MODE = "warn"
+
+
+class PromotionGateBlocked(RuntimeError):
+    """Raised in `block` mode when the champion-challenger promotion gates
+    rejected the candidate. The error message includes the failed-gate reasons
+    from the underlying `PromotionDecision` plus the override path
+    (set ML_PROMOTION_GATE_MODE=warn after manual review)."""
+
+
+def normalize_mode(mode: str | None) -> str:
+    """Coerce arbitrary input to a valid mode; unknown values collapse to warn.
+
+    Mirrors the pattern in `credit_policy.py:405` and
+    `fairness_gate_mode.normalize_mode` — a misconfigured deployment never
+    silently disables the gate.
+    """
+    if mode in VALID_MODES:
+        return mode
+    if mode is not None:
+        logger.warning(
+            "Unknown ML_PROMOTION_GATE_MODE=%r — defaulting to %r",
+            mode,
+            DEFAULT_MODE,
+        )
+    return DEFAULT_MODE
+
+
+def evaluate_promotion_gates_for_activation(
+    decision: PromotionDecision,
+    mode: str,
+) -> dict:
+    """Decide whether activation should proceed given a promotion decision + mode.
+
+    Args:
+        decision: The `PromotionDecision` returned by
+            `model_selector.promote_if_eligible(candidate_stub)`. Carries the
+            promoted bool, gate-by-gate evidence, reasons, and champion id.
+        mode: One of "warn", "block", or "off". Unknown values are coerced to
+            "warn" via `normalize_mode`.
+
+    Returns:
+        {
+            "action": "activate" | "skip_check",
+            "decision": PromotionDecision | None,   # None when mode=="off"
+            "mode": str,                            # normalized mode
+        }
+
+    Raises:
+        PromotionGateBlocked: in `block` mode when `decision.promoted` is False.
+            The caller (tasks.py) is responsible for ensuring this raise happens
+            BEFORE any model-activation transaction so old segment models keep
+            serving.
+    """
+    mode = normalize_mode(mode)
+
+    if mode == "off":
+        return {"action": "skip_check", "decision": None, "mode": "off"}
+
+    if mode == "block" and not decision.promoted:
+        reasons = "; ".join(decision.reasons) if decision.reasons else "(no reasons recorded)"
+        raise PromotionGateBlocked(
+            f"Activation blocked (mode=block): champion-challenger promotion "
+            f"gates failed: {reasons}. Set ML_PROMOTION_GATE_MODE=warn after "
+            "manual review, or fix the regression and retrain."
+        )
+
+    return {"action": "activate", "decision": decision, "mode": mode}

--- a/backend/apps/ml_engine/tasks.py
+++ b/backend/apps/ml_engine/tasks.py
@@ -49,10 +49,16 @@ def train_model_task(self, algorithm="xgb", data_path=None, segment=None):
 
 def _do_train(task, algorithm, data_path, lock, *, segment=None):
     """Inner training logic — called with lock held."""
+    from types import SimpleNamespace
+
     from apps.ml_engine.services.fairness_gate_mode import (
         evaluate_fairness_gate_for_activation,
     )
+    from apps.ml_engine.services.model_selector import promote_if_eligible
     from apps.ml_engine.services.predictor import clear_model_cache
+    from apps.ml_engine.services.promotion_gate_mode import (
+        evaluate_promotion_gates_for_activation,
+    )
     from apps.ml_engine.services.segmentation import SEGMENT_UNIFIED
     from apps.ml_engine.services.trainer import ModelTrainer
 
@@ -84,6 +90,27 @@ def _do_train(task, algorithm, data_path, lock, *, segment=None):
     fairness_data = metrics.get("fairness", {})
     gate_mode = getattr(settings, "ML_FAIRNESS_GATE_MODE", "warn")
     gate_decision = evaluate_fairness_gate_for_activation(fairness_data, gate_mode)
+
+    # Pre-activation champion-challenger promotion gates. Build a transient
+    # candidate stub from the in-memory metrics — promote_if_eligible reads
+    # via getattr + training_metadata, no DB write needed. The pk=None makes
+    # the .exclude(pk=...) clause inside promote_if_eligible a no-op which is
+    # correct here (we want the existing active model excluded only if it
+    # shares pk with us). In `block` mode this raises PromotionGateBlocked
+    # BEFORE the atomic activation block. See
+    # docs/superpowers/specs/2026-05-07-ml-promotion-gate-mode-design.md.
+    candidate_stub = SimpleNamespace(
+        id="(pre-activation)",
+        pk=None,
+        segment=segment,
+        auc_roc=metrics["auc_roc"],
+        ks_statistic=metrics["ks_statistic"],
+        ece=metrics.get("calibration_data", {}).get("ece"),
+        training_metadata=metrics.get("training_metadata", {}),
+    )
+    promotion_decision = promote_if_eligible(candidate_stub)
+    promotion_mode = getattr(settings, "ML_PROMOTION_GATE_MODE", "warn")
+    promotion_gate_decision = evaluate_promotion_gates_for_activation(promotion_decision, promotion_mode)
 
     # Deactivate old models and activate new one atomically — if create()
     # fails, the old active model remains active (no zero-model gap).
@@ -131,10 +158,14 @@ def _do_train(task, algorithm, data_path, lock, *, segment=None):
             next_review_date=(timezone.now() + timedelta(days=90)).date(),
         )
 
-    # Record the gate decision (mode + result) on the activated mv so the
-    # MRM dossier §1 banner has the audit trail. In `warn` mode a failed
-    # gate is logged + flagged; activation already happened.
-    gate_meta = {**(mv.training_metadata or {}), "fairness_gate_mode": gate_decision["mode"]}
+    # Record the gate decisions (mode + result) on the activated mv so the
+    # MRM dossier §1 banner has the audit trail for both gates. In `warn`
+    # mode a failed gate is logged + flagged; activation already happened.
+    gate_meta = {
+        **(mv.training_metadata or {}),
+        "fairness_gate_mode": gate_decision["mode"],
+        "promotion_gate_mode": promotion_gate_decision["mode"],
+    }
     gate_result = gate_decision["gate_result"]
     if gate_result is not None:
         gate_meta["fairness_gate"] = gate_result
@@ -148,6 +179,23 @@ def _do_train(task, algorithm, data_path, lock, *, segment=None):
                 gate_result["minimum_dir"],
             )
             gate_meta["requires_fairness_review"] = True
+
+    # Promotion gate decision — record only when the dispatcher inspected it
+    # (None when mode == "off"). In `warn` mode log a clear line if rejected
+    # so audit trails capture the regression-vs-champion verdict even though
+    # activation proceeded.
+    promo_decision_payload = promotion_gate_decision["decision"]
+    if promo_decision_payload is not None:
+        gate_meta["promotion_gate"] = promo_decision_payload.to_dict()
+        if not promo_decision_payload.promoted:
+            logger.warning(
+                "Model %s REJECTED by promotion gates (mode=%s, reasons: %s). "
+                "Model remains active but flagged for human review.",
+                mv.id,
+                promotion_gate_decision["mode"],
+                "; ".join(promo_decision_payload.reasons),
+            )
+            gate_meta["requires_promotion_review"] = True
     mv.training_metadata = gate_meta
     mv.save(update_fields=["training_metadata"])
 

--- a/backend/apps/ml_engine/tests/test_promotion_gate_mode.py
+++ b/backend/apps/ml_engine/tests/test_promotion_gate_mode.py
@@ -1,0 +1,201 @@
+"""Unit tests for the pre-activation promotion gate mode dispatcher.
+
+The dispatcher is pure-functional — it takes a `PromotionDecision` and a
+mode string and returns a structured decision. These tests construct
+`PromotionDecision` instances directly (no DB, no Django boot, no Celery)
+and exercise the full mode matrix.
+
+The integration of `model_selector.promote_if_eligible` with the
+`SimpleNamespace` candidate stub is mechanical (build stub → call function);
+existing `test_metrics_production_grade.py::promote_if_eligible — gate matrix`
+tests already exercise the gate logic with DB.
+
+Spec: docs/superpowers/specs/2026-05-07-ml-promotion-gate-mode-design.md
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from apps.ml_engine.services.model_selector import PromotionDecision
+from apps.ml_engine.services.promotion_gate_mode import (
+    DEFAULT_MODE,
+    VALID_MODES,
+    PromotionGateBlocked,
+    evaluate_promotion_gates_for_activation,
+    normalize_mode,
+)
+
+# ---------------------------------------------------------------------------
+# PromotionDecision fixtures — keep these terse; the gate-by-gate evidence
+# isn't material to the dispatcher's logic, only `promoted` and `reasons`.
+# ---------------------------------------------------------------------------
+
+
+def _promoted_decision() -> PromotionDecision:
+    return PromotionDecision(
+        promoted=True,
+        candidate_id="cand-123",
+        champion_id="champ-456",
+        reasons=["All gates passed"],
+        gates={"max_psi": {"passed": True}, "ece": {"passed": True}},
+    )
+
+
+def _rejected_decision() -> PromotionDecision:
+    return PromotionDecision(
+        promoted=False,
+        candidate_id="cand-123",
+        champion_id="champ-456",
+        reasons=[
+            "PSI gate failed: max feature PSI 0.3500 exceeds 0.25 ceiling",
+            "Calibration gate failed: ECE 0.0612 exceeds 0.03 ceiling",
+        ],
+        gates={"max_psi": {"passed": False}, "ece": {"passed": False}},
+    )
+
+
+def _rejected_decision_no_reasons() -> PromotionDecision:
+    """Edge case — rejected with empty reasons list."""
+    return PromotionDecision(
+        promoted=False,
+        candidate_id="cand-123",
+        champion_id="champ-456",
+        reasons=[],
+        gates={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# normalize_mode
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_mode_accepts_valid_values():
+    for mode in VALID_MODES:
+        assert normalize_mode(mode) == mode
+
+
+def test_normalize_mode_collapses_unknown_to_warn(caplog):
+    with caplog.at_level(logging.WARNING):
+        assert normalize_mode("bogus") == DEFAULT_MODE
+    assert any("Unknown ML_PROMOTION_GATE_MODE" in r.message for r in caplog.records)
+
+
+def test_normalize_mode_handles_none_silently():
+    assert normalize_mode(None) == DEFAULT_MODE
+
+
+# ---------------------------------------------------------------------------
+# warn mode — preserves current behaviour byte-identically (gates were never
+# invoked from production paths before this PR; warn just records the decision
+# without acting on it).
+# ---------------------------------------------------------------------------
+
+
+def test_warn_mode_promoted_returns_activate():
+    decision = _promoted_decision()
+    out = evaluate_promotion_gates_for_activation(decision, "warn")
+    assert out["action"] == "activate"
+    assert out["mode"] == "warn"
+    assert out["decision"] is decision
+
+
+def test_warn_mode_rejected_still_returns_activate():
+    """Regression guard for current behaviour — warn mode never blocks even
+    when gates report regressions vs the incumbent champion."""
+    decision = _rejected_decision()
+    out = evaluate_promotion_gates_for_activation(decision, "warn")
+    assert out["action"] == "activate"
+    assert out["mode"] == "warn"
+    assert out["decision"] is decision
+
+
+# ---------------------------------------------------------------------------
+# block mode — refuses activation on rejected promotion
+# ---------------------------------------------------------------------------
+
+
+def test_block_mode_promoted_returns_activate():
+    decision = _promoted_decision()
+    out = evaluate_promotion_gates_for_activation(decision, "block")
+    assert out["action"] == "activate"
+    assert out["mode"] == "block"
+    assert out["decision"] is decision
+
+
+def test_block_mode_rejected_raises_with_reasons():
+    decision = _rejected_decision()
+    with pytest.raises(PromotionGateBlocked) as excinfo:
+        evaluate_promotion_gates_for_activation(decision, "block")
+    msg = str(excinfo.value)
+    assert "mode=block" in msg
+    assert "PSI gate failed" in msg
+    assert "Calibration gate failed" in msg
+
+
+def test_block_mode_includes_remediation_hint_in_error():
+    """Operators should see the override path in the error message."""
+    decision = _rejected_decision()
+    with pytest.raises(PromotionGateBlocked) as excinfo:
+        evaluate_promotion_gates_for_activation(decision, "block")
+    assert "ML_PROMOTION_GATE_MODE=warn" in str(excinfo.value)
+
+
+def test_block_mode_rejected_without_reasons_still_raises():
+    """Defensive — if a future PromotionDecision returns rejected with empty
+    reasons, the dispatcher must still block (and surface a sensible message)."""
+    decision = _rejected_decision_no_reasons()
+    with pytest.raises(PromotionGateBlocked) as excinfo:
+        evaluate_promotion_gates_for_activation(decision, "block")
+    assert "mode=block" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# off mode — escape hatch
+# ---------------------------------------------------------------------------
+
+
+def test_off_mode_skips_check_for_promoted_decision():
+    out = evaluate_promotion_gates_for_activation(_promoted_decision(), "off")
+    assert out["action"] == "skip_check"
+    assert out["decision"] is None
+    assert out["mode"] == "off"
+
+
+def test_off_mode_skips_check_for_rejected_decision():
+    """Off mode must not block, must not record the decision."""
+    out = evaluate_promotion_gates_for_activation(_rejected_decision(), "off")
+    assert out["action"] == "skip_check"
+    assert out["decision"] is None
+    assert out["mode"] == "off"
+
+
+# ---------------------------------------------------------------------------
+# Unknown mode — coerced to warn (regression guard for misconfigured deployments)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_mode_falls_through_to_warn_for_rejected_decision():
+    """A misconfigured deployment must never silently disable the gate."""
+    out = evaluate_promotion_gates_for_activation(_rejected_decision(), "bogus")
+    assert out["action"] == "activate"
+    assert out["mode"] == "warn"
+
+
+def test_unknown_mode_does_not_block_even_with_rejected_decision():
+    """Even with the worst possible decision, unknown mode must not raise."""
+    evaluate_promotion_gates_for_activation(_rejected_decision(), "totally-made-up")
+
+
+# ---------------------------------------------------------------------------
+# Exception subclass contract
+# ---------------------------------------------------------------------------
+
+
+def test_promotion_gate_blocked_is_runtime_error():
+    """The outer train_model_task wrapper catches RuntimeError to release
+    the training lock; PromotionGateBlocked must satisfy that contract."""
+    assert issubclass(PromotionGateBlocked, RuntimeError)

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -251,6 +251,17 @@ CREDIT_POLICY_OVERLAY_MODE = os.environ.get("CREDIT_POLICY_OVERLAY_MODE", "shado
 # docs/superpowers/specs/2026-05-07-ml-fairness-gate-mode-design.md.
 ML_FAIRNESS_GATE_MODE = os.environ.get("ML_FAIRNESS_GATE_MODE", "warn")
 
+# Pre-activation champion-challenger promotion gate mode for `train_model_task`.
+# Mirrors ML_FAIRNESS_GATE_MODE: "warn" (default — gates run, decision recorded
+# on training_metadata, model activates regardless), "block" (refuse activation
+# if model_selector.promote_if_eligible reports any of the 4 gates failed —
+# KS regression, PSI stability, ECE calibration, AUC regression), "off" (skip
+# the check entirely). Default "warn" so the PR ships zero behaviour change for
+# any deployment that doesn't set the env var; flip to "block" only after
+# validating the trainer produces compliant promotion metrics for the segments
+# in scope. See docs/superpowers/specs/2026-05-07-ml-promotion-gate-mode-design.md.
+ML_PROMOTION_GATE_MODE = os.environ.get("ML_PROMOTION_GATE_MODE", "warn")
+
 # D7 — MRM dossier auto-generation on ModelVersion post_save.
 # Enabled by default; disable in unit tests that create throwaway models.
 MRM_DOSSIER_AUTO_GENERATE = os.environ.get("MRM_DOSSIER_AUTO_GENERATE", "true").lower() == "true"

--- a/docs/superpowers/specs/2026-05-07-ml-promotion-gate-mode-design.md
+++ b/docs/superpowers/specs/2026-05-07-ml-promotion-gate-mode-design.md
@@ -1,0 +1,145 @@
+# ML Promotion Gate Mode — runtime activation gating, Phase 2
+
+**Date:** 2026-05-07
+**Status:** Approved design, pending implementation plan
+**Scope:** Phase 2 of the runtime gating work deferred from PR #162. Wires `model_selector.promote_if_eligible` (KS, PSI, ECE, AUC regression gates — currently dead code outside tests) into `train_model_task` activation, gated by an opt-in `ML_PROMOTION_GATE_MODE` setting that mirrors `ML_FAIRNESS_GATE_MODE` from PR #163. Phase 3 (`CREDIT_POLICY_OVERLAY_MODE` default flip) is out of scope and is now documented as a runbook artifact rather than a code change.
+
+## Context
+
+PR #163 added a fairness gate dispatcher (`evaluate_fairness_gate_for_activation`) with three modes: `warn` (default — current behaviour byte-identical), `block`, `off`. This spec adds the parallel dispatcher for the four-gate champion-challenger promotion check (KS regression, PSI stability, ECE calibration, AUC regression). The promotion gates already exist as `model_selector.promote_if_eligible`; they're well-tested but never invoked from production code paths.
+
+Mirroring Phase 1's mode shape lets operators learn one pattern that applies to both gates. The default `warn` mode preserves current behaviour byte-identically — gates run nowhere, model activates regardless of metric regressions vs the incumbent champion.
+
+## The wiring trick
+
+`promote_if_eligible(candidate)` reads metric attributes via `getattr` + `training_metadata` JSON (duck-typed), queries the DB **once** for the champion, returns a `PromotionDecision`, and does **not** mutate the candidate. So we can call it pre-activation by passing a transient `SimpleNamespace` stub built from the in-memory `metrics` dict — no DB write needed, no refactor of `promote_if_eligible`. The `pk=None` on the stub makes the `.exclude(pk=...)` clause inside `promote_if_eligible` a no-op which is correct (we want the existing active model excluded only if it shares pk with us, which a None pk never does).
+
+## The setting
+
+`backend/config/settings/base.py` near `ML_FAIRNESS_GATE_MODE`:
+
+```python
+ML_PROMOTION_GATE_MODE = os.environ.get("ML_PROMOTION_GATE_MODE", "warn")
+```
+
+Three valid values, identical semantics to the fairness gate:
+
+| Mode | Behaviour |
+|---|---|
+| `warn` (default) | Run gates, log + record decision on `training_metadata`, leave model active. Byte-identical to pre-PR behaviour where gates simply weren't invoked at all (we now invoke them but don't act on a failure). |
+| `block` | Run gates pre-activation. If `decision.promoted == False`, raise `PromotionGateBlocked` BEFORE the atomic activation transaction. Old segment models keep `is_active=True`; no zero-model gap. |
+| `off` | Skip gate evaluation entirely. Emergency escape hatch. |
+
+Unknown values fall through to `warn` with one log line (mirrors `credit_policy.py:405`, `fairness_gate_mode.py:normalize_mode`).
+
+## The dispatcher
+
+New module `backend/apps/ml_engine/services/promotion_gate_mode.py`:
+
+```python
+class PromotionGateBlocked(RuntimeError): ...
+
+VALID_MODES = ("warn", "block", "off")
+DEFAULT_MODE = "warn"
+
+def normalize_mode(mode): ...
+
+def evaluate_promotion_gates_for_activation(decision: PromotionDecision, mode: str) -> dict:
+    """Decide whether activation should proceed given a promotion decision.
+
+    Returns:
+        {"action": "activate" | "skip_check",
+         "decision": PromotionDecision | None,
+         "mode": str}
+
+    Raises PromotionGateBlocked in `block` mode when decision.promoted is False.
+    """
+```
+
+Pure-functional, no DB, no Django settings dependency — takes mode as an argument so it's testable without app boot.
+
+## Wiring in `tasks.py`
+
+Drops in directly after the fairness gate dispatcher call (added in PR #163), still pre-`transaction.atomic()`:
+
+```python
+# Existing (PR #163): fairness gate dispatcher
+fairness_decision = evaluate_fairness_gate_for_activation(...)
+
+# New: promotion gates pre-activation. Build a transient candidate stub
+# from in-memory metrics — no DB write needed.
+from types import SimpleNamespace
+candidate_stub = SimpleNamespace(
+    id="(pre-activation)", pk=None, segment=segment,
+    auc_roc=metrics["auc_roc"],
+    ks_statistic=metrics["ks_statistic"],
+    ece=metrics.get("calibration_data", {}).get("ece"),
+    training_metadata=metrics.get("training_metadata", {}),
+)
+promotion_decision = promote_if_eligible(candidate_stub)
+promotion_gate_decision = evaluate_promotion_gates_for_activation(
+    promotion_decision,
+    getattr(settings, "ML_PROMOTION_GATE_MODE", "warn"),
+)
+# raise propagates to outer task wrapper, releases lock, no atomic block entered
+
+# (existing atomic activation block — unchanged)
+with transaction.atomic():
+    ...
+```
+
+Post-activation, the dispatcher result joins `mv.training_metadata` so the dossier audit trail captures the promotion decision (gates + champion id + reasons + mode).
+
+## Edge cases
+
+- **First model in segment** — `promote_if_eligible` short-circuits Gates 1+4 (KS regression, AUC regression) when no champion exists; only PSI + ECE are evaluated. The dispatcher delegates wholesale, so this just works — first models in a segment auto-promote after PSI+ECE pass.
+- **Pre-D5 model with no `psi_by_feature` recorded** — `_max_psi` returns `float("inf")`, which fails Gate 2. In `block` mode, this means an old-format model can't be activated until it's retrained with the v1.9.9+ trainer. Acceptable — the model registry uses post-D5 trainers in practice.
+- **`metrics["calibration_data"]` missing `ece`** — `_metric` falls back to `1.0`, which is well above the 0.03 ECE ceiling. `block` mode would refuse activation. Operators see "ECE 1.0000 exceeds 0.03 ceiling" in the error and either fix the trainer or set mode to `warn`.
+- **DB query inside `promote_if_eligible`** — the function performs one ORM query for the champion. In CI without DB, the query layer raises and the dispatcher would propagate. Tests for the dispatcher patch `promote_if_eligible` to avoid the DB; the integration of `promote_if_eligible` itself is covered by existing `test_metrics_production_grade.py` tests.
+
+## Test surface
+
+New file `backend/apps/ml_engine/tests/test_promotion_gate_mode.py` — service-level pure-function tests of the dispatcher. Constructs `PromotionDecision` instances directly (no DB). ~10 tests, ~120 LOC.
+
+| Test | Focus |
+|---|---|
+| `test_normalize_mode_accepts_valid_values` | Sanity floor |
+| `test_normalize_mode_collapses_unknown_to_warn` | Misconfigured deployment doesn't silently bypass |
+| `test_warn_mode_promoted_returns_activate` | Default mode + decision.promoted=True → activate, decision recorded |
+| `test_warn_mode_rejected_still_returns_activate` | Default mode + decision.promoted=False → activate (regression guard for the current zero-call-site behaviour) |
+| `test_block_mode_promoted_returns_activate` | block + promoted → activate |
+| `test_block_mode_rejected_raises_with_reasons` | block + rejected → `PromotionGateBlocked` whose message includes the failed gate reasons |
+| `test_block_mode_includes_remediation_hint_in_error` | Error message names `ML_PROMOTION_GATE_MODE=warn` as the override path |
+| `test_off_mode_skips_check_entirely` | off mode → skip_check, no raise |
+| `test_off_mode_does_not_inspect_decision` | Patches `decision.promoted` access; off mode must not read the decision |
+| `test_promotion_gate_blocked_is_runtime_error` | Subclass contract |
+
+The `_do_train` integration is mechanical (build stub → call function → call dispatcher → raise/proceed). Existing `test_metrics_production_grade.py::promote_if_eligible — gate matrix` tests already exercise the gate logic with DB.
+
+## Implementation footprint
+
+- `backend/config/settings/base.py`: 1 line (`ML_PROMOTION_GATE_MODE = os.environ.get("ML_PROMOTION_GATE_MODE", "warn")`)
+- `backend/apps/ml_engine/services/promotion_gate_mode.py`: ~70 LOC (new)
+- `backend/apps/ml_engine/tests/test_promotion_gate_mode.py`: ~150 LOC (new)
+- `backend/apps/ml_engine/tasks.py`: ~20 LOC (stub construction + dispatcher call + metadata write)
+
+`tasks.py` is at 422 LOC after PR #163; +20 lands at ~442, comfortably under the 500-LOC quality-bar cap.
+
+## Constraints honored
+
+Same as PR #163, restated for completeness:
+
+- **No retroactive deactivation.** The gate runs only on new `train_model_task` runs; existing `is_active=True` models are never touched.
+- **No zero-model gap.** `block`-mode raise happens before the atomic transaction.
+- **Opt-in default.** `warn` is the default — the PR ships zero behaviour change for any deployment that doesn't set the env var.
+- **Reversible.** Operators flip `ML_PROMOTION_GATE_MODE=warn` to revert.
+
+## Branch + PR shape
+
+- Branch: `feat/ml-promotion-gate-block-mode`
+- Single squash-merge PR. Title: `feat(ml): add ML_PROMOTION_GATE_MODE setting (warn/block/off) wiring promote_if_eligible into activation`.
+- Body cites PR #163 as the upstream pattern and the parent #162 review.
+
+## Out of scope (Phase 3 — handled separately)
+
+`CREDIT_POLICY_OVERLAY_MODE` default `shadow` → `enforce`. After thinking it through: this is a runbook artifact, not a code change. Flipping the global default would change runtime behaviour for every deployment without an explicit env var, which violates the "opt-in default" safety constraint that Phases 1 and 2 honor. The right Phase 3 deliverable is a documented enablement procedure (prerequisite checks, rollout monitoring, rollback steps) so an operator can flip `CREDIT_POLICY_OVERLAY_MODE=enforce` in their own deployment when ready. Tracked as a follow-up doc PR.


### PR DESCRIPTION
## Summary

Phase 2 of the runtime gating work deferred from PR #162 (Phase 1 was PR #163). Wires the previously-dead-code `model_selector.promote_if_eligible` (KS, PSI, ECE, AUC regression gates) into `train_model_task` via a new opt-in `ML_PROMOTION_GATE_MODE` setting. Mirrors the `ML_FAIRNESS_GATE_MODE` mode-shape from PR #163 so operators learn one pattern that applies to both gates.

Phase 3 (`CREDIT_POLICY_OVERLAY_MODE` default flip) is reframed in this PR's spec as a runbook artifact rather than a code change — a follow-up doc PR will land separately.

## What changed

**Setting** — `ML_PROMOTION_GATE_MODE` env var, default `warn`. Three modes: `warn` (gates run, decision recorded on `training_metadata`, model activates regardless — current behaviour byte-identical since the gates were never invoked from production paths before), `block` (refuse activation when `decision.promoted == False`; raises `PromotionGateBlocked` BEFORE the atomic activation transaction), `off` (skip the check entirely).

**Dispatcher** — new pure-functional `apps.ml_engine.services.promotion_gate_mode.evaluate_promotion_gates_for_activation`. Takes mode as an argument so it's testable without DB / Django boot.

**Wiring trick** — `promote_if_eligible` reads candidate attributes via `getattr` + `training_metadata` JSON (duck-typed). I build a transient `SimpleNamespace` stub from the in-memory `metrics` dict; no DB write needed. The `pk=None` makes the function's `.exclude(pk=...)` clause a no-op which is correct here (we want the existing active model excluded only if it shares pk with us, which a None pk never does). Result: pre-activation gate evaluation without refactoring `promote_if_eligible`.

**Audit trail** — the activated `mv.training_metadata` now carries both `fairness_gate_mode` (from PR #163) and `promotion_gate_mode` plus the structured gate results, giving the MRM dossier §1 compliance banner audit visibility for both controls.

## Test plan

- [x] **14 service-level dispatcher tests** in `apps/ml_engine/tests/test_promotion_gate_mode.py` — full mode matrix across `warn` / `block` / `off` plus unknown-mode fallthrough plus `PromotionGateBlocked` RuntimeError contract. Pure-functional, no DB.
- [x] `apps/ml_engine/` full suite — **377 passing** (was 363 pre-PR). 7 DB-bound integration errors unchanged from prior PRs (same env-not-code issue from #161, #162, #163).
- [x] Ruff clean
- [x] `ruff format --check` clean
- [x] `python tools/check_file_sizes.py` — passed (`tasks.py` 422 → 470 LOC, under the 500-LOC cap)
- [x] **Default-mode regression guard**: `test_warn_mode_rejected_still_returns_activate` proves a rejected promotion in warn mode still activates (byte-identical to current behaviour where the gate was simply never invoked)

## Constraints honored

Same as PR #163:

- **No retroactive deactivation.** Gate runs only on new training runs.
- **No zero-model gap.** `block`-mode raise happens before the atomic transaction.
- **Opt-in default.** `warn` is the default — PR ships zero behaviour change.
- **Reversible.** `ML_PROMOTION_GATE_MODE=warn` env flip reverts.

## Phase 3 — runbook artifact, not a code PR

After thinking it through, switching `CREDIT_POLICY_OVERLAY_MODE` default `shadow` → `enforce` would change runtime behaviour for every deployment that doesn't explicitly set the env var, violating the opt-in-default safety constraint that Phases 1 and 2 honor. The right Phase 3 deliverable is a documented enablement procedure (prerequisite checks, rollout monitoring, rollback steps). That'll land as a follow-up doc PR after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)