### PR TITLE
fix(robustness): defensive cascade in pipeline dispatch + regression tests

### DIFF
--- a/backend/apps/loans/admin.py
+++ b/backend/apps/loans/admin.py
@@ -58,6 +58,11 @@ class LoanApplicationAdmin(admin.ModelAdmin):
             # added in this closure is lost. Failure visibility comes from the
             # QUEUE_FAILED status flip below, surfaced via the dashboard's status
             # filter. Mirrors loans/views.py:73 perform_create.
+            #
+            # The outbox-record and status-flip steps each get their own try/except so
+            # one failure (e.g., DB lock on the outbox table) doesn't prevent the other
+            # from running. The on_commit hook itself must not raise — Django logs but
+            # there's no recovery path post-response.
             try:
                 orchestrate_pipeline_task.delay(str(obj.pk))
                 logger.info("Admin-triggered pipeline for application %s", obj.pk)
@@ -67,11 +72,25 @@ class LoanApplicationAdmin(admin.ModelAdmin):
                     obj.pk,
                     exc,
                 )
-                PipelineDispatchOutbox.objects.get_or_create(
-                    application=obj,
-                    defaults={"last_error": str(exc)[:1000]},
-                )
-                LoanApplication.objects.filter(pk=obj.pk).update(status=LoanApplication.Status.QUEUE_FAILED)
+                try:
+                    PipelineDispatchOutbox.objects.get_or_create(
+                        application=obj,
+                        defaults={"last_error": str(exc)[:1000]},
+                    )
+                except Exception as outbox_exc:
+                    logger.exception(
+                        "Failed to record PipelineDispatchOutbox row for %s: %s",
+                        obj.pk,
+                        outbox_exc,
+                    )
+                try:
+                    LoanApplication.objects.filter(pk=obj.pk).update(status=LoanApplication.Status.QUEUE_FAILED)
+                except Exception as status_exc:
+                    logger.exception(
+                        "Failed to flip status to QUEUE_FAILED for %s: %s",
+                        obj.pk,
+                        status_exc,
+                    )
 
         transaction.on_commit(_dispatch)
 

--- a/backend/apps/loans/tests/test_admin.py
+++ b/backend/apps/loans/tests/test_admin.py
@@ -158,7 +158,11 @@ def test_get_form_keeps_applicant_required_on_change(admin_request, admin_user):
 
 
 def test_save_model_warns_when_applicant_has_no_email(admin_request, db):
-    """If the resolved applicant has no email, surface a warning so admin knows."""
+    """If the resolved applicant has no email, surface a warning so admin knows.
+
+    Tightened to assert exactly one message of warning level — defends against
+    any future change that adds duplicate or stray messages on this path.
+    """
     no_email_user = User.objects.create_user(
         username="noemail",
         password="test1234",
@@ -173,5 +177,38 @@ def test_save_model_warns_when_applicant_has_no_email(admin_request, db):
         _admin().save_model(admin_request, app, form=None, change=False)
 
     messages_storage = list(admin_request._messages)
-    assert any("no email on file" in str(m).lower() for m in messages_storage)
-    assert any("application queued" in str(m).lower() for m in messages_storage)
+    assert len(messages_storage) == 1, f"expected exactly 1 message, got {len(messages_storage)}: {messages_storage}"
+    only_msg = str(messages_storage[0]).lower()
+    assert "application queued" in only_msg
+    assert "no email on file" in only_msg
+
+
+def test_save_model_celery_failure_emits_no_warning_message(admin_request, admin_user):
+    """Regression guard: messages added inside the transaction.on_commit closure
+    are silently lost (MessageMiddleware has already serialized request._messages
+    by the time on_commit fires). The Celery-failure path must therefore NOT
+    add any message — failure visibility comes from the QUEUE_FAILED status flip.
+
+    Without this guard, a future contributor who tests against the on_commit
+    patch (which fires the closure synchronously) might re-introduce a warning
+    that 'works in tests' but disappears in production.
+    """
+    app = _make_app(applicant=admin_user)
+    mock_task = MagicMock()
+    mock_task.delay.side_effect = ConnectionError("broker down")
+
+    with (
+        patch("apps.agents.tasks.orchestrate_pipeline_task", mock_task),
+        patch("apps.loans.admin.transaction.on_commit", side_effect=lambda fn: fn()),
+    ):
+        _admin().save_model(admin_request, app, form=None, change=False)
+
+    messages_storage = list(admin_request._messages)
+    # Exactly one synchronous success message (added before on_commit). No
+    # extras from the closure.
+    assert len(messages_storage) == 1, (
+        f"expected exactly 1 message (synchronous success), got {len(messages_storage)}: {messages_storage}"
+    )
+    only_msg = str(messages_storage[0]).lower()
+    assert "application queued" in only_msg, "synchronous success message expected"
+    assert "failed" not in only_msg, "no failure verbiage — that signal goes via QUEUE_FAILED status, not messages"

--- a/backend/apps/loans/views.py
+++ b/backend/apps/loans/views.py
@@ -107,6 +107,10 @@ class LoanApplicationViewSet(viewsets.ModelViewSet):
             from apps.loans.models import PipelineDispatchOutbox
 
             def _dispatch():
+                # The outbox-record and status-flip each get their own try/except so a
+                # failure in one (e.g., DB lock on the outbox table) doesn't prevent
+                # the other from running. on_commit hooks must not raise — Django
+                # logs but there's no recovery path post-response.
                 try:
                     orchestrate_pipeline_task.delay(str(instance.pk))
                     logger.info("Auto-triggered pipeline for application %s", instance.pk)
@@ -116,11 +120,27 @@ class LoanApplicationViewSet(viewsets.ModelViewSet):
                         instance.pk,
                         exc,
                     )
-                    PipelineDispatchOutbox.objects.get_or_create(
-                        application=instance,
-                        defaults={"last_error": str(exc)[:1000]},
-                    )
-                    LoanApplication.objects.filter(pk=instance.pk).update(status=LoanApplication.Status.QUEUE_FAILED)
+                    try:
+                        PipelineDispatchOutbox.objects.get_or_create(
+                            application=instance,
+                            defaults={"last_error": str(exc)[:1000]},
+                        )
+                    except Exception as outbox_exc:
+                        logger.exception(
+                            "Failed to record PipelineDispatchOutbox row for %s: %s",
+                            instance.pk,
+                            outbox_exc,
+                        )
+                    try:
+                        LoanApplication.objects.filter(pk=instance.pk).update(
+                            status=LoanApplication.Status.QUEUE_FAILED
+                        )
+                    except Exception as status_exc:
+                        logger.exception(
+                            "Failed to flip status to QUEUE_FAILED for %s: %s",
+                            instance.pk,
+                            status_exc,
+                        )
 
             transaction.on_commit(_dispatch)
 

--- a/backend/tests/test_html_renderer.py
+++ b/backend/tests/test_html_renderer.py
@@ -355,6 +355,18 @@ def test_inner_max_width_600():
     assert "max-width:600px" in html
 
 
+def test_render_html_includes_outlook_bottom_radius():
+    """Body td carries border-radius:0 0 8px 8px so Outlook's MSO renderer
+    (which doesn't honor table-level border-radius) still gets rounded
+    bottom corners. Regression guard against silently dropping the
+    declaration during refactors that auto-regenerate snapshots."""
+    for email_type in ("approval", "denial", "marketing"):
+        html = render_html("Dear John,\n\nHello.\n", email_type=email_type)
+        assert "border-radius:0 0 8px 8px" in html, (
+            f"{email_type}: body td must carry bottom border-radius for Outlook clients"
+        )
+
+
 # ----------------------------------------------------------------------------
 # Gmail-safe lint hardening (PR 6 Task 6.3)
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to PR #167 addressing the actionable findings from its post-merge self-review. Two atomic commits:

### Commit 1 — `fix(robustness)`: independent try/except around outbox + status flip

Both `loans/admin.py:save_model._dispatch` (added in PR #166) and `loans/views.py:73 perform_create._dispatch` (since first written) had a flat exception flow inside the on_commit closure: if `delay()` raised, `PipelineDispatchOutbox.objects.get_or_create()` and `LoanApplication.objects.update(status=QUEUE_FAILED)` ran sequentially with no isolation. A failure in either (e.g., DB lock contention on the outbox table during a worker storm) would propagate out, abort the on_commit hook, and leave the application on `pending` with no outbox row — invisible to operators.

Both call sites now have independent try/except around the outbox-record and status-flip operations. Worst-case degradation is log lines without DB side effects; the outbox retry worker (`loans/tasks.py:retry_dispatch_outbox`) eventually re-attempts based on row age, so an admin-visible state mismatch is recoverable.

### Commit 2 — `test(admin+email)`: 3 regression guards

- `test_render_html_includes_outlook_bottom_radius` — asserts the body td carries `border-radius:0 0 8px 8px` for all three email types (PR #167 added this for Outlook clients that don't honor table-level border-radius). Catches refactors that silently regenerate snapshots while losing the declaration.
- `test_save_model_celery_failure_emits_no_warning_message` — defends against re-introducing a `messages.warning(...)` inside the on_commit closure. Such a warning passes tests (which patch `on_commit` to fire synchronously) but vanishes in production because `MessageMiddleware` has already serialized `request._messages` by then.
- Tightened `test_save_model_warns_when_applicant_has_no_email` from loose substring `any(...)` to a strict `len == 1` invariant + content match.

## Test plan

- [x] `ruff check backend/` — clean
- [x] `ruff format --check backend/` — 364 files already formatted
- [x] `pytest backend/tests/test_html_renderer.py` — 73/73 pass (was 72 before this PR)
- [x] Cross-language Py↔TS parity unaffected (no renderer logic change, just an additive test)
- [ ] Admin tests verified by CI (DB-bound)
- [ ] CI green on master target

🤖 Generated with [Claude Code](https://claude.com/claude-code)