### PR TITLE
fix(ui): uniform card borders — symmetric gradient ring

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -118,13 +118,19 @@
   .gradient-border {
     position: relative;
   }
+  /* 1px brand-tinted ring rendered via padding+mask trick. The gradient stops
+     are kept at consistent opacity around the full perimeter so the ring is
+     visually uniform on every side — earlier the gradient faded to transparent
+     at one corner, leaving the bottom-right of every card visibly thinner /
+     less colored than the top-left. Use this in place of (not in addition to)
+     Tailwind's `border` class so we don't stack two 1px rings. */
   .gradient-border::before {
     content: '';
     position: absolute;
     inset: 0;
     border-radius: inherit;
     padding: 1px;
-    background: linear-gradient(145deg, rgba(99,102,241,0.15), rgba(139,92,246,0.08), transparent);
+    background: linear-gradient(145deg, rgba(99,102,241,0.18) 0%, rgba(139,92,246,0.14) 50%, rgba(99,102,241,0.18) 100%);
     -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
     mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
     -webkit-mask-composite: xor;

--- a/frontend/src/components/dashboard/StatsCards.tsx
+++ b/frontend/src/components/dashboard/StatsCards.tsx
@@ -58,7 +58,7 @@ export function StatsCards({ totalApplications, approvalRate, avgProcessingTime,
       {stats.map((stat) => (
         <div
           key={stat.title}
-          className="group relative rounded-xl border bg-white p-5 sheen-card gradient-border"
+          className="group relative rounded-xl bg-white p-5 sheen-card gradient-border"
         >
           <div className="flex items-start justify-between">
             <div className="space-y-2">

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils"
 
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("rounded-xl border bg-card text-card-foreground sheen-card gradient-border", className)} {...props} />
+    <div ref={ref} className={cn("rounded-xl bg-card text-card-foreground sheen-card gradient-border", className)} {...props} />
   )
 )
 Card.displayName = "Card"


### PR DESCRIPTION
## Summary

Reported issue: card outline borders looked uneven across the dashboard — top-left edge of every card appeared darker/purple-tinted while bottom-right edge appeared plain gray.

## Root cause

Two stacking issues in `frontend/src/app/globals.css` + `frontend/src/components/ui/card.tsx`:

1. **Asymmetric gradient.** `.gradient-border::before` used `linear-gradient(145deg, rgba(99,102,241,0.15), rgba(139,92,246,0.08), transparent)` — the third stop is fully transparent, so the bottom-right of every card had no gradient overlay at all while the top-left had a 15% indigo tint. With `145deg` the asymmetry was visible on every card with the naked eye.

2. **Two overlapping 1px rings.** The `Card` component stacked tailwind's `border` (1px gray ring on the outer edge of border-box) AND `.gradient-border` (1px tinted ring rendered via padding+mask trick on the inner edge of padding-box). The two rings sit at slightly different positions, so subpixel rounding made some edges visibly thicker than others.

## Fix

1. **`globals.css`** — rewrote the gradient with consistent-opacity stops: `linear-gradient(145deg, rgba(99,102,241,0.18) 0%, rgba(139,92,246,0.14) 50%, rgba(99,102,241,0.18) 100%)`. Same brand tint, same direction, but no transparent terminus — the ring renders uniformly on every side.
2. **`card.tsx` + `StatsCards.tsx`** — dropped the redundant tailwind `border` class. Since `.gradient-border` already provides the 1px ring, the underlying tailwind border was just creating subpixel noise.

Added an explanatory comment on `.gradient-border::before` so this doesn't get accidentally re-broken.

## Verified visually

Spun up `next dev`, screenshotted `/dashboard`, `/dashboard/applications`, and `/dashboard/customers`. All cards (stats cards, donut-chart card, recent-applications table card, applications-list table card, customers-list card) now show a uniform border on all four sides with the subtle indigo brand tint applied evenly.

## Test plan

- [x] `npm run lint` — 0 errors on touched files (8 pre-existing warnings elsewhere, unrelated)
- [x] `npm test` — 321/321 across 42 files
- [x] Visual confirmation across 3 dashboard routes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)