### PR TITLE
fix(ml): close codex adversarial review findings (gates + dossier)

### DIFF
--- a/backend/apps/ml_engine/management/commands/backfill_psi_by_feature.py
+++ b/backend/apps/ml_engine/management/commands/backfill_psi_by_feature.py
@@ -1,0 +1,116 @@
+"""Backfill training_metadata.psi_by_feature on existing model versions.
+
+Models trained before the trainer's psi_by_feature mirror landed have
+empty `mv.training_metadata.psi_by_feature`, so the dossier prints
+"No PSI data recorded" even when reference distributions exist in the
+bundle. This command computes per-feature PSI between the bundle's
+stored feature_distributions (training reference) and a fresh
+DataGenerator batch (the proxy for "current" data), and writes the
+result into mv.training_metadata.psi_by_feature.
+
+Idempotent — refuses to overwrite without --force.
+"""
+
+import joblib
+import pandas as pd
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.ml_engine.models import ModelVersion
+from apps.ml_engine.services.metrics import psi_by_feature
+from apps.ml_engine.services.prediction_cache import _validate_model_path
+
+
+class Command(BaseCommand):
+    help = "Backfill ModelVersion.training_metadata.psi_by_feature for models that pre-date the trainer mirror."
+
+    def add_arguments(self, parser):
+        target = parser.add_mutually_exclusive_group(required=True)
+        target.add_argument("--model-id", type=str, help="UUID of a specific ModelVersion to backfill.")
+        target.add_argument("--all-active", action="store_true", help="Backfill every is_active=True ModelVersion.")
+        parser.add_argument(
+            "--sample", type=int, default=5000,
+            help="DataGenerator sample size used as the 'current' frame for PSI (default 5000).",
+        )
+        parser.add_argument(
+            "--force", action="store_true",
+            help="Overwrite existing training_metadata.psi_by_feature. Default refuses.",
+        )
+
+    def handle(self, *args, **options):
+        if options["all_active"]:
+            targets = list(ModelVersion.objects.filter(is_active=True))
+        else:
+            try:
+                targets = [ModelVersion.objects.get(id=options["model_id"])]
+            except ModelVersion.DoesNotExist:
+                raise CommandError(f"ModelVersion {options['model_id']} not found")
+
+        if not targets:
+            self.stdout.write("No matching models found.")
+            return
+
+        for mv in targets:
+            self._backfill_one(mv, options["sample"], options["force"])
+
+    def _backfill_one(self, mv: ModelVersion, sample_size: int, force: bool) -> None:
+        from apps.ml_engine.services.data_generator import DataGenerator
+        from apps.ml_engine.services.predictor import ModelPredictor
+
+        meta = dict(mv.training_metadata or {})
+        if meta.get("psi_by_feature") and not force:
+            self.stdout.write(
+                f"[skip] {mv.algorithm} v{mv.version}: psi_by_feature already populated; "
+                f"pass --force to overwrite."
+            )
+            return
+
+        try:
+            bundle_path = _validate_model_path(mv.file_path)
+        except (ValueError, FileNotFoundError) as exc:
+            raise CommandError(f"Bundle path invalid for {mv.id}: {exc}")
+
+        bundle = joblib.load(bundle_path)
+        ref_dist = bundle.get("reference_distribution") or {}
+        feature_distributions = ref_dist.get("feature_distributions") or {}
+        if not feature_distributions:
+            raise CommandError(
+                f"Bundle for {mv.id} has no feature_distributions in reference_distribution; "
+                f"run backfill_reference_distribution first."
+            )
+
+        train_df = pd.DataFrame({col: vals for col, vals in feature_distributions.items()})
+
+        gen_df = DataGenerator().generate(num_records=sample_size, random_seed=42, label_noise_rate=0.05)
+        for target_col in ("default_flag", "approved", "is_default"):
+            if target_col in gen_df.columns:
+                gen_df = gen_df.drop(columns=[target_col])
+
+        try:
+            predictor = ModelPredictor(model_version=mv)
+        except Exception as exc:
+            raise CommandError(f"Could not load predictor for {mv.id}: {exc}")
+
+        try:
+            current_df = predictor._transform(gen_df.copy())
+        except Exception as exc:
+            raise CommandError(f"Feature transformation failed for {mv.id}: {exc}")
+
+        feature_cols = [c for c in feature_distributions.keys() if c in current_df.columns]
+        if not feature_cols:
+            raise CommandError(
+                f"No overlap between bundle feature_distributions and predictor output for {mv.id}; "
+                f"cannot compute PSI."
+            )
+
+        try:
+            psi_map = psi_by_feature(train_df, current_df, feature_cols)
+        except Exception as exc:
+            raise CommandError(f"psi_by_feature computation failed for {mv.id}: {exc}")
+
+        meta["psi_by_feature"] = psi_map
+        mv.training_metadata = meta
+        mv.save(update_fields=["training_metadata"])
+
+        self.stdout.write(self.style.SUCCESS(
+            f"[ok] {mv.algorithm} v{mv.version}: wrote psi_by_feature with {len(psi_map)} feature columns"
+        ))

--- a/backend/apps/ml_engine/services/mrm_compliance.py
+++ b/backend/apps/ml_engine/services/mrm_compliance.py
@@ -44,8 +44,14 @@ def _compliance_status(mv) -> tuple[str, list[str]]:
 
     fairness = mv.fairness_metrics or {}
     psi_map = (mv.training_metadata or {}).get("psi_by_feature") or {}
+    decile_analysis = mv.decile_analysis or {}
     calibration = mv.calibration_data or {}
-    deciles = calibration.get("deciles") or calibration.get("decile_analysis") or []
+    deciles = (
+        decile_analysis.get("deciles")
+        or calibration.get("deciles")
+        or calibration.get("decile_analysis")
+        or []
+    )
 
     failed_attrs: list[str] = []
     for attr, data in fairness.items():

--- a/backend/apps/ml_engine/services/mrm_dossier.py
+++ b/backend/apps/ml_engine/services/mrm_dossier.py
@@ -244,17 +244,26 @@ def _calibration_section(mv) -> str:
             "emits `decile_analysis.deciles` on every run."
         )
 
-    rows = ["| Decile | Expected PD | Observed default rate | n |", "|---|---|---|---|"]
-    for i, row in enumerate(deciles, start=1):
-        if isinstance(row, dict):
-            exp = row.get("expected") or row.get("predicted_rate") or row.get("mean_pred") or row.get("predicted_default_rate")
-            obs = row.get("observed") or row.get("observed_rate") or row.get("default_rate") or row.get("actual_default_rate")
-            n = row.get("n") or row.get("count") or "—"
-        else:
-            exp = obs = n = "—"
-        exp_s = f"{exp:.4f}" if isinstance(exp, (int, float)) else str(exp)
-        obs_s = f"{obs:.4f}" if isinstance(obs, (int, float)) else str(obs)
-        rows.append(f"| {i} | {exp_s} | {obs_s} | {n} |")
+    rows = ["| Decile | Actual default rate | Cumulative rate | Lift | n |",
+            "|---|---|---|---|---|"]
+    for row in deciles:
+        if not isinstance(row, dict):
+            rows.append("| — | — | — | — | — |")
+            continue
+        decile_idx = row.get("decile") or row.get("rank") or "—"
+        actual = (
+            row.get("actual_rate")
+            or row.get("observed")
+            or row.get("observed_rate")
+            or row.get("default_rate")
+        )
+        cum = row.get("cumulative_rate") or row.get("cumulative")
+        lift = row.get("lift")
+        n = row.get("count") or row.get("n") or "—"
+        actual_s = f"{actual:.4f}" if isinstance(actual, (int, float)) else "—"
+        cum_s = f"{cum:.4f}" if isinstance(cum, (int, float)) else "—"
+        lift_s = f"{lift:.4f}" if isinstance(lift, (int, float)) else "—"
+        rows.append(f"| {decile_idx} | {actual_s} | {cum_s} | {lift_s} | {n} |")
     return "## 6. Calibration report\n\n" + "\n".join(rows)
 
 

--- a/backend/apps/ml_engine/services/mrm_dossier.py
+++ b/backend/apps/ml_engine/services/mrm_dossier.py
@@ -229,20 +229,26 @@ def _performance_section(mv) -> str:
 
 def _calibration_section(mv) -> str:
     """§6 — Calibration report (decile table)."""
+    decile_analysis = mv.decile_analysis or {}
     calibration = mv.calibration_data or {}
-    deciles = calibration.get("deciles") or calibration.get("decile_analysis") or []
+    deciles = (
+        decile_analysis.get("deciles")
+        or calibration.get("deciles")
+        or calibration.get("decile_analysis")
+        or []
+    )
     if not deciles:
         return (
             "## 6. Calibration report\n\n"
             "Decile calibration not recorded. Re-train with v1.9.0+ trainer which "
-            "emits `calibration_data.deciles` on every run."
+            "emits `decile_analysis.deciles` on every run."
         )
 
     rows = ["| Decile | Expected PD | Observed default rate | n |", "|---|---|---|---|"]
     for i, row in enumerate(deciles, start=1):
         if isinstance(row, dict):
-            exp = row.get("expected") or row.get("predicted_rate") or row.get("mean_pred")
-            obs = row.get("observed") or row.get("observed_rate") or row.get("default_rate")
+            exp = row.get("expected") or row.get("predicted_rate") or row.get("mean_pred") or row.get("predicted_default_rate")
+            obs = row.get("observed") or row.get("observed_rate") or row.get("default_rate") or row.get("actual_default_rate")
             n = row.get("n") or row.get("count") or "—"
         else:
             exp = obs = n = "—"

--- a/backend/apps/ml_engine/services/mrm_dossier.py
+++ b/backend/apps/ml_engine/services/mrm_dossier.py
@@ -78,7 +78,6 @@ def _header_section(mv) -> str:
         f"- **Training duration:** {training_meta.get('training_seconds', 'unknown')}s",
         f"- **Training samples:** {training_meta.get('n_training_samples', 'unknown')}",
         f"- **Class balance (positive rate):** {training_meta.get('positive_rate', 'unknown')}",
-        f"- **Active:** {mv.is_active}",
         f"- **Compliance status:** {status}",
     ]
     for reason in reasons:
@@ -336,7 +335,7 @@ def _policy_section(mv) -> str:
         "## 9. Policy overlay reference\n\n"
         + "\n".join(rows)
         + "\n\nCurrent overlay mode is read from `CREDIT_POLICY_OVERLAY_MODE` "
-        "(off / shadow / enforce); default is `shadow`."
+        "(off / shadow / enforce). See §2 for the mode this dossier was generated under."
     )
 
 

--- a/backend/apps/ml_engine/services/trainer.py
+++ b/backend/apps/ml_engine/services/trainer.py
@@ -1016,6 +1016,7 @@ class ModelTrainer:
             "iv_features_selected": len(getattr(self, "_iv_result", {}).get("selected_features", [])),
             "iv_features_excluded_weak": len(getattr(self, "_iv_result", {}).get("excluded_weak", [])),
             "iv_features_excluded_leakage": len(getattr(self, "_iv_result", {}).get("excluded_leakage", [])),
+            "psi_by_feature": dict(metrics.get("psi_by_feature") or {}),
             "reference_probabilities": list(getattr(self, "_holdout_probabilities", []) or []),
             **split_meta,
         }

--- a/backend/apps/ml_engine/tests/test_mrm_dossier.py
+++ b/backend/apps/ml_engine/tests/test_mrm_dossier.py
@@ -55,10 +55,11 @@ def _make_mv(**overrides):
             "gender": {"disparate_impact_ratio": 0.92, "passes_80_percent_rule": True},
             "age_group": {"disparate_impact_ratio": 0.78, "passes_80_percent_rule": False},
         },
-        calibration_data={
+        calibration_data={},
+        decile_analysis={
             "deciles": [
-                {"expected": 0.05, "observed": 0.04, "n": 1000},
-                {"expected": 0.15, "observed": 0.16, "n": 1000},
+                {"decile": 1, "actual_rate": 0.04, "cumulative_rate": 0.04, "lift": 0.18, "n": 1000},
+                {"decile": 2, "actual_rate": 0.16, "cumulative_rate": 0.10, "lift": 0.72, "n": 1000},
             ]
         },
         retraining_policy={"cadence_days": 90, "min_samples": 10000, "max_psi_before_retrain": 0.25},
@@ -172,7 +173,7 @@ def test_missing_fairness_metrics_renders_guidance():
 def test_missing_calibration_renders_guidance():
     from apps.ml_engine.services.mrm_dossier import generate_dossier_markdown
 
-    mv = _make_mv(calibration_data={})
+    mv = _make_mv(calibration_data={}, decile_analysis={})
     with patch("apps.ml_engine.services.mrm_dossier._changelog_section") as _cl:
         _cl.return_value = "## 11. Change log\n\n(stub)"
         md = generate_dossier_markdown(mv)
@@ -268,18 +269,39 @@ def test_monitoring_drift_url_uses_actual_route():
 # ---------------------------------------------------------------------------
 
 
-def test_purpose_section_default_mode_emits_shadow_wording():
-    """Default settings (no env override) → shadow wording, **not blocked**."""
+def test_purpose_section_default_mode_emits_enforce_wording():
+    """Default settings (no env override) → enforce wording.
+
+    The deployed default was flipped from `shadow` to `enforce` in
+    `b4789f2 fix(config): strict gate-mode defaults`. The dossier must
+    reflect actual runtime behaviour, not a stale default."""
     from apps.ml_engine.services.mrm_dossier import generate_dossier_markdown
 
     with patch("apps.ml_engine.services.mrm_dossier._changelog_section") as _cl:
         _cl.return_value = "## 11. Change log\n\n(stub)"
         md = generate_dossier_markdown(_make_compliant_mv())
 
-    assert "shadow" in md.lower()
-    assert "not blocked" in md
-    # The old unconditional mandate must not appear in shadow mode.
+    assert "`enforce` mode" in md
+    assert "blocked by the overlay" in md
+    # The old unconditional mandate must not appear regardless of mode.
     assert "must be treated as advisory" not in md
+
+
+def test_purpose_section_shadow_mode_emits_observational_wording():
+    """Explicit `shadow` mode → observational wording, **not blocked**."""
+    from django.test import override_settings
+
+    from apps.ml_engine.services.mrm_dossier import generate_dossier_markdown
+
+    with (
+        override_settings(CREDIT_POLICY_OVERLAY_MODE="shadow"),
+        patch("apps.ml_engine.services.mrm_dossier._changelog_section") as _cl,
+    ):
+        _cl.return_value = "## 11. Change log\n\n(stub)"
+        md = generate_dossier_markdown(_make_compliant_mv())
+
+    assert "`shadow` (observational) mode" in md
+    assert "not blocked" in md
 
 
 def test_purpose_section_enforce_mode_emits_mandatory_referral():
@@ -430,7 +452,7 @@ def test_compliance_status_needs_review_when_psi_missing():
 def test_compliance_status_needs_review_when_calibration_missing():
     from apps.ml_engine.services.mrm_compliance import _compliance_status
 
-    mv = _make_compliant_mv(calibration_data={})
+    mv = _make_compliant_mv(calibration_data={}, decile_analysis={})
     status, reasons = _compliance_status(mv)
     assert status == "NEEDS REVIEW"
     assert any("calibration" in r for r in reasons)
@@ -474,6 +496,52 @@ def test_document_subtitle_drops_alignment_keeps_format_reference():
     assert "alignment" not in subtitle, f"Subtitle still implies alignment: {subtitle!r}"
     assert "APRA CPS 220 / SR 11-7" in subtitle
     assert "Format:" in subtitle
+
+
+# ---------------------------------------------------------------------------
+# Dossier honesty — mutable runtime state must not leak into the static
+# snapshot. (Codex 2026-05-14 round-2 finding 2.)
+# ---------------------------------------------------------------------------
+
+
+def test_header_does_not_render_mutable_active_flag():
+    """`Active: <bool>` is mutable runtime state — a static dossier can't
+    represent it accurately once a successor model is promoted on the same
+    segment. The header must NOT include it; current is_active is read
+    from the DB, not from frozen markdown.
+    """
+    from apps.ml_engine.services.mrm_dossier import generate_dossier_markdown
+
+    with patch("apps.ml_engine.services.mrm_dossier._changelog_section") as _cl:
+        _cl.return_value = "## 11. Change log\n\n(stub)"
+        md_active = generate_dossier_markdown(_make_mv(is_active=True))
+        md_inactive = generate_dossier_markdown(_make_mv(is_active=False))
+
+    # Regression guard against both stale-state shapes.
+    assert "**Active:** True" not in md_active
+    assert "**Active:** False" not in md_inactive
+    # And the bare "Active:" label must be absent — it's the line we removed.
+    assert "- **Active:**" not in md_active
+    assert "- **Active:**" not in md_inactive
+
+
+def test_policy_section_does_not_hardcode_overlay_default():
+    """§9 used to claim `default is shadow` even after settings flipped to
+    `enforce`. The static dossier must not assert a default — the live mode
+    is correctly rendered in §2 from settings at generation time."""
+    from apps.ml_engine.services.mrm_dossier import generate_dossier_markdown
+
+    with patch("apps.ml_engine.services.mrm_dossier._changelog_section") as _cl:
+        _cl.return_value = "## 11. Change log\n\n(stub)"
+        md = generate_dossier_markdown(_make_compliant_mv())
+
+    # The line cited by Codex: "default is `shadow`." (or any other mode).
+    assert "default is `shadow`" not in md
+    assert "default is `enforce`" not in md
+    assert "default is `off`" not in md
+    # The env-var name and valid values must remain so readers know where to look.
+    assert "`CREDIT_POLICY_OVERLAY_MODE`" in md
+    assert "(off / shadow / enforce)" in md
 
 
 # ---------------------------------------------------------------------------

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -238,7 +238,7 @@ ML_XGB_N_JOBS = 2
 # to enforce. Unknown values collapse to "shadow" at read time so a
 # misconfigured deployment never silently downgrades responsible-lending
 # safeguards.
-CREDIT_POLICY_OVERLAY_MODE = os.environ.get("CREDIT_POLICY_OVERLAY_MODE", "shadow")
+CREDIT_POLICY_OVERLAY_MODE = os.environ.get("CREDIT_POLICY_OVERLAY_MODE", "enforce")
 
 # Pre-activation fairness gate mode for `train_model_task`. Three values:
 # "warn" (default — log + flag failures, leave model active; current
@@ -249,7 +249,7 @@ CREDIT_POLICY_OVERLAY_MODE = os.environ.get("CREDIT_POLICY_OVERLAY_MODE", "shado
 # the env var; flip to "block" only after validating the training pipeline
 # produces compliant fairness metrics for the segments in scope. See
 # docs/superpowers/specs/2026-05-07-ml-fairness-gate-mode-design.md.
-ML_FAIRNESS_GATE_MODE = os.environ.get("ML_FAIRNESS_GATE_MODE", "warn")
+ML_FAIRNESS_GATE_MODE = os.environ.get("ML_FAIRNESS_GATE_MODE", "block")
 
 # Pre-activation champion-challenger promotion gate mode for `train_model_task`.
 # Mirrors ML_FAIRNESS_GATE_MODE: "warn" (default — gates run, decision recorded
@@ -260,7 +260,7 @@ ML_FAIRNESS_GATE_MODE = os.environ.get("ML_FAIRNESS_GATE_MODE", "warn")
 # any deployment that doesn't set the env var; flip to "block" only after
 # validating the trainer produces compliant promotion metrics for the segments
 # in scope. See docs/superpowers/specs/2026-05-07-ml-promotion-gate-mode-design.md.
-ML_PROMOTION_GATE_MODE = os.environ.get("ML_PROMOTION_GATE_MODE", "warn")
+ML_PROMOTION_GATE_MODE = os.environ.get("ML_PROMOTION_GATE_MODE", "block")
 
 # D7 — MRM dossier auto-generation on ModelVersion post_save.
 # Enabled by default; disable in unit tests that create throwaway models.

--- a/backend/docs/RUNBOOK.md
+++ b/backend/docs/RUNBOOK.md
@@ -716,3 +716,47 @@ The seed command creates one synthetic `LoanApplication` per ModelVersion
 (deterministic username `seed_predictions_mv_<uuid>`, status `approved`)
 to satisfy the `PredictionLog.application` FK. The application is kept in
 a terminal status so it never enters the agents' pending-batch queue.
+
+## Strict gate defaults — when and how to relax
+
+The deployment defaults to enforcement on three model-governance gates:
+
+| Variable | Default | Effect when default is active |
+|---|---|---|
+| `ML_FAIRNESS_GATE_MODE` | `block` | A new training run that fails the 4/5ths fairness rule raises `FairnessGateBlocked` BEFORE atomic activation. Old segment model stays `is_active=True`. |
+| `ML_PROMOTION_GATE_MODE` | `block` | A new model that fails champion-challenger promotion gates (PSI / calibration / KS) is rejected pre-activation. |
+| `CREDIT_POLICY_OVERLAY_MODE` | `enforce` | Out-of-scope predictions (commercial lending, applicants outside AU residency, etc.) are routed to manual review automatically rather than silently scored. |
+
+### What you see when a gate fires
+
+The training task wrapper releases the lock and surfaces the blocked condition in:
+
+- Celery worker logs (`docker compose logs celery_worker_ml`)
+- Flower UI (`http://localhost:5555` → failed task with the gate exception class in the traceback)
+- `ModelVersion.training_metadata` on the most recent training run carries `fairness_gate_mode` / `promotion_gate_mode` plus the rejection reason
+
+### Decision tree when a real violation surfaces
+
+1. **Re-train with adjusted features.** Most fairness violations come from a single feature with strong protected-class correlation. Re-binning, dropping, or interacting it with a less-correlated feature usually clears the gate without sacrificing AUC.
+2. **Accept the violation explicitly.** If the violation is unavoidable for the segment (e.g. limited training data for a protected group), set the env var to `warn` for ONE training run, document the operator decision in the model's MRM dossier, then flip back to `block`.
+3. **Skip activation.** Train the model; do not promote. The blocked state is not destructive — the existing active model continues serving.
+
+### Emergency rollback
+
+If a gate misfires (false positive — e.g. a bug in the gate logic itself rather than a real violation), relax the relevant variable in `.env`:
+
+```bash
+ML_FAIRNESS_GATE_MODE=warn
+ML_PROMOTION_GATE_MODE=warn
+CREDIT_POLICY_OVERLAY_MODE=shadow
+```
+
+Restart the affected services:
+
+```bash
+docker compose restart backend celery_worker_ml
+```
+
+Confirm via `docker compose logs backend` that the new mode is active. Re-trigger the training run. Once the underlying issue is fixed, restore the env vars to enforcement defaults and restart again.
+
+See [`docs/superpowers/specs/2026-05-07-ml-fairness-gate-mode-design.md`](../../docs/superpowers/specs/2026-05-07-ml-fairness-gate-mode-design.md) for the gate-mode machinery internals.

--- a/backend/ml_models/1919919b-f142-4501-a8fe-ddc3243442ef/mrm.md
+++ b/backend/ml_models/1919919b-f142-4501-a8fe-ddc3243442ef/mrm.md
@@ -1,0 +1,196 @@
+# Model Risk Management Dossier — `1919919b-f142-4501-a8fe-ddc3243442ef`
+_Generated 2026-05-13T23:10:56Z — Format: APRA CPS 220 / SR 11-7_
+
+## 1. Header
+
+- **Model ID:** `1919919b-f142-4501-a8fe-ddc3243442ef`
+- **Algorithm:** XGBoost
+- **Version:** 20260508_111850
+- **Segment:** `unified`
+- **Trained at:** 2026-05-08T11:18:50.071863+00:00
+- **Training duration:** unknowns
+- **Training samples:** unknown
+- **Class balance (positive rate):** unknown
+- **Compliance status:** NON-COMPLIANT
+  - Fairness 80%-rule fails on: employment_type, state
+- **File hash (SHA-256):** `d60a5daf91275358451f210615c14f7b3ac3601f47daa3d507df9b48a65f32e6`
+
+## 2. Purpose & limitations
+
+General-purpose PD estimation across AU retail loan products. Not validated for: business lending, secured non-home lending, applicants outside AU residency, loans > $5M, loans with unusual repayment structures (balloon, interest-only > 5yr).
+
+All scope boundaries above reflect the training distribution. The policy overlay runs in `enforce` mode in this deployment. Out-of-scope predictions are blocked by the overlay and routed to manual underwriter review (see §9 P-codes).
+
+## 3. Data lineage
+
+- **Source:** synthetic (DataGenerator v1 + GMSC real-data benchmark)
+- **Synthetic vs real:** synthetic
+- **Class balance (positive rate):** unknown
+- **Reject-inference usage:** not applied
+- **Temporal coverage:** unknown → unknown
+
+Reject-inference is not applied for this version; the accept-only training distribution is a known bias risk and is mitigated through ongoing PSI monitoring (§10) + quarterly challenger retraining.
+
+## 4. Monotonicity constraint table
+
+| Feature | Sign | Rationale |
+|---|---|---|
+| `annual_income` | +1 (↑) | Higher income increases serviceability — core AU responsible-lending assumption. |
+| `avg_monthly_savings_rate` | +1 (↑) | Positive savings rate demonstrates cash-flow surplus. |
+| `consumer_confidence` | +1 (↑) | Higher macro confidence lowers tail-event probability during loan term. |
+| `credit_history_months` | +1 (↑) | More history = thicker file; thin files penalised across AU bureaux. |
+| `credit_score` | +1 (↑) | Higher Equifax score indicates lower historical default probability. |
+| `debt_service_coverage` | +1 (↑) | DSCR > 1 means income covers repayments with buffer; linear in safety. |
+| `deposit_amount` | +1 (↑) | Larger deposit reduces LVR and demonstrates savings discipline. |
+| `deposit_ratio` | +1 (↑) | deposit / loan_amount — direct proxy for equity skin-in-the-game. |
+| `document_consistency_score` | +1 (↑) | Consistent docs = lower fraud risk; monotone in data quality. |
+| `employment_length` | +1 (↑) | Longer tenure proxies income stability; CBA/NAB scorecards apply length floors. |
+| `financial_literacy_score` | +1 (↑) | Higher literacy = better decision making; TMD-aligned protective factor. |
+| `has_cosigner` | +1 (↑) | Guarantor increases recovery pool; monotonically safer. |
+| `hem_surplus` | +1 (↑) | Income − HEM floor; larger surplus = more serviceability headroom. |
+| `income_per_dependant` | +1 (↑) | More income per dependant = more discretionary buffer. |
+| `income_source_count` | +1 (↑) | Income diversification reduces concentration risk on a single employer. |
+| `income_verification_score` | +1 (↑) | CDR/Basiq-confirmed income is strictly safer than self-attested. |
+| `is_existing_customer` | +1 (↑) | Known customer behaviour is strictly more informative than acquired-unknown. |
+| `log_annual_income` | +1 (↑) | Log transform of annual_income; monotone transform, same sign as source. |
+| `months_since_last_default` | +1 (↑) | Longer since default = more recovery evidence; monotone in safety. |
+| `net_monthly_surplus` | +1 (↑) | Income − expenses; foundational serviceability quantity. |
+| `prepayment_buffer_months` | +1 (↑) | Months of repayments already paid ahead reduces imminent default risk. |
+| `property_value` | +1 (↑) | Higher collateral value reduces LGD for secured lending (APS 112). |
+| `rent_payment_regularity` | +1 (↑) | Consistent rent payments predict mortgage payment consistency. |
+| `salary_credit_regularity` | +1 (↑) | Regular salary credits confirm employment reality, reduce income-fabrication risk. |
+| `savings_balance` | +1 (↑) | Larger liquid buffer lowers short-term default risk during shocks. |
+| `savings_to_loan_ratio` | +1 (↑) | More savings relative to loan = more shock-absorption capacity. |
+| `serviceability_ratio` | +1 (↑) | Aggregated serviceability score; direction matches individual drivers. |
+| `uncommitted_monthly_income` | +1 (↑) | After fixed commitments; larger = more affordability buffer. |
+| `utility_payment_regularity` | +1 (↑) | Consistent utility payments are a cheap positive signal in thin files. |
+| `bnpl_active_count` | −1 (↓) | Active BNPL accounts duplicate num_bnpl_accounts signal; same sign. |
+| `bnpl_late_payments_12m` | −1 (↓) | BNPL late payments predict revolving-credit late payments. |
+| `bnpl_monthly_commitment` | −1 (↓) | Monthly BNPL scheduled repayments; direct expense. |
+| `bnpl_total_limit` | −1 (↓) | Total BNPL exposure; larger = more hidden serviceability drag. |
+| `bnpl_utilization_pct` | −1 (↓) | BNPL used ÷ limit; high use signals liquidity stress. |
+| `bureau_risk_score` | −1 (↓) | Higher bureau risk score = more recently adverse activity. |
+| `cash_advance_count_12m` | −1 (↓) | Cash advances indicate short-term liquidity stress; high rate-cost. |
+| `credit_card_burden` | −1 (↓) | Derived: card limits / income; same direction as limits. |
+| `credit_utilization_pct` | −1 (↓) | Above 70% utilisation is a top-3 bureau-score negative in AU. |
+| `days_in_overdraft_12m` | −1 (↓) | More days negative = tighter cash-flow margin; monotone worse. |
+| `days_negative_balance_90d` | −1 (↓) | Recent days in negative balance = cashflow fragility. |
+| `debt_to_income` | −1 (↓) | APRA limits above DTI=6; higher = less serviceability (APS 220 focus). |
+| `effective_loan_amount` | −1 (↓) | Loan + LMI (what actually appears on the mortgage); same direction as loan_amount. |
+| `enquiry_intensity` | −1 (↓) | Enquiries per open account; high velocity = shopping-for-credit stress. |
+| `essential_to_total_spend` | −1 (↓) | Higher essentials ratio = less discretionary buffer to cut. |
+| `existing_credit_card_limit` | −1 (↓) | More unused revolving limit inflates stressed serviceability commitments. |
+| `expense_to_income` | −1 (↓) | Mechanical ratio; more expense per dollar of income = less slack. |
+| `gambling_spend_ratio` | −1 (↓) | Gambling share of spend is a direct negative; mirrors AFCA guidance. |
+| `gambling_transaction_flag` | −1 (↓) | AFCA 2023: gambling spend is a responsible-lending red flag. |
+| `has_bankruptcy` | −1 (↓) | Bankruptcy is a hard-fail predictor historically; monotone worse. |
+| `hecs_debt_balance` | −1 (↓) | HECS balance proxies future HELP repayment; higher = more drag. |
+| `help_repayment_monthly` | −1 (↓) | HELP/HECS repayment reduces post-tax serviceability income. |
+| `hem_gap` | −1 (↓) | Negative gap means HEM > income (hard-fail); magnitude monotonic in severity. |
+| `income_verification_gap` | −1 (↓) | Mismatch between stated and verified income; higher = higher fraud risk. |
+| `lmi_premium` | −1 (↓) | LMI charged only above 80% LVR; higher = higher-LVR loan = riskier. |
+| `loan_amount` | −1 (↓) | Larger loans = larger repayment shocks under stress. |
+| `loan_to_income` | −1 (↓) | Higher LTI = less room for income shocks; NAB LTI cap 9×. |
+| `log_loan_amount` | −1 (↓) | Log transform of loan_amount; monotone transform, same sign. |
+| `lvr` | −1 (↓) | Key secured-lending risk variable; APRA flags LVR > 80% and LMI-required bands. |
+| `lvr_x_dti` | −1 (↓) | Interaction of two negative drivers; sign is the product: negative. |
+| `monthly_expenses` | −1 (↓) | Higher declared expenses reduce serviceability surplus. |
+| `monthly_rent` | −1 (↓) | Current rent is effectively baseline housing commitment; larger = less surplus. |
+| `num_bnpl_accounts` | −1 (↓) | More BNPL accounts = more hidden commitments (CCR gap; 2024 ASIC concern). |
+| `num_credit_enquiries_6m` | −1 (↓) | Shopping intensity signals financial stress; > 6 enquiries is a red flag. |
+| `num_defaults_5yr` | −1 (↓) | Historical defaults are the strongest negative signal in bureau scoring. |
+| `num_dishonours_12m` | −1 (↓) | Dishonours indicate cash-flow failures; AFCA/Basiq flags these as leading indicators. |
+| `num_hardship_flags` | −1 (↓) | AFCA/ASIC 2023 guidance: hardship history is materially negative. |
+| `num_late_payments_24m` | −1 (↓) | CCR-era late payments directly predict future default. |
+| `number_of_dependants` | −1 (↓) | More dependants = more baseline expenses (HEM scales with dependants). |
+| `overdraft_frequency_90d` | −1 (↓) | Frequent overdraft = recurring cash-flow fragility. |
+| `postcode_default_rate` | −1 (↓) | Geographic concentration risk; higher area default rate = worse tail. |
+| `stress_index` | −1 (↓) | Aggregated stress score; direction matches its component drivers. |
+| `stressed_dsr` | −1 (↓) | DSR at stressed rate; higher = less buffer against RBA hikes (APS 220). |
+| `stressed_repayment` | −1 (↓) | Repayment at assessed-rate; higher = more monthly burden under stress. |
+| `subscription_burden` | −1 (↓) | Sticky subscriptions reduce flex to cut expenses under stress. |
+| `unemployment_rate` | −1 (↓) | Macro unemployment tail-risk correlates with individual default. |
+| `worst_arrears_months` | −1 (↓) | More months in arrears = stronger recent negative evidence. |
+| `worst_late_payment_days` | −1 (↓) | Severity of worst late-payment episode; more days = worse. |
+
+## 5. Performance
+
+Evaluated on hold-out test set (20% of training data):
+
+- **AUC-ROC:** 0.8709
+- **KS statistic:** 0.6420
+- **Brier score (pointwise):** 0.1371
+- **ECE (15-bin):** 0.0337
+
+**Temporal cross-validation:** not recorded
+
+**Baseline logistic-regression gap:** not measured
+
+KS > 0.30 and AUC > 0.75 are the regulator-expected performance floor for AU retail-credit scorecards. Champion-challenger promotion gates exist in `model_selector.py` (PSI, calibration, KS); the current activation path in `tasks.py` activates new models directly, so confirm pre-promotion review for production deployments before relying on these gates.
+
+## 6. Calibration report
+
+| Decile | Actual default rate | Cumulative rate | Lift | n |
+|---|---|---|---|---|
+| 1 | 0.1227 | 0.1227 | 0.2169 | 864 |
+| 2 | 0.2060 | 0.1644 | 0.3642 | 864 |
+| 3 | 0.2627 | 0.1971 | 0.4645 | 864 |
+| 4 | 0.2697 | 0.2153 | 0.4768 | 864 |
+| 5 | 0.3889 | 0.2500 | 0.6875 | 864 |
+| 6 | 0.7014 | 0.3252 | 1.2400 | 864 |
+| 7 | 0.8773 | 0.4041 | 1.5511 | 864 |
+| 8 | 0.9259 | 0.4693 | 1.6370 | 864 |
+| 9 | 0.9479 | 0.5225 | 1.6759 | 864 |
+| 10 | 0.9537 | 0.5656 | 1.6861 | 864 |
+
+## 7. PSI by feature
+
+No PSI data recorded. Train with v1.9.9+ trainer — it emits `training_metadata.psi_by_feature` (train vs test) on every run.
+
+## 8. Fairness audit
+
+| Protected attribute | DI ratio | 80%-rule passes |
+|---|---|---|
+| `state` | 0.7736 | False |
+| `applicant_type` | 0.8956 | True |
+| `employment_type` | 0.7206 | False |
+
+Cross-reference `intersectional_fairness.py` output in `training_metadata.intersectional_fairness` for two-way slices.
+
+## 9. Policy overlay reference
+
+| Code | Severity | Description |
+|---|---|---|
+| P01 | hard_fail | Non-resident / ineligible visa (bridging/student/tourist) — decline |
+| P02 | hard_fail | Applicant age < 18 or age at maturity > 75 |
+| P03 | hard_fail | Undischarged bankruptcy or within 7yr window — decline |
+| P04 | hard_fail | Active ATO tax-debt default flag — decline |
+| P05 | hard_fail | Credit score below floor 450 — decline |
+| P06 | hard_fail | LVR > 95% owner-occupier or ≥ 100% any — decline |
+| P07 | hard_fail | DTI exceeds APRA intervention ceiling 8.0× — decline |
+| P08 | refer | LTI > 9× — refer to manual underwriting |
+| P09 | refer | Postcode default rate > 8% — geographic concentration review |
+| P10 | refer | Self-employed with < 24mo trading history — refer |
+| P11 | refer | Hardship flag(s) on file — AFCA 2023 mandates human review |
+| P12 | refer | Personal loan > $50k TMD band — refer to TMD-aware underwriting |
+
+Current overlay mode is read from `CREDIT_POLICY_OVERLAY_MODE` (off / shadow / enforce). See §2 for the mode this dossier was generated under.
+
+## 10. Ongoing monitoring plan
+
+- **Retraining cadence:** every 90 days minimum.
+- **Minimum fresh samples before retrain:** 10000
+- **PSI alert threshold:** 0.25 (per-feature); cumulative PSI > 0.5 triggers retrain.
+- **ECE re-validation cadence:** quarterly.
+- **KS regression trigger:** drop > 5pp vs champion baseline triggers retrain.
+- **Fairness audit cadence:** every training run pre-promotion (see fairness_gate.py).
+- **Drift dashboard:** `/api/v1/ml/models/active/drift/` (weekly DriftReport cron).
+
+## 11. Change log
+
+Comparison vs previous ModelVersion on segment `unified`: `25356f34-dfb4-4a7c-882c-754a90183ee6` (v20260508_194730).
+
+- **AUC-ROC:** 0.8709 vs 0.8709 (→0.0000)
+- **KS:** 0.6420 vs 0.6420 (→0.0000)
+- **Brier:** 0.1371 vs 0.1371 (→0.0000)
+- **ECE:** 0.0337 vs 0.0337 (→0.0000)

--- a/backend/ml_models/1c21d19b-f1a9-43ce-a115-fdef602d410d/mrm.md
+++ b/backend/ml_models/1c21d19b-f1a9-43ce-a115-fdef602d410d/mrm.md
@@ -1,0 +1,276 @@
+# Model Risk Management Dossier — `1c21d19b-f1a9-43ce-a115-fdef602d410d`
+_Generated 2026-05-13T23:10:59Z — Format: APRA CPS 220 / SR 11-7_
+
+## 1. Header
+
+- **Model ID:** `1c21d19b-f1a9-43ce-a115-fdef602d410d`
+- **Algorithm:** XGBoost
+- **Version:** 20260508_174941
+- **Segment:** `unified`
+- **Trained at:** 2026-05-08T17:49:41.356878+00:00
+- **Training duration:** unknowns
+- **Training samples:** unknown
+- **Class balance (positive rate):** unknown
+- **Compliance status:** NON-COMPLIANT
+  - Fairness 80%-rule fails on: employment_type, state
+- **File hash (SHA-256):** `06bd68842ebc503cd15ed005877cd088659e2a9e5aea4bd4604e0725231b801d`
+
+## 2. Purpose & limitations
+
+General-purpose PD estimation across AU retail loan products. Not validated for: business lending, secured non-home lending, applicants outside AU residency, loans > $5M, loans with unusual repayment structures (balloon, interest-only > 5yr).
+
+All scope boundaries above reflect the training distribution. The policy overlay runs in `enforce` mode in this deployment. Out-of-scope predictions are blocked by the overlay and routed to manual underwriter review (see §9 P-codes).
+
+## 3. Data lineage
+
+- **Source:** synthetic (DataGenerator v1 + GMSC real-data benchmark)
+- **Synthetic vs real:** synthetic
+- **Class balance (positive rate):** unknown
+- **Reject-inference usage:** not applied
+- **Temporal coverage:** unknown → unknown
+
+Reject-inference is not applied for this version; the accept-only training distribution is a known bias risk and is mitigated through ongoing PSI monitoring (§10) + quarterly challenger retraining.
+
+## 4. Monotonicity constraint table
+
+| Feature | Sign | Rationale |
+|---|---|---|
+| `annual_income` | +1 (↑) | Higher income increases serviceability — core AU responsible-lending assumption. |
+| `avg_monthly_savings_rate` | +1 (↑) | Positive savings rate demonstrates cash-flow surplus. |
+| `consumer_confidence` | +1 (↑) | Higher macro confidence lowers tail-event probability during loan term. |
+| `credit_history_months` | +1 (↑) | More history = thicker file; thin files penalised across AU bureaux. |
+| `credit_score` | +1 (↑) | Higher Equifax score indicates lower historical default probability. |
+| `debt_service_coverage` | +1 (↑) | DSCR > 1 means income covers repayments with buffer; linear in safety. |
+| `deposit_amount` | +1 (↑) | Larger deposit reduces LVR and demonstrates savings discipline. |
+| `deposit_ratio` | +1 (↑) | deposit / loan_amount — direct proxy for equity skin-in-the-game. |
+| `document_consistency_score` | +1 (↑) | Consistent docs = lower fraud risk; monotone in data quality. |
+| `employment_length` | +1 (↑) | Longer tenure proxies income stability; CBA/NAB scorecards apply length floors. |
+| `financial_literacy_score` | +1 (↑) | Higher literacy = better decision making; TMD-aligned protective factor. |
+| `has_cosigner` | +1 (↑) | Guarantor increases recovery pool; monotonically safer. |
+| `hem_surplus` | +1 (↑) | Income − HEM floor; larger surplus = more serviceability headroom. |
+| `income_per_dependant` | +1 (↑) | More income per dependant = more discretionary buffer. |
+| `income_source_count` | +1 (↑) | Income diversification reduces concentration risk on a single employer. |
+| `income_verification_score` | +1 (↑) | CDR/Basiq-confirmed income is strictly safer than self-attested. |
+| `is_existing_customer` | +1 (↑) | Known customer behaviour is strictly more informative than acquired-unknown. |
+| `log_annual_income` | +1 (↑) | Log transform of annual_income; monotone transform, same sign as source. |
+| `months_since_last_default` | +1 (↑) | Longer since default = more recovery evidence; monotone in safety. |
+| `net_monthly_surplus` | +1 (↑) | Income − expenses; foundational serviceability quantity. |
+| `prepayment_buffer_months` | +1 (↑) | Months of repayments already paid ahead reduces imminent default risk. |
+| `property_value` | +1 (↑) | Higher collateral value reduces LGD for secured lending (APS 112). |
+| `rent_payment_regularity` | +1 (↑) | Consistent rent payments predict mortgage payment consistency. |
+| `salary_credit_regularity` | +1 (↑) | Regular salary credits confirm employment reality, reduce income-fabrication risk. |
+| `savings_balance` | +1 (↑) | Larger liquid buffer lowers short-term default risk during shocks. |
+| `savings_to_loan_ratio` | +1 (↑) | More savings relative to loan = more shock-absorption capacity. |
+| `serviceability_ratio` | +1 (↑) | Aggregated serviceability score; direction matches individual drivers. |
+| `uncommitted_monthly_income` | +1 (↑) | After fixed commitments; larger = more affordability buffer. |
+| `utility_payment_regularity` | +1 (↑) | Consistent utility payments are a cheap positive signal in thin files. |
+| `bnpl_active_count` | −1 (↓) | Active BNPL accounts duplicate num_bnpl_accounts signal; same sign. |
+| `bnpl_late_payments_12m` | −1 (↓) | BNPL late payments predict revolving-credit late payments. |
+| `bnpl_monthly_commitment` | −1 (↓) | Monthly BNPL scheduled repayments; direct expense. |
+| `bnpl_total_limit` | −1 (↓) | Total BNPL exposure; larger = more hidden serviceability drag. |
+| `bnpl_utilization_pct` | −1 (↓) | BNPL used ÷ limit; high use signals liquidity stress. |
+| `bureau_risk_score` | −1 (↓) | Higher bureau risk score = more recently adverse activity. |
+| `cash_advance_count_12m` | −1 (↓) | Cash advances indicate short-term liquidity stress; high rate-cost. |
+| `credit_card_burden` | −1 (↓) | Derived: card limits / income; same direction as limits. |
+| `credit_utilization_pct` | −1 (↓) | Above 70% utilisation is a top-3 bureau-score negative in AU. |
+| `days_in_overdraft_12m` | −1 (↓) | More days negative = tighter cash-flow margin; monotone worse. |
+| `days_negative_balance_90d` | −1 (↓) | Recent days in negative balance = cashflow fragility. |
+| `debt_to_income` | −1 (↓) | APRA limits above DTI=6; higher = less serviceability (APS 220 focus). |
+| `effective_loan_amount` | −1 (↓) | Loan + LMI (what actually appears on the mortgage); same direction as loan_amount. |
+| `enquiry_intensity` | −1 (↓) | Enquiries per open account; high velocity = shopping-for-credit stress. |
+| `essential_to_total_spend` | −1 (↓) | Higher essentials ratio = less discretionary buffer to cut. |
+| `existing_credit_card_limit` | −1 (↓) | More unused revolving limit inflates stressed serviceability commitments. |
+| `expense_to_income` | −1 (↓) | Mechanical ratio; more expense per dollar of income = less slack. |
+| `gambling_spend_ratio` | −1 (↓) | Gambling share of spend is a direct negative; mirrors AFCA guidance. |
+| `gambling_transaction_flag` | −1 (↓) | AFCA 2023: gambling spend is a responsible-lending red flag. |
+| `has_bankruptcy` | −1 (↓) | Bankruptcy is a hard-fail predictor historically; monotone worse. |
+| `hecs_debt_balance` | −1 (↓) | HECS balance proxies future HELP repayment; higher = more drag. |
+| `help_repayment_monthly` | −1 (↓) | HELP/HECS repayment reduces post-tax serviceability income. |
+| `hem_gap` | −1 (↓) | Negative gap means HEM > income (hard-fail); magnitude monotonic in severity. |
+| `income_verification_gap` | −1 (↓) | Mismatch between stated and verified income; higher = higher fraud risk. |
+| `lmi_premium` | −1 (↓) | LMI charged only above 80% LVR; higher = higher-LVR loan = riskier. |
+| `loan_amount` | −1 (↓) | Larger loans = larger repayment shocks under stress. |
+| `loan_to_income` | −1 (↓) | Higher LTI = less room for income shocks; NAB LTI cap 9×. |
+| `log_loan_amount` | −1 (↓) | Log transform of loan_amount; monotone transform, same sign. |
+| `lvr` | −1 (↓) | Key secured-lending risk variable; APRA flags LVR > 80% and LMI-required bands. |
+| `lvr_x_dti` | −1 (↓) | Interaction of two negative drivers; sign is the product: negative. |
+| `monthly_expenses` | −1 (↓) | Higher declared expenses reduce serviceability surplus. |
+| `monthly_rent` | −1 (↓) | Current rent is effectively baseline housing commitment; larger = less surplus. |
+| `num_bnpl_accounts` | −1 (↓) | More BNPL accounts = more hidden commitments (CCR gap; 2024 ASIC concern). |
+| `num_credit_enquiries_6m` | −1 (↓) | Shopping intensity signals financial stress; > 6 enquiries is a red flag. |
+| `num_defaults_5yr` | −1 (↓) | Historical defaults are the strongest negative signal in bureau scoring. |
+| `num_dishonours_12m` | −1 (↓) | Dishonours indicate cash-flow failures; AFCA/Basiq flags these as leading indicators. |
+| `num_hardship_flags` | −1 (↓) | AFCA/ASIC 2023 guidance: hardship history is materially negative. |
+| `num_late_payments_24m` | −1 (↓) | CCR-era late payments directly predict future default. |
+| `number_of_dependants` | −1 (↓) | More dependants = more baseline expenses (HEM scales with dependants). |
+| `overdraft_frequency_90d` | −1 (↓) | Frequent overdraft = recurring cash-flow fragility. |
+| `postcode_default_rate` | −1 (↓) | Geographic concentration risk; higher area default rate = worse tail. |
+| `stress_index` | −1 (↓) | Aggregated stress score; direction matches its component drivers. |
+| `stressed_dsr` | −1 (↓) | DSR at stressed rate; higher = less buffer against RBA hikes (APS 220). |
+| `stressed_repayment` | −1 (↓) | Repayment at assessed-rate; higher = more monthly burden under stress. |
+| `subscription_burden` | −1 (↓) | Sticky subscriptions reduce flex to cut expenses under stress. |
+| `unemployment_rate` | −1 (↓) | Macro unemployment tail-risk correlates with individual default. |
+| `worst_arrears_months` | −1 (↓) | More months in arrears = stronger recent negative evidence. |
+| `worst_late_payment_days` | −1 (↓) | Severity of worst late-payment episode; more days = worse. |
+
+## 5. Performance
+
+Evaluated on hold-out test set (20% of training data):
+
+- **AUC-ROC:** 0.8709
+- **KS statistic:** 0.6420
+- **Brier score (pointwise):** 0.1371
+- **ECE (15-bin):** 0.0337
+
+**Temporal cross-validation:** not recorded
+
+**Baseline logistic-regression gap:** not measured
+
+KS > 0.30 and AUC > 0.75 are the regulator-expected performance floor for AU retail-credit scorecards. Champion-challenger promotion gates exist in `model_selector.py` (PSI, calibration, KS); the current activation path in `tasks.py` activates new models directly, so confirm pre-promotion review for production deployments before relying on these gates.
+
+## 6. Calibration report
+
+| Decile | Actual default rate | Cumulative rate | Lift | n |
+|---|---|---|---|---|
+| 1 | 0.1227 | 0.1227 | 0.2169 | 864 |
+| 2 | 0.2060 | 0.1644 | 0.3642 | 864 |
+| 3 | 0.2627 | 0.1971 | 0.4645 | 864 |
+| 4 | 0.2697 | 0.2153 | 0.4768 | 864 |
+| 5 | 0.3889 | 0.2500 | 0.6875 | 864 |
+| 6 | 0.7014 | 0.3252 | 1.2400 | 864 |
+| 7 | 0.8773 | 0.4041 | 1.5511 | 864 |
+| 8 | 0.9259 | 0.4693 | 1.6370 | 864 |
+| 9 | 0.9479 | 0.5225 | 1.6759 | 864 |
+| 10 | 0.9537 | 0.5656 | 1.6861 | 864 |
+
+## 7. PSI by feature
+
+| Feature | PSI (train vs test) | Status |
+|---|---|---|
+| `dti_x_rate_sensitivity` | 0.1119 | ⚠ moderate drift |
+| `rate_stress_buffer` | 0.0959 | stable |
+| `savings_to_loan_ratio` | 0.0763 | stable |
+| `debt_service_coverage` | 0.0613 | stable |
+| `credit_history_months` | 0.0553 | stable |
+| `stress_index` | 0.0241 | stable |
+| `net_monthly_surplus` | 0.0235 | stable |
+| `income_credit_interaction` | 0.0170 | stable |
+| `hem_surplus` | 0.0161 | stable |
+| `stressed_dsr` | 0.0160 | stable |
+| `uncommitted_monthly_income` | 0.0144 | stable |
+| `stressed_repayment` | 0.0121 | stable |
+| `lvr_x_property_growth` | 0.0120 | stable |
+| `credit_score_x_tenure` | 0.0110 | stable |
+| `credit_score` | 0.0104 | stable |
+| `employment_stability` | 0.0104 | stable |
+| `property_value` | 0.0099 | stable |
+| `employment_length` | 0.0098 | stable |
+| `credit_x_employment` | 0.0090 | stable |
+| `deposit_amount` | 0.0085 | stable |
+| `lvr_x_dti` | 0.0073 | stable |
+| `loan_term_months` | 0.0073 | stable |
+| `monthly_repayment_ratio` | 0.0072 | stable |
+| `loan_amount` | 0.0070 | stable |
+| `debt_to_income` | 0.0070 | stable |
+| `log_loan_amount` | 0.0070 | stable |
+| `lvr` | 0.0066 | stable |
+| `deposit_x_income_stability` | 0.0066 | stable |
+| `worst_late_payment_days` | 0.0064 | stable |
+| `deposit_ratio` | 0.0043 | stable |
+| `loan_to_income` | 0.0033 | stable |
+| `industry_anzsic_M` | 0.0010 | stable |
+| `existing_property_count` | 0.0003 | stable |
+| `state_NT` | 0.0000 | stable |
+| `state_SA` | 0.0000 | stable |
+| `state_WA` | 0.0000 | stable |
+| `state_ACT` | 0.0000 | stable |
+| `state_NSW` | 0.0000 | stable |
+| `state_QLD` | 0.0000 | stable |
+| `state_TAS` | 0.0000 | stable |
+| `state_VIC` | 0.0000 | stable |
+| `purpose_auto` | 0.0000 | stable |
+| `purpose_home` | 0.0000 | stable |
+| `has_bankruptcy` | 0.0000 | stable |
+| `num_defaults_5yr` | 0.0000 | stable |
+| `purpose_business` | 0.0000 | stable |
+| `purpose_personal` | 0.0000 | stable |
+| `industry_anzsic_A` | 0.0000 | stable |
+| `industry_anzsic_B` | 0.0000 | stable |
+| `industry_anzsic_C` | 0.0000 | stable |
+| `industry_anzsic_E` | 0.0000 | stable |
+| `industry_anzsic_G` | 0.0000 | stable |
+| `industry_anzsic_H` | 0.0000 | stable |
+| `industry_anzsic_I` | 0.0000 | stable |
+| `industry_anzsic_J` | 0.0000 | stable |
+| `industry_anzsic_K` | 0.0000 | stable |
+| `industry_anzsic_N` | 0.0000 | stable |
+| `industry_anzsic_O` | 0.0000 | stable |
+| `industry_anzsic_P` | 0.0000 | stable |
+| `industry_anzsic_Q` | 0.0000 | stable |
+| `industry_anzsic_S` | 0.0000 | stable |
+| `purpose_education` | 0.0000 | stable |
+| `home_ownership_own` | 0.0000 | stable |
+| `home_ownership_rent` | 0.0000 | stable |
+| `applicant_type_couple` | 0.0000 | stable |
+| `applicant_type_single` | 0.0000 | stable |
+| `savings_trend_3m_flat` | 0.0000 | stable |
+| `cash_advance_count_12m` | 0.0000 | stable |
+| `industry_risk_tier_low` | 0.0000 | stable |
+| `home_ownership_mortgage` | 0.0000 | stable |
+| `industry_risk_tier_high` | 0.0000 | stable |
+| `employment_type_contract` | 0.0000 | stable |
+| `industry_risk_tier_medium` | 0.0000 | stable |
+| `savings_trend_3m_negative` | 0.0000 | stable |
+| `savings_trend_3m_positive` | 0.0000 | stable |
+| `employment_type_payg_casual` | 0.0000 | stable |
+| `industry_risk_tier_very_high` | 0.0000 | stable |
+| `employment_type_self_employed` | 0.0000 | stable |
+| `employment_type_payg_permanent` | 0.0000 | stable |
+
+## 8. Fairness audit
+
+| Protected attribute | DI ratio | 80%-rule passes |
+|---|---|---|
+| `state` | 0.7736 | False |
+| `applicant_type` | 0.8956 | True |
+| `employment_type` | 0.7206 | False |
+
+Cross-reference `intersectional_fairness.py` output in `training_metadata.intersectional_fairness` for two-way slices.
+
+## 9. Policy overlay reference
+
+| Code | Severity | Description |
+|---|---|---|
+| P01 | hard_fail | Non-resident / ineligible visa (bridging/student/tourist) — decline |
+| P02 | hard_fail | Applicant age < 18 or age at maturity > 75 |
+| P03 | hard_fail | Undischarged bankruptcy or within 7yr window — decline |
+| P04 | hard_fail | Active ATO tax-debt default flag — decline |
+| P05 | hard_fail | Credit score below floor 450 — decline |
+| P06 | hard_fail | LVR > 95% owner-occupier or ≥ 100% any — decline |
+| P07 | hard_fail | DTI exceeds APRA intervention ceiling 8.0× — decline |
+| P08 | refer | LTI > 9× — refer to manual underwriting |
+| P09 | refer | Postcode default rate > 8% — geographic concentration review |
+| P10 | refer | Self-employed with < 24mo trading history — refer |
+| P11 | refer | Hardship flag(s) on file — AFCA 2023 mandates human review |
+| P12 | refer | Personal loan > $50k TMD band — refer to TMD-aware underwriting |
+
+Current overlay mode is read from `CREDIT_POLICY_OVERLAY_MODE` (off / shadow / enforce). See §2 for the mode this dossier was generated under.
+
+## 10. Ongoing monitoring plan
+
+- **Retraining cadence:** every 90 days minimum.
+- **Minimum fresh samples before retrain:** 10000
+- **PSI alert threshold:** 0.25 (per-feature); cumulative PSI > 0.5 triggers retrain.
+- **ECE re-validation cadence:** quarterly.
+- **KS regression trigger:** drop > 5pp vs champion baseline triggers retrain.
+- **Fairness audit cadence:** every training run pre-promotion (see fairness_gate.py).
+- **Drift dashboard:** `/api/v1/ml/models/active/drift/` (weekly DriftReport cron).
+
+## 11. Change log
+
+Comparison vs previous ModelVersion on segment `unified`: `25356f34-dfb4-4a7c-882c-754a90183ee6` (v20260508_194730).
+
+- **AUC-ROC:** 0.8709 vs 0.8709 (→0.0000)
+- **KS:** 0.6420 vs 0.6420 (→0.0000)
+- **Brier:** 0.1371 vs 0.1371 (→0.0000)
+- **ECE:** 0.0337 vs 0.0337 (→0.0000)

--- a/backend/ml_models/1d0059ac-7366-417c-a338-f6fece1609c8/mrm.md
+++ b/backend/ml_models/1d0059ac-7366-417c-a338-f6fece1609c8/mrm.md
@@ -1,0 +1,276 @@
+# Model Risk Management Dossier — `1d0059ac-7366-417c-a338-f6fece1609c8`
+_Generated 2026-05-13T23:11:02Z — Format: APRA CPS 220 / SR 11-7_
+
+## 1. Header
+
+- **Model ID:** `1d0059ac-7366-417c-a338-f6fece1609c8`
+- **Algorithm:** XGBoost
+- **Version:** 20260507_152903
+- **Segment:** `unified`
+- **Trained at:** 2026-05-07T15:29:03.471260+00:00
+- **Training duration:** unknowns
+- **Training samples:** unknown
+- **Class balance (positive rate):** unknown
+- **Compliance status:** NON-COMPLIANT
+  - Fairness 80%-rule fails on: employment_type, state
+- **File hash (SHA-256):** `7f3f627dd40f8c0f1de88e5342717ef57a88f532dd0835c9377dd1e5c4dbf7be`
+
+## 2. Purpose & limitations
+
+General-purpose PD estimation across AU retail loan products. Not validated for: business lending, secured non-home lending, applicants outside AU residency, loans > $5M, loans with unusual repayment structures (balloon, interest-only > 5yr).
+
+All scope boundaries above reflect the training distribution. The policy overlay runs in `enforce` mode in this deployment. Out-of-scope predictions are blocked by the overlay and routed to manual underwriter review (see §9 P-codes).
+
+## 3. Data lineage
+
+- **Source:** synthetic (DataGenerator v1 + GMSC real-data benchmark)
+- **Synthetic vs real:** synthetic
+- **Class balance (positive rate):** unknown
+- **Reject-inference usage:** not applied
+- **Temporal coverage:** unknown → unknown
+
+Reject-inference is not applied for this version; the accept-only training distribution is a known bias risk and is mitigated through ongoing PSI monitoring (§10) + quarterly challenger retraining.
+
+## 4. Monotonicity constraint table
+
+| Feature | Sign | Rationale |
+|---|---|---|
+| `annual_income` | +1 (↑) | Higher income increases serviceability — core AU responsible-lending assumption. |
+| `avg_monthly_savings_rate` | +1 (↑) | Positive savings rate demonstrates cash-flow surplus. |
+| `consumer_confidence` | +1 (↑) | Higher macro confidence lowers tail-event probability during loan term. |
+| `credit_history_months` | +1 (↑) | More history = thicker file; thin files penalised across AU bureaux. |
+| `credit_score` | +1 (↑) | Higher Equifax score indicates lower historical default probability. |
+| `debt_service_coverage` | +1 (↑) | DSCR > 1 means income covers repayments with buffer; linear in safety. |
+| `deposit_amount` | +1 (↑) | Larger deposit reduces LVR and demonstrates savings discipline. |
+| `deposit_ratio` | +1 (↑) | deposit / loan_amount — direct proxy for equity skin-in-the-game. |
+| `document_consistency_score` | +1 (↑) | Consistent docs = lower fraud risk; monotone in data quality. |
+| `employment_length` | +1 (↑) | Longer tenure proxies income stability; CBA/NAB scorecards apply length floors. |
+| `financial_literacy_score` | +1 (↑) | Higher literacy = better decision making; TMD-aligned protective factor. |
+| `has_cosigner` | +1 (↑) | Guarantor increases recovery pool; monotonically safer. |
+| `hem_surplus` | +1 (↑) | Income − HEM floor; larger surplus = more serviceability headroom. |
+| `income_per_dependant` | +1 (↑) | More income per dependant = more discretionary buffer. |
+| `income_source_count` | +1 (↑) | Income diversification reduces concentration risk on a single employer. |
+| `income_verification_score` | +1 (↑) | CDR/Basiq-confirmed income is strictly safer than self-attested. |
+| `is_existing_customer` | +1 (↑) | Known customer behaviour is strictly more informative than acquired-unknown. |
+| `log_annual_income` | +1 (↑) | Log transform of annual_income; monotone transform, same sign as source. |
+| `months_since_last_default` | +1 (↑) | Longer since default = more recovery evidence; monotone in safety. |
+| `net_monthly_surplus` | +1 (↑) | Income − expenses; foundational serviceability quantity. |
+| `prepayment_buffer_months` | +1 (↑) | Months of repayments already paid ahead reduces imminent default risk. |
+| `property_value` | +1 (↑) | Higher collateral value reduces LGD for secured lending (APS 112). |
+| `rent_payment_regularity` | +1 (↑) | Consistent rent payments predict mortgage payment consistency. |
+| `salary_credit_regularity` | +1 (↑) | Regular salary credits confirm employment reality, reduce income-fabrication risk. |
+| `savings_balance` | +1 (↑) | Larger liquid buffer lowers short-term default risk during shocks. |
+| `savings_to_loan_ratio` | +1 (↑) | More savings relative to loan = more shock-absorption capacity. |
+| `serviceability_ratio` | +1 (↑) | Aggregated serviceability score; direction matches individual drivers. |
+| `uncommitted_monthly_income` | +1 (↑) | After fixed commitments; larger = more affordability buffer. |
+| `utility_payment_regularity` | +1 (↑) | Consistent utility payments are a cheap positive signal in thin files. |
+| `bnpl_active_count` | −1 (↓) | Active BNPL accounts duplicate num_bnpl_accounts signal; same sign. |
+| `bnpl_late_payments_12m` | −1 (↓) | BNPL late payments predict revolving-credit late payments. |
+| `bnpl_monthly_commitment` | −1 (↓) | Monthly BNPL scheduled repayments; direct expense. |
+| `bnpl_total_limit` | −1 (↓) | Total BNPL exposure; larger = more hidden serviceability drag. |
+| `bnpl_utilization_pct` | −1 (↓) | BNPL used ÷ limit; high use signals liquidity stress. |
+| `bureau_risk_score` | −1 (↓) | Higher bureau risk score = more recently adverse activity. |
+| `cash_advance_count_12m` | −1 (↓) | Cash advances indicate short-term liquidity stress; high rate-cost. |
+| `credit_card_burden` | −1 (↓) | Derived: card limits / income; same direction as limits. |
+| `credit_utilization_pct` | −1 (↓) | Above 70% utilisation is a top-3 bureau-score negative in AU. |
+| `days_in_overdraft_12m` | −1 (↓) | More days negative = tighter cash-flow margin; monotone worse. |
+| `days_negative_balance_90d` | −1 (↓) | Recent days in negative balance = cashflow fragility. |
+| `debt_to_income` | −1 (↓) | APRA limits above DTI=6; higher = less serviceability (APS 220 focus). |
+| `effective_loan_amount` | −1 (↓) | Loan + LMI (what actually appears on the mortgage); same direction as loan_amount. |
+| `enquiry_intensity` | −1 (↓) | Enquiries per open account; high velocity = shopping-for-credit stress. |
+| `essential_to_total_spend` | −1 (↓) | Higher essentials ratio = less discretionary buffer to cut. |
+| `existing_credit_card_limit` | −1 (↓) | More unused revolving limit inflates stressed serviceability commitments. |
+| `expense_to_income` | −1 (↓) | Mechanical ratio; more expense per dollar of income = less slack. |
+| `gambling_spend_ratio` | −1 (↓) | Gambling share of spend is a direct negative; mirrors AFCA guidance. |
+| `gambling_transaction_flag` | −1 (↓) | AFCA 2023: gambling spend is a responsible-lending red flag. |
+| `has_bankruptcy` | −1 (↓) | Bankruptcy is a hard-fail predictor historically; monotone worse. |
+| `hecs_debt_balance` | −1 (↓) | HECS balance proxies future HELP repayment; higher = more drag. |
+| `help_repayment_monthly` | −1 (↓) | HELP/HECS repayment reduces post-tax serviceability income. |
+| `hem_gap` | −1 (↓) | Negative gap means HEM > income (hard-fail); magnitude monotonic in severity. |
+| `income_verification_gap` | −1 (↓) | Mismatch between stated and verified income; higher = higher fraud risk. |
+| `lmi_premium` | −1 (↓) | LMI charged only above 80% LVR; higher = higher-LVR loan = riskier. |
+| `loan_amount` | −1 (↓) | Larger loans = larger repayment shocks under stress. |
+| `loan_to_income` | −1 (↓) | Higher LTI = less room for income shocks; NAB LTI cap 9×. |
+| `log_loan_amount` | −1 (↓) | Log transform of loan_amount; monotone transform, same sign. |
+| `lvr` | −1 (↓) | Key secured-lending risk variable; APRA flags LVR > 80% and LMI-required bands. |
+| `lvr_x_dti` | −1 (↓) | Interaction of two negative drivers; sign is the product: negative. |
+| `monthly_expenses` | −1 (↓) | Higher declared expenses reduce serviceability surplus. |
+| `monthly_rent` | −1 (↓) | Current rent is effectively baseline housing commitment; larger = less surplus. |
+| `num_bnpl_accounts` | −1 (↓) | More BNPL accounts = more hidden commitments (CCR gap; 2024 ASIC concern). |
+| `num_credit_enquiries_6m` | −1 (↓) | Shopping intensity signals financial stress; > 6 enquiries is a red flag. |
+| `num_defaults_5yr` | −1 (↓) | Historical defaults are the strongest negative signal in bureau scoring. |
+| `num_dishonours_12m` | −1 (↓) | Dishonours indicate cash-flow failures; AFCA/Basiq flags these as leading indicators. |
+| `num_hardship_flags` | −1 (↓) | AFCA/ASIC 2023 guidance: hardship history is materially negative. |
+| `num_late_payments_24m` | −1 (↓) | CCR-era late payments directly predict future default. |
+| `number_of_dependants` | −1 (↓) | More dependants = more baseline expenses (HEM scales with dependants). |
+| `overdraft_frequency_90d` | −1 (↓) | Frequent overdraft = recurring cash-flow fragility. |
+| `postcode_default_rate` | −1 (↓) | Geographic concentration risk; higher area default rate = worse tail. |
+| `stress_index` | −1 (↓) | Aggregated stress score; direction matches its component drivers. |
+| `stressed_dsr` | −1 (↓) | DSR at stressed rate; higher = less buffer against RBA hikes (APS 220). |
+| `stressed_repayment` | −1 (↓) | Repayment at assessed-rate; higher = more monthly burden under stress. |
+| `subscription_burden` | −1 (↓) | Sticky subscriptions reduce flex to cut expenses under stress. |
+| `unemployment_rate` | −1 (↓) | Macro unemployment tail-risk correlates with individual default. |
+| `worst_arrears_months` | −1 (↓) | More months in arrears = stronger recent negative evidence. |
+| `worst_late_payment_days` | −1 (↓) | Severity of worst late-payment episode; more days = worse. |
+
+## 5. Performance
+
+Evaluated on hold-out test set (20% of training data):
+
+- **AUC-ROC:** 0.8709
+- **KS statistic:** 0.6420
+- **Brier score (pointwise):** 0.1371
+- **ECE (15-bin):** 0.0337
+
+**Temporal cross-validation:** not recorded
+
+**Baseline logistic-regression gap:** not measured
+
+KS > 0.30 and AUC > 0.75 are the regulator-expected performance floor for AU retail-credit scorecards. Champion-challenger promotion gates exist in `model_selector.py` (PSI, calibration, KS); the current activation path in `tasks.py` activates new models directly, so confirm pre-promotion review for production deployments before relying on these gates.
+
+## 6. Calibration report
+
+| Decile | Actual default rate | Cumulative rate | Lift | n |
+|---|---|---|---|---|
+| 1 | 0.1227 | 0.1227 | 0.2169 | 864 |
+| 2 | 0.2060 | 0.1644 | 0.3642 | 864 |
+| 3 | 0.2627 | 0.1971 | 0.4645 | 864 |
+| 4 | 0.2697 | 0.2153 | 0.4768 | 864 |
+| 5 | 0.3889 | 0.2500 | 0.6875 | 864 |
+| 6 | 0.7014 | 0.3252 | 1.2400 | 864 |
+| 7 | 0.8773 | 0.4041 | 1.5511 | 864 |
+| 8 | 0.9259 | 0.4693 | 1.6370 | 864 |
+| 9 | 0.9479 | 0.5225 | 1.6759 | 864 |
+| 10 | 0.9537 | 0.5656 | 1.6861 | 864 |
+
+## 7. PSI by feature
+
+| Feature | PSI (train vs test) | Status |
+|---|---|---|
+| `rate_stress_buffer` | 0.1761 | ⚠ moderate drift |
+| `dti_x_rate_sensitivity` | 0.1532 | ⚠ moderate drift |
+| `credit_history_months` | 0.1283 | ⚠ moderate drift |
+| `debt_service_coverage` | 0.0021 | stable |
+| `net_monthly_surplus` | 0.0020 | stable |
+| `stressed_repayment` | 0.0018 | stable |
+| `hem_surplus` | 0.0017 | stable |
+| `debt_to_income` | 0.0016 | stable |
+| `monthly_repayment_ratio` | 0.0013 | stable |
+| `uncommitted_monthly_income` | 0.0013 | stable |
+| `loan_amount` | 0.0012 | stable |
+| `log_loan_amount` | 0.0012 | stable |
+| `deposit_x_income_stability` | 0.0012 | stable |
+| `stress_index` | 0.0011 | stable |
+| `credit_x_employment` | 0.0011 | stable |
+| `stressed_dsr` | 0.0010 | stable |
+| `deposit_amount` | 0.0010 | stable |
+| `loan_to_income` | 0.0010 | stable |
+| `savings_to_loan_ratio` | 0.0010 | stable |
+| `credit_score` | 0.0009 | stable |
+| `credit_score_x_tenure` | 0.0009 | stable |
+| `lvr_x_property_growth` | 0.0008 | stable |
+| `income_credit_interaction` | 0.0008 | stable |
+| `deposit_ratio` | 0.0007 | stable |
+| `employment_stability` | 0.0005 | stable |
+| `existing_property_count` | 0.0004 | stable |
+| `loan_term_months` | 0.0003 | stable |
+| `lvr` | 0.0002 | stable |
+| `employment_length` | 0.0002 | stable |
+| `lvr_x_dti` | 0.0001 | stable |
+| `property_value` | 0.0001 | stable |
+| `worst_late_payment_days` | 0.0001 | stable |
+| `state_NT` | 0.0000 | stable |
+| `state_SA` | 0.0000 | stable |
+| `state_WA` | 0.0000 | stable |
+| `state_ACT` | 0.0000 | stable |
+| `state_NSW` | 0.0000 | stable |
+| `state_QLD` | 0.0000 | stable |
+| `state_TAS` | 0.0000 | stable |
+| `state_VIC` | 0.0000 | stable |
+| `purpose_auto` | 0.0000 | stable |
+| `purpose_home` | 0.0000 | stable |
+| `has_bankruptcy` | 0.0000 | stable |
+| `num_defaults_5yr` | 0.0000 | stable |
+| `purpose_business` | 0.0000 | stable |
+| `purpose_personal` | 0.0000 | stable |
+| `industry_anzsic_A` | 0.0000 | stable |
+| `industry_anzsic_B` | 0.0000 | stable |
+| `industry_anzsic_C` | 0.0000 | stable |
+| `industry_anzsic_E` | 0.0000 | stable |
+| `industry_anzsic_G` | 0.0000 | stable |
+| `industry_anzsic_H` | 0.0000 | stable |
+| `industry_anzsic_I` | 0.0000 | stable |
+| `industry_anzsic_J` | 0.0000 | stable |
+| `industry_anzsic_K` | 0.0000 | stable |
+| `industry_anzsic_M` | 0.0000 | stable |
+| `industry_anzsic_N` | 0.0000 | stable |
+| `industry_anzsic_O` | 0.0000 | stable |
+| `industry_anzsic_P` | 0.0000 | stable |
+| `industry_anzsic_Q` | 0.0000 | stable |
+| `industry_anzsic_S` | 0.0000 | stable |
+| `purpose_education` | 0.0000 | stable |
+| `home_ownership_own` | 0.0000 | stable |
+| `home_ownership_rent` | 0.0000 | stable |
+| `applicant_type_couple` | 0.0000 | stable |
+| `applicant_type_single` | 0.0000 | stable |
+| `savings_trend_3m_flat` | 0.0000 | stable |
+| `cash_advance_count_12m` | 0.0000 | stable |
+| `industry_risk_tier_low` | 0.0000 | stable |
+| `home_ownership_mortgage` | 0.0000 | stable |
+| `industry_risk_tier_high` | 0.0000 | stable |
+| `employment_type_contract` | 0.0000 | stable |
+| `industry_risk_tier_medium` | 0.0000 | stable |
+| `savings_trend_3m_negative` | 0.0000 | stable |
+| `savings_trend_3m_positive` | 0.0000 | stable |
+| `employment_type_payg_casual` | 0.0000 | stable |
+| `industry_risk_tier_very_high` | 0.0000 | stable |
+| `employment_type_self_employed` | 0.0000 | stable |
+| `employment_type_payg_permanent` | 0.0000 | stable |
+
+## 8. Fairness audit
+
+| Protected attribute | DI ratio | 80%-rule passes |
+|---|---|---|
+| `state` | 0.7736 | False |
+| `applicant_type` | 0.8956 | True |
+| `employment_type` | 0.7206 | False |
+
+Cross-reference `intersectional_fairness.py` output in `training_metadata.intersectional_fairness` for two-way slices.
+
+## 9. Policy overlay reference
+
+| Code | Severity | Description |
+|---|---|---|
+| P01 | hard_fail | Non-resident / ineligible visa (bridging/student/tourist) — decline |
+| P02 | hard_fail | Applicant age < 18 or age at maturity > 75 |
+| P03 | hard_fail | Undischarged bankruptcy or within 7yr window — decline |
+| P04 | hard_fail | Active ATO tax-debt default flag — decline |
+| P05 | hard_fail | Credit score below floor 450 — decline |
+| P06 | hard_fail | LVR > 95% owner-occupier or ≥ 100% any — decline |
+| P07 | hard_fail | DTI exceeds APRA intervention ceiling 8.0× — decline |
+| P08 | refer | LTI > 9× — refer to manual underwriting |
+| P09 | refer | Postcode default rate > 8% — geographic concentration review |
+| P10 | refer | Self-employed with < 24mo trading history — refer |
+| P11 | refer | Hardship flag(s) on file — AFCA 2023 mandates human review |
+| P12 | refer | Personal loan > $50k TMD band — refer to TMD-aware underwriting |
+
+Current overlay mode is read from `CREDIT_POLICY_OVERLAY_MODE` (off / shadow / enforce). See §2 for the mode this dossier was generated under.
+
+## 10. Ongoing monitoring plan
+
+- **Retraining cadence:** every 90 days minimum.
+- **Minimum fresh samples before retrain:** 10000
+- **PSI alert threshold:** 0.25 (per-feature); cumulative PSI > 0.5 triggers retrain.
+- **ECE re-validation cadence:** quarterly.
+- **KS regression trigger:** drop > 5pp vs champion baseline triggers retrain.
+- **Fairness audit cadence:** every training run pre-promotion (see fairness_gate.py).
+- **Drift dashboard:** `/api/v1/ml/models/active/drift/` (weekly DriftReport cron).
+
+## 11. Change log
+
+Comparison vs previous ModelVersion on segment `unified`: `25356f34-dfb4-4a7c-882c-754a90183ee6` (v20260508_194730).
+
+- **AUC-ROC:** 0.8709 vs 0.8709 (→0.0000)
+- **KS:** 0.6420 vs 0.6420 (→0.0000)
+- **Brier:** 0.1371 vs 0.1371 (→0.0000)
+- **ECE:** 0.0337 vs 0.0337 (→0.0000)

--- a/backend/ml_models/25356f34-dfb4-4a7c-882c-754a90183ee6/mrm.md
+++ b/backend/ml_models/25356f34-dfb4-4a7c-882c-754a90183ee6/mrm.md
@@ -1,0 +1,276 @@
+# Model Risk Management Dossier — `25356f34-dfb4-4a7c-882c-754a90183ee6`
+_Generated 2026-05-13T23:11:05Z — Format: APRA CPS 220 / SR 11-7_
+
+## 1. Header
+
+- **Model ID:** `25356f34-dfb4-4a7c-882c-754a90183ee6`
+- **Algorithm:** XGBoost
+- **Version:** 20260508_194730
+- **Segment:** `unified`
+- **Trained at:** 2026-05-08T19:47:30.764426+00:00
+- **Training duration:** unknowns
+- **Training samples:** unknown
+- **Class balance (positive rate):** unknown
+- **Compliance status:** NON-COMPLIANT
+  - Fairness 80%-rule fails on: employment_type, state
+- **File hash (SHA-256):** `06bd68842ebc503cd15ed005877cd088659e2a9e5aea4bd4604e0725231b801d`
+
+## 2. Purpose & limitations
+
+General-purpose PD estimation across AU retail loan products. Not validated for: business lending, secured non-home lending, applicants outside AU residency, loans > $5M, loans with unusual repayment structures (balloon, interest-only > 5yr).
+
+All scope boundaries above reflect the training distribution. The policy overlay runs in `enforce` mode in this deployment. Out-of-scope predictions are blocked by the overlay and routed to manual underwriter review (see §9 P-codes).
+
+## 3. Data lineage
+
+- **Source:** synthetic (DataGenerator v1 + GMSC real-data benchmark)
+- **Synthetic vs real:** synthetic
+- **Class balance (positive rate):** unknown
+- **Reject-inference usage:** not applied
+- **Temporal coverage:** unknown → unknown
+
+Reject-inference is not applied for this version; the accept-only training distribution is a known bias risk and is mitigated through ongoing PSI monitoring (§10) + quarterly challenger retraining.
+
+## 4. Monotonicity constraint table
+
+| Feature | Sign | Rationale |
+|---|---|---|
+| `annual_income` | +1 (↑) | Higher income increases serviceability — core AU responsible-lending assumption. |
+| `avg_monthly_savings_rate` | +1 (↑) | Positive savings rate demonstrates cash-flow surplus. |
+| `consumer_confidence` | +1 (↑) | Higher macro confidence lowers tail-event probability during loan term. |
+| `credit_history_months` | +1 (↑) | More history = thicker file; thin files penalised across AU bureaux. |
+| `credit_score` | +1 (↑) | Higher Equifax score indicates lower historical default probability. |
+| `debt_service_coverage` | +1 (↑) | DSCR > 1 means income covers repayments with buffer; linear in safety. |
+| `deposit_amount` | +1 (↑) | Larger deposit reduces LVR and demonstrates savings discipline. |
+| `deposit_ratio` | +1 (↑) | deposit / loan_amount — direct proxy for equity skin-in-the-game. |
+| `document_consistency_score` | +1 (↑) | Consistent docs = lower fraud risk; monotone in data quality. |
+| `employment_length` | +1 (↑) | Longer tenure proxies income stability; CBA/NAB scorecards apply length floors. |
+| `financial_literacy_score` | +1 (↑) | Higher literacy = better decision making; TMD-aligned protective factor. |
+| `has_cosigner` | +1 (↑) | Guarantor increases recovery pool; monotonically safer. |
+| `hem_surplus` | +1 (↑) | Income − HEM floor; larger surplus = more serviceability headroom. |
+| `income_per_dependant` | +1 (↑) | More income per dependant = more discretionary buffer. |
+| `income_source_count` | +1 (↑) | Income diversification reduces concentration risk on a single employer. |
+| `income_verification_score` | +1 (↑) | CDR/Basiq-confirmed income is strictly safer than self-attested. |
+| `is_existing_customer` | +1 (↑) | Known customer behaviour is strictly more informative than acquired-unknown. |
+| `log_annual_income` | +1 (↑) | Log transform of annual_income; monotone transform, same sign as source. |
+| `months_since_last_default` | +1 (↑) | Longer since default = more recovery evidence; monotone in safety. |
+| `net_monthly_surplus` | +1 (↑) | Income − expenses; foundational serviceability quantity. |
+| `prepayment_buffer_months` | +1 (↑) | Months of repayments already paid ahead reduces imminent default risk. |
+| `property_value` | +1 (↑) | Higher collateral value reduces LGD for secured lending (APS 112). |
+| `rent_payment_regularity` | +1 (↑) | Consistent rent payments predict mortgage payment consistency. |
+| `salary_credit_regularity` | +1 (↑) | Regular salary credits confirm employment reality, reduce income-fabrication risk. |
+| `savings_balance` | +1 (↑) | Larger liquid buffer lowers short-term default risk during shocks. |
+| `savings_to_loan_ratio` | +1 (↑) | More savings relative to loan = more shock-absorption capacity. |
+| `serviceability_ratio` | +1 (↑) | Aggregated serviceability score; direction matches individual drivers. |
+| `uncommitted_monthly_income` | +1 (↑) | After fixed commitments; larger = more affordability buffer. |
+| `utility_payment_regularity` | +1 (↑) | Consistent utility payments are a cheap positive signal in thin files. |
+| `bnpl_active_count` | −1 (↓) | Active BNPL accounts duplicate num_bnpl_accounts signal; same sign. |
+| `bnpl_late_payments_12m` | −1 (↓) | BNPL late payments predict revolving-credit late payments. |
+| `bnpl_monthly_commitment` | −1 (↓) | Monthly BNPL scheduled repayments; direct expense. |
+| `bnpl_total_limit` | −1 (↓) | Total BNPL exposure; larger = more hidden serviceability drag. |
+| `bnpl_utilization_pct` | −1 (↓) | BNPL used ÷ limit; high use signals liquidity stress. |
+| `bureau_risk_score` | −1 (↓) | Higher bureau risk score = more recently adverse activity. |
+| `cash_advance_count_12m` | −1 (↓) | Cash advances indicate short-term liquidity stress; high rate-cost. |
+| `credit_card_burden` | −1 (↓) | Derived: card limits / income; same direction as limits. |
+| `credit_utilization_pct` | −1 (↓) | Above 70% utilisation is a top-3 bureau-score negative in AU. |
+| `days_in_overdraft_12m` | −1 (↓) | More days negative = tighter cash-flow margin; monotone worse. |
+| `days_negative_balance_90d` | −1 (↓) | Recent days in negative balance = cashflow fragility. |
+| `debt_to_income` | −1 (↓) | APRA limits above DTI=6; higher = less serviceability (APS 220 focus). |
+| `effective_loan_amount` | −1 (↓) | Loan + LMI (what actually appears on the mortgage); same direction as loan_amount. |
+| `enquiry_intensity` | −1 (↓) | Enquiries per open account; high velocity = shopping-for-credit stress. |
+| `essential_to_total_spend` | −1 (↓) | Higher essentials ratio = less discretionary buffer to cut. |
+| `existing_credit_card_limit` | −1 (↓) | More unused revolving limit inflates stressed serviceability commitments. |
+| `expense_to_income` | −1 (↓) | Mechanical ratio; more expense per dollar of income = less slack. |
+| `gambling_spend_ratio` | −1 (↓) | Gambling share of spend is a direct negative; mirrors AFCA guidance. |
+| `gambling_transaction_flag` | −1 (↓) | AFCA 2023: gambling spend is a responsible-lending red flag. |
+| `has_bankruptcy` | −1 (↓) | Bankruptcy is a hard-fail predictor historically; monotone worse. |
+| `hecs_debt_balance` | −1 (↓) | HECS balance proxies future HELP repayment; higher = more drag. |
+| `help_repayment_monthly` | −1 (↓) | HELP/HECS repayment reduces post-tax serviceability income. |
+| `hem_gap` | −1 (↓) | Negative gap means HEM > income (hard-fail); magnitude monotonic in severity. |
+| `income_verification_gap` | −1 (↓) | Mismatch between stated and verified income; higher = higher fraud risk. |
+| `lmi_premium` | −1 (↓) | LMI charged only above 80% LVR; higher = higher-LVR loan = riskier. |
+| `loan_amount` | −1 (↓) | Larger loans = larger repayment shocks under stress. |
+| `loan_to_income` | −1 (↓) | Higher LTI = less room for income shocks; NAB LTI cap 9×. |
+| `log_loan_amount` | −1 (↓) | Log transform of loan_amount; monotone transform, same sign. |
+| `lvr` | −1 (↓) | Key secured-lending risk variable; APRA flags LVR > 80% and LMI-required bands. |
+| `lvr_x_dti` | −1 (↓) | Interaction of two negative drivers; sign is the product: negative. |
+| `monthly_expenses` | −1 (↓) | Higher declared expenses reduce serviceability surplus. |
+| `monthly_rent` | −1 (↓) | Current rent is effectively baseline housing commitment; larger = less surplus. |
+| `num_bnpl_accounts` | −1 (↓) | More BNPL accounts = more hidden commitments (CCR gap; 2024 ASIC concern). |
+| `num_credit_enquiries_6m` | −1 (↓) | Shopping intensity signals financial stress; > 6 enquiries is a red flag. |
+| `num_defaults_5yr` | −1 (↓) | Historical defaults are the strongest negative signal in bureau scoring. |
+| `num_dishonours_12m` | −1 (↓) | Dishonours indicate cash-flow failures; AFCA/Basiq flags these as leading indicators. |
+| `num_hardship_flags` | −1 (↓) | AFCA/ASIC 2023 guidance: hardship history is materially negative. |
+| `num_late_payments_24m` | −1 (↓) | CCR-era late payments directly predict future default. |
+| `number_of_dependants` | −1 (↓) | More dependants = more baseline expenses (HEM scales with dependants). |
+| `overdraft_frequency_90d` | −1 (↓) | Frequent overdraft = recurring cash-flow fragility. |
+| `postcode_default_rate` | −1 (↓) | Geographic concentration risk; higher area default rate = worse tail. |
+| `stress_index` | −1 (↓) | Aggregated stress score; direction matches its component drivers. |
+| `stressed_dsr` | −1 (↓) | DSR at stressed rate; higher = less buffer against RBA hikes (APS 220). |
+| `stressed_repayment` | −1 (↓) | Repayment at assessed-rate; higher = more monthly burden under stress. |
+| `subscription_burden` | −1 (↓) | Sticky subscriptions reduce flex to cut expenses under stress. |
+| `unemployment_rate` | −1 (↓) | Macro unemployment tail-risk correlates with individual default. |
+| `worst_arrears_months` | −1 (↓) | More months in arrears = stronger recent negative evidence. |
+| `worst_late_payment_days` | −1 (↓) | Severity of worst late-payment episode; more days = worse. |
+
+## 5. Performance
+
+Evaluated on hold-out test set (20% of training data):
+
+- **AUC-ROC:** 0.8709
+- **KS statistic:** 0.6420
+- **Brier score (pointwise):** 0.1371
+- **ECE (15-bin):** 0.0337
+
+**Temporal cross-validation:** not recorded
+
+**Baseline logistic-regression gap:** not measured
+
+KS > 0.30 and AUC > 0.75 are the regulator-expected performance floor for AU retail-credit scorecards. Champion-challenger promotion gates exist in `model_selector.py` (PSI, calibration, KS); the current activation path in `tasks.py` activates new models directly, so confirm pre-promotion review for production deployments before relying on these gates.
+
+## 6. Calibration report
+
+| Decile | Actual default rate | Cumulative rate | Lift | n |
+|---|---|---|---|---|
+| 1 | 0.1227 | 0.1227 | 0.2169 | 864 |
+| 2 | 0.2060 | 0.1644 | 0.3642 | 864 |
+| 3 | 0.2627 | 0.1971 | 0.4645 | 864 |
+| 4 | 0.2697 | 0.2153 | 0.4768 | 864 |
+| 5 | 0.3889 | 0.2500 | 0.6875 | 864 |
+| 6 | 0.7014 | 0.3252 | 1.2400 | 864 |
+| 7 | 0.8773 | 0.4041 | 1.5511 | 864 |
+| 8 | 0.9259 | 0.4693 | 1.6370 | 864 |
+| 9 | 0.9479 | 0.5225 | 1.6759 | 864 |
+| 10 | 0.9537 | 0.5656 | 1.6861 | 864 |
+
+## 7. PSI by feature
+
+| Feature | PSI (train vs test) | Status |
+|---|---|---|
+| `rate_stress_buffer` | 0.1761 | ⚠ moderate drift |
+| `dti_x_rate_sensitivity` | 0.1532 | ⚠ moderate drift |
+| `credit_history_months` | 0.1283 | ⚠ moderate drift |
+| `debt_service_coverage` | 0.0021 | stable |
+| `net_monthly_surplus` | 0.0020 | stable |
+| `stressed_repayment` | 0.0018 | stable |
+| `hem_surplus` | 0.0017 | stable |
+| `debt_to_income` | 0.0016 | stable |
+| `monthly_repayment_ratio` | 0.0013 | stable |
+| `uncommitted_monthly_income` | 0.0013 | stable |
+| `loan_amount` | 0.0012 | stable |
+| `log_loan_amount` | 0.0012 | stable |
+| `deposit_x_income_stability` | 0.0012 | stable |
+| `stress_index` | 0.0011 | stable |
+| `credit_x_employment` | 0.0011 | stable |
+| `stressed_dsr` | 0.0010 | stable |
+| `deposit_amount` | 0.0010 | stable |
+| `loan_to_income` | 0.0010 | stable |
+| `savings_to_loan_ratio` | 0.0010 | stable |
+| `credit_score` | 0.0009 | stable |
+| `credit_score_x_tenure` | 0.0009 | stable |
+| `lvr_x_property_growth` | 0.0008 | stable |
+| `income_credit_interaction` | 0.0008 | stable |
+| `deposit_ratio` | 0.0007 | stable |
+| `employment_stability` | 0.0005 | stable |
+| `existing_property_count` | 0.0004 | stable |
+| `loan_term_months` | 0.0003 | stable |
+| `lvr` | 0.0002 | stable |
+| `employment_length` | 0.0002 | stable |
+| `lvr_x_dti` | 0.0001 | stable |
+| `property_value` | 0.0001 | stable |
+| `worst_late_payment_days` | 0.0001 | stable |
+| `state_NT` | 0.0000 | stable |
+| `state_SA` | 0.0000 | stable |
+| `state_WA` | 0.0000 | stable |
+| `state_ACT` | 0.0000 | stable |
+| `state_NSW` | 0.0000 | stable |
+| `state_QLD` | 0.0000 | stable |
+| `state_TAS` | 0.0000 | stable |
+| `state_VIC` | 0.0000 | stable |
+| `purpose_auto` | 0.0000 | stable |
+| `purpose_home` | 0.0000 | stable |
+| `has_bankruptcy` | 0.0000 | stable |
+| `num_defaults_5yr` | 0.0000 | stable |
+| `purpose_business` | 0.0000 | stable |
+| `purpose_personal` | 0.0000 | stable |
+| `industry_anzsic_A` | 0.0000 | stable |
+| `industry_anzsic_B` | 0.0000 | stable |
+| `industry_anzsic_C` | 0.0000 | stable |
+| `industry_anzsic_E` | 0.0000 | stable |
+| `industry_anzsic_G` | 0.0000 | stable |
+| `industry_anzsic_H` | 0.0000 | stable |
+| `industry_anzsic_I` | 0.0000 | stable |
+| `industry_anzsic_J` | 0.0000 | stable |
+| `industry_anzsic_K` | 0.0000 | stable |
+| `industry_anzsic_M` | 0.0000 | stable |
+| `industry_anzsic_N` | 0.0000 | stable |
+| `industry_anzsic_O` | 0.0000 | stable |
+| `industry_anzsic_P` | 0.0000 | stable |
+| `industry_anzsic_Q` | 0.0000 | stable |
+| `industry_anzsic_S` | 0.0000 | stable |
+| `purpose_education` | 0.0000 | stable |
+| `home_ownership_own` | 0.0000 | stable |
+| `home_ownership_rent` | 0.0000 | stable |
+| `applicant_type_couple` | 0.0000 | stable |
+| `applicant_type_single` | 0.0000 | stable |
+| `savings_trend_3m_flat` | 0.0000 | stable |
+| `cash_advance_count_12m` | 0.0000 | stable |
+| `industry_risk_tier_low` | 0.0000 | stable |
+| `home_ownership_mortgage` | 0.0000 | stable |
+| `industry_risk_tier_high` | 0.0000 | stable |
+| `employment_type_contract` | 0.0000 | stable |
+| `industry_risk_tier_medium` | 0.0000 | stable |
+| `savings_trend_3m_negative` | 0.0000 | stable |
+| `savings_trend_3m_positive` | 0.0000 | stable |
+| `employment_type_payg_casual` | 0.0000 | stable |
+| `industry_risk_tier_very_high` | 0.0000 | stable |
+| `employment_type_self_employed` | 0.0000 | stable |
+| `employment_type_payg_permanent` | 0.0000 | stable |
+
+## 8. Fairness audit
+
+| Protected attribute | DI ratio | 80%-rule passes |
+|---|---|---|
+| `state` | 0.7736 | False |
+| `applicant_type` | 0.8956 | True |
+| `employment_type` | 0.7206 | False |
+
+Cross-reference `intersectional_fairness.py` output in `training_metadata.intersectional_fairness` for two-way slices.
+
+## 9. Policy overlay reference
+
+| Code | Severity | Description |
+|---|---|---|
+| P01 | hard_fail | Non-resident / ineligible visa (bridging/student/tourist) — decline |
+| P02 | hard_fail | Applicant age < 18 or age at maturity > 75 |
+| P03 | hard_fail | Undischarged bankruptcy or within 7yr window — decline |
+| P04 | hard_fail | Active ATO tax-debt default flag — decline |
+| P05 | hard_fail | Credit score below floor 450 — decline |
+| P06 | hard_fail | LVR > 95% owner-occupier or ≥ 100% any — decline |
+| P07 | hard_fail | DTI exceeds APRA intervention ceiling 8.0× — decline |
+| P08 | refer | LTI > 9× — refer to manual underwriting |
+| P09 | refer | Postcode default rate > 8% — geographic concentration review |
+| P10 | refer | Self-employed with < 24mo trading history — refer |
+| P11 | refer | Hardship flag(s) on file — AFCA 2023 mandates human review |
+| P12 | refer | Personal loan > $50k TMD band — refer to TMD-aware underwriting |
+
+Current overlay mode is read from `CREDIT_POLICY_OVERLAY_MODE` (off / shadow / enforce). See §2 for the mode this dossier was generated under.
+
+## 10. Ongoing monitoring plan
+
+- **Retraining cadence:** every 90 days minimum.
+- **Minimum fresh samples before retrain:** 10000
+- **PSI alert threshold:** 0.25 (per-feature); cumulative PSI > 0.5 triggers retrain.
+- **ECE re-validation cadence:** quarterly.
+- **KS regression trigger:** drop > 5pp vs champion baseline triggers retrain.
+- **Fairness audit cadence:** every training run pre-promotion (see fairness_gate.py).
+- **Drift dashboard:** `/api/v1/ml/models/active/drift/` (weekly DriftReport cron).
+
+## 11. Change log
+
+Comparison vs previous ModelVersion on segment `unified`: `1c21d19b-f1a9-43ce-a115-fdef602d410d` (v20260508_174941).
+
+- **AUC-ROC:** 0.8709 vs 0.8709 (→0.0000)
+- **KS:** 0.6420 vs 0.6420 (→0.0000)
+- **Brier:** 0.1371 vs 0.1371 (→0.0000)
+- **ECE:** 0.0337 vs 0.0337 (→0.0000)

--- a/backend/ml_models/3502284e-2a83-4ff7-8367-07e6787456c5/mrm.md
+++ b/backend/ml_models/3502284e-2a83-4ff7-8367-07e6787456c5/mrm.md
@@ -1,0 +1,196 @@
+# Model Risk Management Dossier — `3502284e-2a83-4ff7-8367-07e6787456c5`
+_Generated 2026-05-13T23:11:09Z — Format: APRA CPS 220 / SR 11-7_
+
+## 1. Header
+
+- **Model ID:** `3502284e-2a83-4ff7-8367-07e6787456c5`
+- **Algorithm:** XGBoost
+- **Version:** 20260508_110834
+- **Segment:** `unified`
+- **Trained at:** 2026-05-08T11:08:35.076850+00:00
+- **Training duration:** unknowns
+- **Training samples:** unknown
+- **Class balance (positive rate):** unknown
+- **Compliance status:** NON-COMPLIANT
+  - Fairness 80%-rule fails on: employment_type, state
+- **File hash (SHA-256):** `7f3f627dd40f8c0f1de88e5342717ef57a88f532dd0835c9377dd1e5c4dbf7be`
+
+## 2. Purpose & limitations
+
+General-purpose PD estimation across AU retail loan products. Not validated for: business lending, secured non-home lending, applicants outside AU residency, loans > $5M, loans with unusual repayment structures (balloon, interest-only > 5yr).
+
+All scope boundaries above reflect the training distribution. The policy overlay runs in `enforce` mode in this deployment. Out-of-scope predictions are blocked by the overlay and routed to manual underwriter review (see §9 P-codes).
+
+## 3. Data lineage
+
+- **Source:** synthetic (DataGenerator v1 + GMSC real-data benchmark)
+- **Synthetic vs real:** synthetic
+- **Class balance (positive rate):** unknown
+- **Reject-inference usage:** not applied
+- **Temporal coverage:** unknown → unknown
+
+Reject-inference is not applied for this version; the accept-only training distribution is a known bias risk and is mitigated through ongoing PSI monitoring (§10) + quarterly challenger retraining.
+
+## 4. Monotonicity constraint table
+
+| Feature | Sign | Rationale |
+|---|---|---|
+| `annual_income` | +1 (↑) | Higher income increases serviceability — core AU responsible-lending assumption. |
+| `avg_monthly_savings_rate` | +1 (↑) | Positive savings rate demonstrates cash-flow surplus. |
+| `consumer_confidence` | +1 (↑) | Higher macro confidence lowers tail-event probability during loan term. |
+| `credit_history_months` | +1 (↑) | More history = thicker file; thin files penalised across AU bureaux. |
+| `credit_score` | +1 (↑) | Higher Equifax score indicates lower historical default probability. |
+| `debt_service_coverage` | +1 (↑) | DSCR > 1 means income covers repayments with buffer; linear in safety. |
+| `deposit_amount` | +1 (↑) | Larger deposit reduces LVR and demonstrates savings discipline. |
+| `deposit_ratio` | +1 (↑) | deposit / loan_amount — direct proxy for equity skin-in-the-game. |
+| `document_consistency_score` | +1 (↑) | Consistent docs = lower fraud risk; monotone in data quality. |
+| `employment_length` | +1 (↑) | Longer tenure proxies income stability; CBA/NAB scorecards apply length floors. |
+| `financial_literacy_score` | +1 (↑) | Higher literacy = better decision making; TMD-aligned protective factor. |
+| `has_cosigner` | +1 (↑) | Guarantor increases recovery pool; monotonically safer. |
+| `hem_surplus` | +1 (↑) | Income − HEM floor; larger surplus = more serviceability headroom. |
+| `income_per_dependant` | +1 (↑) | More income per dependant = more discretionary buffer. |
+| `income_source_count` | +1 (↑) | Income diversification reduces concentration risk on a single employer. |
+| `income_verification_score` | +1 (↑) | CDR/Basiq-confirmed income is strictly safer than self-attested. |
+| `is_existing_customer` | +1 (↑) | Known customer behaviour is strictly more informative than acquired-unknown. |
+| `log_annual_income` | +1 (↑) | Log transform of annual_income; monotone transform, same sign as source. |
+| `months_since_last_default` | +1 (↑) | Longer since default = more recovery evidence; monotone in safety. |
+| `net_monthly_surplus` | +1 (↑) | Income − expenses; foundational serviceability quantity. |
+| `prepayment_buffer_months` | +1 (↑) | Months of repayments already paid ahead reduces imminent default risk. |
+| `property_value` | +1 (↑) | Higher collateral value reduces LGD for secured lending (APS 112). |
+| `rent_payment_regularity` | +1 (↑) | Consistent rent payments predict mortgage payment consistency. |
+| `salary_credit_regularity` | +1 (↑) | Regular salary credits confirm employment reality, reduce income-fabrication risk. |
+| `savings_balance` | +1 (↑) | Larger liquid buffer lowers short-term default risk during shocks. |
+| `savings_to_loan_ratio` | +1 (↑) | More savings relative to loan = more shock-absorption capacity. |
+| `serviceability_ratio` | +1 (↑) | Aggregated serviceability score; direction matches individual drivers. |
+| `uncommitted_monthly_income` | +1 (↑) | After fixed commitments; larger = more affordability buffer. |
+| `utility_payment_regularity` | +1 (↑) | Consistent utility payments are a cheap positive signal in thin files. |
+| `bnpl_active_count` | −1 (↓) | Active BNPL accounts duplicate num_bnpl_accounts signal; same sign. |
+| `bnpl_late_payments_12m` | −1 (↓) | BNPL late payments predict revolving-credit late payments. |
+| `bnpl_monthly_commitment` | −1 (↓) | Monthly BNPL scheduled repayments; direct expense. |
+| `bnpl_total_limit` | −1 (↓) | Total BNPL exposure; larger = more hidden serviceability drag. |
+| `bnpl_utilization_pct` | −1 (↓) | BNPL used ÷ limit; high use signals liquidity stress. |
+| `bureau_risk_score` | −1 (↓) | Higher bureau risk score = more recently adverse activity. |
+| `cash_advance_count_12m` | −1 (↓) | Cash advances indicate short-term liquidity stress; high rate-cost. |
+| `credit_card_burden` | −1 (↓) | Derived: card limits / income; same direction as limits. |
+| `credit_utilization_pct` | −1 (↓) | Above 70% utilisation is a top-3 bureau-score negative in AU. |
+| `days_in_overdraft_12m` | −1 (↓) | More days negative = tighter cash-flow margin; monotone worse. |
+| `days_negative_balance_90d` | −1 (↓) | Recent days in negative balance = cashflow fragility. |
+| `debt_to_income` | −1 (↓) | APRA limits above DTI=6; higher = less serviceability (APS 220 focus). |
+| `effective_loan_amount` | −1 (↓) | Loan + LMI (what actually appears on the mortgage); same direction as loan_amount. |
+| `enquiry_intensity` | −1 (↓) | Enquiries per open account; high velocity = shopping-for-credit stress. |
+| `essential_to_total_spend` | −1 (↓) | Higher essentials ratio = less discretionary buffer to cut. |
+| `existing_credit_card_limit` | −1 (↓) | More unused revolving limit inflates stressed serviceability commitments. |
+| `expense_to_income` | −1 (↓) | Mechanical ratio; more expense per dollar of income = less slack. |
+| `gambling_spend_ratio` | −1 (↓) | Gambling share of spend is a direct negative; mirrors AFCA guidance. |
+| `gambling_transaction_flag` | −1 (↓) | AFCA 2023: gambling spend is a responsible-lending red flag. |
+| `has_bankruptcy` | −1 (↓) | Bankruptcy is a hard-fail predictor historically; monotone worse. |
+| `hecs_debt_balance` | −1 (↓) | HECS balance proxies future HELP repayment; higher = more drag. |
+| `help_repayment_monthly` | −1 (↓) | HELP/HECS repayment reduces post-tax serviceability income. |
+| `hem_gap` | −1 (↓) | Negative gap means HEM > income (hard-fail); magnitude monotonic in severity. |
+| `income_verification_gap` | −1 (↓) | Mismatch between stated and verified income; higher = higher fraud risk. |
+| `lmi_premium` | −1 (↓) | LMI charged only above 80% LVR; higher = higher-LVR loan = riskier. |
+| `loan_amount` | −1 (↓) | Larger loans = larger repayment shocks under stress. |
+| `loan_to_income` | −1 (↓) | Higher LTI = less room for income shocks; NAB LTI cap 9×. |
+| `log_loan_amount` | −1 (↓) | Log transform of loan_amount; monotone transform, same sign. |
+| `lvr` | −1 (↓) | Key secured-lending risk variable; APRA flags LVR > 80% and LMI-required bands. |
+| `lvr_x_dti` | −1 (↓) | Interaction of two negative drivers; sign is the product: negative. |
+| `monthly_expenses` | −1 (↓) | Higher declared expenses reduce serviceability surplus. |
+| `monthly_rent` | −1 (↓) | Current rent is effectively baseline housing commitment; larger = less surplus. |
+| `num_bnpl_accounts` | −1 (↓) | More BNPL accounts = more hidden commitments (CCR gap; 2024 ASIC concern). |
+| `num_credit_enquiries_6m` | −1 (↓) | Shopping intensity signals financial stress; > 6 enquiries is a red flag. |
+| `num_defaults_5yr` | −1 (↓) | Historical defaults are the strongest negative signal in bureau scoring. |
+| `num_dishonours_12m` | −1 (↓) | Dishonours indicate cash-flow failures; AFCA/Basiq flags these as leading indicators. |
+| `num_hardship_flags` | −1 (↓) | AFCA/ASIC 2023 guidance: hardship history is materially negative. |
+| `num_late_payments_24m` | −1 (↓) | CCR-era late payments directly predict future default. |
+| `number_of_dependants` | −1 (↓) | More dependants = more baseline expenses (HEM scales with dependants). |
+| `overdraft_frequency_90d` | −1 (↓) | Frequent overdraft = recurring cash-flow fragility. |
+| `postcode_default_rate` | −1 (↓) | Geographic concentration risk; higher area default rate = worse tail. |
+| `stress_index` | −1 (↓) | Aggregated stress score; direction matches its component drivers. |
+| `stressed_dsr` | −1 (↓) | DSR at stressed rate; higher = less buffer against RBA hikes (APS 220). |
+| `stressed_repayment` | −1 (↓) | Repayment at assessed-rate; higher = more monthly burden under stress. |
+| `subscription_burden` | −1 (↓) | Sticky subscriptions reduce flex to cut expenses under stress. |
+| `unemployment_rate` | −1 (↓) | Macro unemployment tail-risk correlates with individual default. |
+| `worst_arrears_months` | −1 (↓) | More months in arrears = stronger recent negative evidence. |
+| `worst_late_payment_days` | −1 (↓) | Severity of worst late-payment episode; more days = worse. |
+
+## 5. Performance
+
+Evaluated on hold-out test set (20% of training data):
+
+- **AUC-ROC:** 0.8709
+- **KS statistic:** 0.6420
+- **Brier score (pointwise):** 0.1371
+- **ECE (15-bin):** 0.0337
+
+**Temporal cross-validation:** not recorded
+
+**Baseline logistic-regression gap:** not measured
+
+KS > 0.30 and AUC > 0.75 are the regulator-expected performance floor for AU retail-credit scorecards. Champion-challenger promotion gates exist in `model_selector.py` (PSI, calibration, KS); the current activation path in `tasks.py` activates new models directly, so confirm pre-promotion review for production deployments before relying on these gates.
+
+## 6. Calibration report
+
+| Decile | Actual default rate | Cumulative rate | Lift | n |
+|---|---|---|---|---|
+| 1 | 0.1227 | 0.1227 | 0.2169 | 864 |
+| 2 | 0.2060 | 0.1644 | 0.3642 | 864 |
+| 3 | 0.2627 | 0.1971 | 0.4645 | 864 |
+| 4 | 0.2697 | 0.2153 | 0.4768 | 864 |
+| 5 | 0.3889 | 0.2500 | 0.6875 | 864 |
+| 6 | 0.7014 | 0.3252 | 1.2400 | 864 |
+| 7 | 0.8773 | 0.4041 | 1.5511 | 864 |
+| 8 | 0.9259 | 0.4693 | 1.6370 | 864 |
+| 9 | 0.9479 | 0.5225 | 1.6759 | 864 |
+| 10 | 0.9537 | 0.5656 | 1.6861 | 864 |
+
+## 7. PSI by feature
+
+No PSI data recorded. Train with v1.9.9+ trainer — it emits `training_metadata.psi_by_feature` (train vs test) on every run.
+
+## 8. Fairness audit
+
+| Protected attribute | DI ratio | 80%-rule passes |
+|---|---|---|
+| `state` | 0.7736 | False |
+| `applicant_type` | 0.8956 | True |
+| `employment_type` | 0.7206 | False |
+
+Cross-reference `intersectional_fairness.py` output in `training_metadata.intersectional_fairness` for two-way slices.
+
+## 9. Policy overlay reference
+
+| Code | Severity | Description |
+|---|---|---|
+| P01 | hard_fail | Non-resident / ineligible visa (bridging/student/tourist) — decline |
+| P02 | hard_fail | Applicant age < 18 or age at maturity > 75 |
+| P03 | hard_fail | Undischarged bankruptcy or within 7yr window — decline |
+| P04 | hard_fail | Active ATO tax-debt default flag — decline |
+| P05 | hard_fail | Credit score below floor 450 — decline |
+| P06 | hard_fail | LVR > 95% owner-occupier or ≥ 100% any — decline |
+| P07 | hard_fail | DTI exceeds APRA intervention ceiling 8.0× — decline |
+| P08 | refer | LTI > 9× — refer to manual underwriting |
+| P09 | refer | Postcode default rate > 8% — geographic concentration review |
+| P10 | refer | Self-employed with < 24mo trading history — refer |
+| P11 | refer | Hardship flag(s) on file — AFCA 2023 mandates human review |
+| P12 | refer | Personal loan > $50k TMD band — refer to TMD-aware underwriting |
+
+Current overlay mode is read from `CREDIT_POLICY_OVERLAY_MODE` (off / shadow / enforce). See §2 for the mode this dossier was generated under.
+
+## 10. Ongoing monitoring plan
+
+- **Retraining cadence:** every 90 days minimum.
+- **Minimum fresh samples before retrain:** 10000
+- **PSI alert threshold:** 0.25 (per-feature); cumulative PSI > 0.5 triggers retrain.
+- **ECE re-validation cadence:** quarterly.
+- **KS regression trigger:** drop > 5pp vs champion baseline triggers retrain.
+- **Fairness audit cadence:** every training run pre-promotion (see fairness_gate.py).
+- **Drift dashboard:** `/api/v1/ml/models/active/drift/` (weekly DriftReport cron).
+
+## 11. Change log
+
+Comparison vs previous ModelVersion on segment `unified`: `25356f34-dfb4-4a7c-882c-754a90183ee6` (v20260508_194730).
+
+- **AUC-ROC:** 0.8709 vs 0.8709 (→0.0000)
+- **KS:** 0.6420 vs 0.6420 (→0.0000)
+- **Brier:** 0.1371 vs 0.1371 (→0.0000)
+- **ECE:** 0.0337 vs 0.0337 (→0.0000)

--- a/backend/tests/test_backfill_psi_by_feature.py
+++ b/backend/tests/test_backfill_psi_by_feature.py
@@ -1,0 +1,144 @@
+"""Tests for the backfill_psi_by_feature management command.
+
+Mirror of the test_backfill_reference_distribution structure: stub
+ModelVersion with a bundle that has feature_distributions but no
+training_metadata.psi_by_feature, run command, assert mirror is now
+populated. Then re-run and verify idempotent refusal + --force overwrite.
+"""
+
+import joblib
+import numpy as np
+import pytest
+from django.core.management import call_command
+from django.test import override_settings
+from sklearn.linear_model import LogisticRegression
+
+from apps.ml_engine.models import ModelVersion
+
+
+@pytest.fixture
+def stub_model(tmp_path):
+    bundle_path = tmp_path / "psi_stub.joblib"
+    X = np.array([[600], [700], [800], [550], [720]])
+    y = np.array([0, 1, 1, 0, 1])
+    model = LogisticRegression().fit(X, y)
+    bundle = {
+        "model": model,
+        "scaler": None,
+        "feature_cols": ["credit_score"],
+        "categorical_cols": [],
+        "numeric_cols": ["credit_score"],
+        "reference_distribution": {
+            "probability_distribution": [0.2, 0.5, 0.8],
+            "feature_distributions": {"credit_score": [600, 650, 700, 750, 800]},
+        },
+        "imputation_values": {"credit_score": 650.0},
+        "conformal_scores": [],
+        "feature_bounds": {},
+        "group_thresholds": {},
+    }
+    joblib.dump(bundle, bundle_path)
+
+    with override_settings(ML_MODELS_DIR=str(tmp_path)):
+        mv = ModelVersion.objects.create(
+            algorithm="rf", version="psi-stub",
+            file_path=str(bundle_path), is_active=True,
+            optimal_threshold=0.5,
+            training_metadata={"reference_probabilities": [0.2, 0.5, 0.8]},
+        )
+    return mv, bundle_path, tmp_path
+
+
+def _patch_predictor(monkeypatch, model, feature_cols):
+    """Stub ModelPredictor so tests don't need a full bundle pipeline."""
+
+    def _fake_init(self, model_version=None, **kwargs):
+        self.model_version = model_version
+        self.model = model
+        self.feature_cols = feature_cols
+
+    def _fake_transform(self, df):
+        return df
+
+    monkeypatch.setattr(
+        "apps.ml_engine.services.predictor.ModelPredictor.__init__",
+        _fake_init,
+    )
+    monkeypatch.setattr(
+        "apps.ml_engine.services.predictor.ModelPredictor._transform",
+        _fake_transform,
+    )
+
+
+def _fitted_test_model():
+    """Tiny fitted model the predictor stub returns."""
+    return LogisticRegression().fit(np.array([[600], [700], [800]]), np.array([0, 1, 1]))
+
+
+@pytest.mark.django_db
+def test_backfill_populates_psi_by_feature(stub_model, monkeypatch):
+    mv, _bundle_path, tmp_path = stub_model
+
+    import pandas as pd
+    monkeypatch.setattr(
+        "apps.ml_engine.services.data_generator.DataGenerator.generate",
+        lambda self, num_records=100, random_seed=42, label_noise_rate=0.05:
+            pd.DataFrame({"credit_score": [620, 660, 690, 740, 780] * (num_records // 5)}),
+    )
+    _patch_predictor(monkeypatch, _fitted_test_model(), ["credit_score"])
+
+    with override_settings(ML_MODELS_DIR=str(tmp_path)):
+        call_command("backfill_psi_by_feature", "--all-active", "--sample", "20")
+
+    mv.refresh_from_db()
+    psi = (mv.training_metadata or {}).get("psi_by_feature") or {}
+    assert "credit_score" in psi
+    assert isinstance(psi["credit_score"], float)
+
+
+@pytest.mark.django_db
+def test_backfill_refuses_without_force_when_present(stub_model, monkeypatch, capsys):
+    mv, _bundle_path, tmp_path = stub_model
+    mv.training_metadata = {**(mv.training_metadata or {}), "psi_by_feature": {"credit_score": 0.5}}
+    with override_settings(ML_MODELS_DIR=str(tmp_path)):
+        mv.save(update_fields=["training_metadata"])
+
+    import pandas as pd
+    monkeypatch.setattr(
+        "apps.ml_engine.services.data_generator.DataGenerator.generate",
+        lambda self, num_records=100, random_seed=42, label_noise_rate=0.05:
+            pd.DataFrame({"credit_score": [700] * num_records}),
+    )
+    _patch_predictor(monkeypatch, _fitted_test_model(), ["credit_score"])
+
+    with override_settings(ML_MODELS_DIR=str(tmp_path)):
+        call_command("backfill_psi_by_feature", "--all-active", "--sample", "10")
+
+    out = capsys.readouterr().out
+    assert "skip" in out.lower() or "already populated" in out.lower()
+    mv.refresh_from_db()
+    assert (mv.training_metadata or {}).get("psi_by_feature") == {"credit_score": 0.5}
+
+
+@pytest.mark.django_db
+def test_backfill_force_overwrites(stub_model, monkeypatch):
+    mv, _bundle_path, tmp_path = stub_model
+    mv.training_metadata = {**(mv.training_metadata or {}), "psi_by_feature": {"credit_score": 0.5}}
+    with override_settings(ML_MODELS_DIR=str(tmp_path)):
+        mv.save(update_fields=["training_metadata"])
+
+    import pandas as pd
+    monkeypatch.setattr(
+        "apps.ml_engine.services.data_generator.DataGenerator.generate",
+        lambda self, num_records=100, random_seed=42, label_noise_rate=0.05:
+            pd.DataFrame({"credit_score": [620, 660, 690, 740, 780] * (num_records // 5)}),
+    )
+    _patch_predictor(monkeypatch, _fitted_test_model(), ["credit_score"])
+
+    with override_settings(ML_MODELS_DIR=str(tmp_path)):
+        call_command("backfill_psi_by_feature", "--all-active", "--sample", "20", "--force")
+
+    mv.refresh_from_db()
+    psi = (mv.training_metadata or {}).get("psi_by_feature") or {}
+    assert psi != {"credit_score": 0.5}
+    assert "credit_score" in psi

--- a/backend/tests/test_mrm_dossier_calibration.py
+++ b/backend/tests/test_mrm_dossier_calibration.py
@@ -1,0 +1,46 @@
+"""Tests for the MRM dossier's calibration section path lookup.
+
+Regression: the dossier used to read `mv.calibration_data["deciles"]` but
+deciles live on a separate `mv.decile_analysis` JSONField. Fix preserves
+fallback for legacy bundles that stored deciles inside calibration_data.
+"""
+
+import pytest
+from types import SimpleNamespace
+
+from apps.ml_engine.services.mrm_dossier import _calibration_section
+
+
+def _stub_mv(decile_analysis=None, calibration_data=None):
+    return SimpleNamespace(
+        decile_analysis=decile_analysis or {},
+        calibration_data=calibration_data or {},
+    )
+
+
+def test_calibration_reads_decile_analysis_field():
+    """When deciles are on mv.decile_analysis (current trainer output)."""
+    deciles = [
+        {"decile": 1, "n": 100, "actual_default_rate": 0.02, "predicted_default_rate": 0.018},
+        {"decile": 2, "n": 100, "actual_default_rate": 0.05, "predicted_default_rate": 0.048},
+    ]
+    mv = _stub_mv(decile_analysis={"deciles": deciles})
+    section = _calibration_section(mv)
+    assert "Decile calibration not recorded" not in section
+    assert "0.02" in section or "2.0%" in section or "0.018" in section
+
+
+def test_calibration_falls_back_to_calibration_data_deciles():
+    """Legacy bundles where deciles were nested under calibration_data."""
+    deciles = [{"decile": 1, "n": 100, "actual_default_rate": 0.01, "predicted_default_rate": 0.012}]
+    mv = _stub_mv(calibration_data={"deciles": deciles})
+    section = _calibration_section(mv)
+    assert "Decile calibration not recorded" not in section
+
+
+def test_calibration_empty_state_when_no_deciles():
+    """Both fields empty/absent → empty-state line."""
+    mv = _stub_mv()
+    section = _calibration_section(mv)
+    assert "Decile calibration not recorded" in section
+    assert "decile_analysis.deciles" in section  # new canonical path in the message

--- a/backend/tests/test_mrm_dossier_calibration.py
+++ b/backend/tests/test_mrm_dossier_calibration.py
@@ -3,6 +3,10 @@
 Regression: the dossier used to read `mv.calibration_data["deciles"]` but
 deciles live on a separate `mv.decile_analysis` JSONField. Fix preserves
 fallback for legacy bundles that stored deciles inside calibration_data.
+
+Stub deciles match the trainer's actual schema (`actual_rate`, `count`,
+`cumulative_rate`, `lift`) so the table renders representative values
+instead of all-`None` placeholders.
 """
 
 import pytest
@@ -18,24 +22,44 @@ def _stub_mv(decile_analysis=None, calibration_data=None):
     )
 
 
+def _real_decile(idx, actual_rate, cumulative_rate, lift, count):
+    """Build a row in the trainer's real `compute_decile_analysis` schema."""
+    return {
+        "decile": idx,
+        "count": count,
+        "actual_rate": actual_rate,
+        "cumulative_rate": cumulative_rate,
+        "lift": lift,
+    }
+
+
 def test_calibration_reads_decile_analysis_field():
     """When deciles are on mv.decile_analysis (current trainer output)."""
     deciles = [
-        {"decile": 1, "n": 100, "actual_default_rate": 0.02, "predicted_default_rate": 0.018},
-        {"decile": 2, "n": 100, "actual_default_rate": 0.05, "predicted_default_rate": 0.048},
+        _real_decile(1, actual_rate=0.02, cumulative_rate=0.02, lift=0.4, count=100),
+        _real_decile(2, actual_rate=0.05, cumulative_rate=0.035, lift=0.7, count=100),
     ]
     mv = _stub_mv(decile_analysis={"deciles": deciles})
     section = _calibration_section(mv)
     assert "Decile calibration not recorded" not in section
-    assert "0.02" in section or "2.0%" in section or "0.018" in section
+    assert "0.0200" in section  # actual_rate of decile 1 rendered
+    assert "0.0500" in section  # actual_rate of decile 2 rendered
 
 
 def test_calibration_falls_back_to_calibration_data_deciles():
     """Legacy bundles where deciles were nested under calibration_data."""
-    deciles = [{"decile": 1, "n": 100, "actual_default_rate": 0.01, "predicted_default_rate": 0.012}]
+    deciles = [_real_decile(1, actual_rate=0.01, cumulative_rate=0.01, lift=0.2, count=100)]
     mv = _stub_mv(calibration_data={"deciles": deciles})
     section = _calibration_section(mv)
     assert "Decile calibration not recorded" not in section
+
+
+def test_calibration_legacy_observed_key_still_renders():
+    """Legacy stub schema using `observed` should still be readable via the fallback chain."""
+    deciles = [{"decile": 1, "n": 100, "observed": 0.0123}]
+    mv = _stub_mv(decile_analysis={"deciles": deciles})
+    section = _calibration_section(mv)
+    assert "0.0123" in section
 
 
 def test_calibration_empty_state_when_no_deciles():
@@ -43,4 +67,4 @@ def test_calibration_empty_state_when_no_deciles():
     mv = _stub_mv()
     section = _calibration_section(mv)
     assert "Decile calibration not recorded" in section
-    assert "decile_analysis.deciles" in section  # new canonical path in the message
+    assert "decile_analysis.deciles" in section

--- a/backend/tests/test_settings_strict_gate_defaults.py
+++ b/backend/tests/test_settings_strict_gate_defaults.py
@@ -1,0 +1,39 @@
+"""Pin the strict default gate modes in base settings.
+
+Defaults must be enforcement-by-default so a non-compliant model cannot
+silently activate. Env vars can still relax the modes for emergency
+rollback.
+"""
+
+import importlib
+
+import pytest
+
+
+def test_credit_policy_overlay_mode_default_is_enforce(monkeypatch):
+    monkeypatch.delenv("CREDIT_POLICY_OVERLAY_MODE", raising=False)
+    from config.settings import base
+    importlib.reload(base)
+    assert base.CREDIT_POLICY_OVERLAY_MODE == "enforce"
+
+
+def test_ml_fairness_gate_mode_default_is_block(monkeypatch):
+    monkeypatch.delenv("ML_FAIRNESS_GATE_MODE", raising=False)
+    from config.settings import base
+    importlib.reload(base)
+    assert base.ML_FAIRNESS_GATE_MODE == "block"
+
+
+def test_ml_promotion_gate_mode_default_is_block(monkeypatch):
+    monkeypatch.delenv("ML_PROMOTION_GATE_MODE", raising=False)
+    from config.settings import base
+    importlib.reload(base)
+    assert base.ML_PROMOTION_GATE_MODE == "block"
+
+
+def test_env_var_override_still_works(monkeypatch):
+    """An operator setting ML_FAIRNESS_GATE_MODE=warn must still see warn."""
+    monkeypatch.setenv("ML_FAIRNESS_GATE_MODE", "warn")
+    from config.settings import base
+    importlib.reload(base)
+    assert base.ML_FAIRNESS_GATE_MODE == "warn"

--- a/backend/tests/test_trainer_psi_mirror.py
+++ b/backend/tests/test_trainer_psi_mirror.py
@@ -1,0 +1,33 @@
+"""Tests for trainer mirroring psi_by_feature into training_metadata.
+
+The dossier reads training_metadata.psi_by_feature; the trainer used to
+write only metrics["psi_by_feature"] (top level) which was dropped by the
+ModelVersion creation path. This test pins the mirror.
+"""
+
+import pytest
+
+from apps.ml_engine.services.trainer import ModelTrainer
+
+
+@pytest.mark.django_db
+def test_train_metrics_include_psi_by_feature_in_training_metadata(tmp_path, monkeypatch):
+    """metrics['training_metadata']['psi_by_feature'] mirrors the top-level metrics['psi_by_feature']."""
+    from apps.ml_engine.services.data_generator import DataGenerator
+
+    gen = DataGenerator()
+    df = gen.generate(num_records=300, random_seed=42, label_noise_rate=0.05)
+    csv_path = tmp_path / "tiny.csv"
+    df.to_csv(csv_path, index=False)
+
+    trainer = ModelTrainer()
+    monkeypatch.setattr(trainer, "_train_xgb", trainer._train_rf)
+    _model, metrics = trainer.train(str(csv_path), algorithm="rf")
+
+    top_level = metrics.get("psi_by_feature") or {}
+    mirrored = metrics.get("training_metadata", {}).get("psi_by_feature") or {}
+
+    assert isinstance(mirrored, dict)
+    assert set(mirrored.keys()) == set(top_level.keys())
+    for k in mirrored:
+        assert abs(mirrored[k] - top_level[k]) < 1e-9, f"mirror diverged for {k}"

--- a/docs/superpowers/plans/2026-05-09-codex-adversarial-response.md
+++ b/docs/superpowers/plans/2026-05-09-codex-adversarial-response.md
@@ -1,0 +1,929 @@
+# Codex Adversarial Review Response Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the three Codex adversarial-review findings: dossier reading the wrong calibration field, trainer not mirroring `psi_by_feature` into `training_metadata`, advisory gate-mode defaults letting non-compliant models activate, and a stale `next-env.d.ts` hand-edit.
+
+**Architecture:** Seven small atomic deliverables in `backend/apps/ml_engine`, `backend/config/settings`, `backend/docs`, and `frontend/`. Trainer change is a single new key inside the existing `metrics["training_metadata"]` block. Dossier change is a single field-lookup correction. Gate-mode flip is three default-value edits in `settings/base.py`. Backfill command mirrors the structure of the existing `backfill_reference_distribution` command. Frontend change is a one-file revert. RUNBOOK addendum is documentation only.
+
+**Tech Stack:** Django + DRF, scikit-learn / XGBoost via existing `ModelTrainer`, joblib bundles, `apps.ml_engine.services.metrics.psi_by_feature` helper, pytest + pytest-django. Frontend: Next.js 16 (Turbopack).
+
+**Spec:** [`docs/superpowers/specs/2026-05-09-codex-adversarial-response-design.md`](../specs/2026-05-09-codex-adversarial-response-design.md)
+
+**Branch:** `feat/codex-adversarial-response` (already checked out, forked from `feat/drift-tiles-fix` which is open as PR #182). The spec commit is also on `feat/drift-tiles-fix` HEAD; if PR #182 is squash-merged or merged-with-merge-commit, the spec history flows naturally into master either way.
+
+**Tests:** `docker exec loan-approval-ai-system-backend-1 python -m pytest tests/<path> -v` (container `/app` workdir maps to host `backend/`).
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `backend/apps/ml_engine/services/mrm_dossier.py` | MODIFY | `_calibration_section` now reads `mv.decile_analysis["deciles"]` first, falls back to legacy `calibration_data` keys. |
+| `backend/apps/ml_engine/services/trainer.py` | MODIFY | Mirror `psi_by_feature` into `metrics["training_metadata"]` so it lands on `ModelVersion.training_metadata`. |
+| `backend/apps/ml_engine/management/commands/backfill_psi_by_feature.py` | NEW | One-shot patch: load bundle, generate fresh DataGenerator batch, compute per-feature PSI vs the bundle's stored `feature_distributions`, write into `mv.training_metadata.psi_by_feature`. Idempotent. |
+| `backend/config/settings/base.py` | MODIFY | Default `CREDIT_POLICY_OVERLAY_MODE=enforce`, `ML_FAIRNESS_GATE_MODE=block`, `ML_PROMOTION_GATE_MODE=block`. Env-var override semantics preserved. |
+| `frontend/next-env.d.ts` | MODIFY | Revert to standard Next-generated content (no dev-only routes import). |
+| `backend/docs/RUNBOOK.md` | MODIFY | Append "Strict gate defaults — when and how to relax" section. |
+| `backend/tests/test_mrm_dossier_calibration.py` | NEW | Unit test: dossier renders deciles when `mv.decile_analysis.deciles` is populated. |
+| `backend/tests/test_trainer_psi_mirror.py` | NEW | Unit test: trainer copies `psi_by_feature` into `metrics["training_metadata"]`. |
+| `backend/tests/test_backfill_psi_by_feature.py` | NEW | 3 tests: populates / refuses-without-force / force-overwrites. |
+| `backend/tests/test_settings_strict_gate_defaults.py` | NEW | Asserts default gate modes when no env vars set. |
+
+---
+
+## Task 1: Dossier reads deciles from `mv.decile_analysis`
+
+**Goal:** Fix the wrong-field-lookup bug. The dossier currently checks `mv.calibration_data["deciles"]`; deciles actually live at `mv.decile_analysis["deciles"]` (a separate JSONField on `ModelVersion`).
+
+**Files:**
+- Modify: `backend/apps/ml_engine/services/mrm_dossier.py` (the `_calibration_section` function near line 231)
+- Test: `backend/tests/test_mrm_dossier_calibration.py` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_mrm_dossier_calibration.py`:
+
+```python
+"""Tests for the MRM dossier's calibration section path lookup.
+
+Regression: the dossier used to read `mv.calibration_data["deciles"]` but
+deciles live on a separate `mv.decile_analysis` JSONField. Fix preserves
+fallback for legacy bundles that stored deciles inside calibration_data.
+"""
+
+import pytest
+from types import SimpleNamespace
+
+from apps.ml_engine.services.mrm_dossier import _calibration_section
+
+
+def _stub_mv(decile_analysis=None, calibration_data=None):
+    return SimpleNamespace(
+        decile_analysis=decile_analysis or {},
+        calibration_data=calibration_data or {},
+    )
+
+
+def test_calibration_reads_decile_analysis_field():
+    """When deciles are on mv.decile_analysis (current trainer output)."""
+    deciles = [
+        {"decile": 1, "n": 100, "actual_default_rate": 0.02, "predicted_default_rate": 0.018},
+        {"decile": 2, "n": 100, "actual_default_rate": 0.05, "predicted_default_rate": 0.048},
+    ]
+    mv = _stub_mv(decile_analysis={"deciles": deciles})
+    section = _calibration_section(mv)
+    assert "Decile calibration not recorded" not in section
+    assert "0.02" in section or "2.0%" in section or "0.018" in section
+
+
+def test_calibration_falls_back_to_calibration_data_deciles():
+    """Legacy bundles where deciles were nested under calibration_data."""
+    deciles = [{"decile": 1, "n": 100, "actual_default_rate": 0.01, "predicted_default_rate": 0.012}]
+    mv = _stub_mv(calibration_data={"deciles": deciles})
+    section = _calibration_section(mv)
+    assert "Decile calibration not recorded" not in section
+
+
+def test_calibration_empty_state_when_no_deciles():
+    """Both fields empty/absent → empty-state line."""
+    mv = _stub_mv()
+    section = _calibration_section(mv)
+    assert "Decile calibration not recorded" in section
+    assert "decile_analysis.deciles" in section  # new canonical path in the message
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+```bash
+docker exec loan-approval-ai-system-backend-1 python -m pytest tests/test_mrm_dossier_calibration.py -v
+```
+
+Expected: `test_calibration_reads_decile_analysis_field` FAIL (the dossier doesn't read from `decile_analysis`); `test_calibration_empty_state_when_no_deciles` FAIL (the empty-state message doesn't yet mention the canonical path).
+
+- [ ] **Step 3: Apply the fix**
+
+Edit `backend/apps/ml_engine/services/mrm_dossier.py`. Find `def _calibration_section(mv)` (around line 231). Replace its body's lookup chain + empty-state message:
+
+```python
+def _calibration_section(mv) -> str:
+    """§6 — Calibration report (decile table)."""
+    decile_analysis = mv.decile_analysis or {}
+    calibration = mv.calibration_data or {}
+    deciles = (
+        decile_analysis.get("deciles")
+        or calibration.get("deciles")
+        or calibration.get("decile_analysis")
+        or []
+    )
+    if not deciles:
+        return (
+            "## 6. Calibration report\n\n"
+            "Decile calibration not recorded. Re-train with v1.9.0+ trainer which "
+            "emits `decile_analysis.deciles` on every run."
+        )
+```
+
+The rest of the function (the part that builds the table once `deciles` is non-empty) stays unchanged.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+docker exec loan-approval-ai-system-backend-1 python -m pytest tests/test_mrm_dossier_calibration.py -v
+```
+
+Expected: 3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/Admin/loan-approval-ai-system"
+git add backend/apps/ml_engine/services/mrm_dossier.py backend/tests/test_mrm_dossier_calibration.py
+git commit -m "$(cat <<'EOF'
+fix(mrm): dossier reads deciles from mv.decile_analysis (canonical path)
+
+The dossier's calibration section was looking for deciles at
+mv.calibration_data["deciles"], but the trainer stores them on the
+separate mv.decile_analysis JSONField. The empty-state stub fired even
+when calibration data was present. Adds the canonical lookup first,
+preserves the legacy calibration_data fallback for older bundles.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Trainer mirrors `psi_by_feature` into `training_metadata`
+
+**Goal:** The trainer computes `metrics["psi_by_feature"]` at the top level of the metrics dict, but `ModelVersion.training_metadata` is populated from `metrics["training_metadata"]` only — so `psi_by_feature` was being dropped before reaching the DB. Mirror it into the nested block so it follows the existing pattern.
+
+**Files:**
+- Modify: `backend/apps/ml_engine/services/trainer.py` — the `metrics["training_metadata"] = { ... }` block (around line 986-1014)
+- Test: `backend/tests/test_trainer_psi_mirror.py` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_trainer_psi_mirror.py`:
+
+```python
+"""Tests for trainer mirroring psi_by_feature into training_metadata.
+
+The dossier reads training_metadata.psi_by_feature; the trainer used to
+write only metrics["psi_by_feature"] (top level) which was dropped by the
+ModelVersion creation path. This test pins the mirror.
+"""
+
+import pytest
+
+from apps.ml_engine.services.trainer import ModelTrainer
+
+
+@pytest.mark.django_db
+def test_train_metrics_include_psi_by_feature_in_training_metadata(tmp_path, monkeypatch):
+    """metrics['training_metadata']['psi_by_feature'] mirrors the top-level metrics['psi_by_feature']."""
+    from apps.ml_engine.services.data_generator import DataGenerator
+
+    gen = DataGenerator()
+    df = gen.generate(num_records=300, random_seed=42, label_noise_rate=0.05)
+    csv_path = tmp_path / "tiny.csv"
+    df.to_csv(csv_path, index=False)
+
+    trainer = ModelTrainer()
+    monkeypatch.setattr(trainer, "_train_xgb", trainer._train_rf)
+    _model, metrics = trainer.train(str(csv_path), algorithm="rf")
+
+    top_level = metrics.get("psi_by_feature") or {}
+    mirrored = metrics.get("training_metadata", {}).get("psi_by_feature") or {}
+
+    # Mirror is populated.
+    assert isinstance(mirrored, dict)
+    # Mirror keys are a subset of (or equal to) top-level keys — same data.
+    assert set(mirrored.keys()) == set(top_level.keys())
+    # Numeric values match (within float tolerance).
+    for k in mirrored:
+        assert abs(mirrored[k] - top_level[k]) < 1e-9, f"mirror diverged for {k}"
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+```bash
+docker exec loan-approval-ai-system-backend-1 python -m pytest tests/test_trainer_psi_mirror.py -v
+```
+
+Expected: FAIL — `training_metadata["psi_by_feature"]` is empty / missing.
+
+- [ ] **Step 3: Apply the mirror**
+
+Edit `backend/apps/ml_engine/services/trainer.py`. Find the line in the `metrics["training_metadata"] = { ... }` block (around line 1019) that reads:
+
+```python
+            "iv_features_excluded_leakage": len(getattr(self, "_iv_result", {}).get("excluded_leakage", [])),
+            "reference_probabilities": list(getattr(self, "_holdout_probabilities", []) or []),
+            **split_meta,
+```
+
+Insert one new key between `iv_features_excluded_leakage` and `reference_probabilities`:
+
+```python
+            "iv_features_excluded_leakage": len(getattr(self, "_iv_result", {}).get("excluded_leakage", [])),
+            "psi_by_feature": dict(metrics.get("psi_by_feature") or {}),
+            "reference_probabilities": list(getattr(self, "_holdout_probabilities", []) or []),
+            **split_meta,
+```
+
+Note: at this point in `train()`, `metrics["psi_by_feature"]` was already set (line ~952). Reading it back is safe and decouples the mirror from upstream computation order changes.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+docker exec loan-approval-ai-system-backend-1 python -m pytest tests/test_trainer_psi_mirror.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/Admin/loan-approval-ai-system"
+git add backend/apps/ml_engine/services/trainer.py backend/tests/test_trainer_psi_mirror.py
+git commit -m "$(cat <<'EOF'
+feat(ml): trainer mirrors psi_by_feature into training_metadata
+
+The dossier reads mv.training_metadata.psi_by_feature; the trainer wrote
+only metrics["psi_by_feature"] which was dropped before hitting the DB.
+Mirror it into the training_metadata block so the canonical path is
+populated for every newly trained model.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `backfill_psi_by_feature` management command
+
+**Goal:** Patch existing models that were trained before Task 2 landed. The active `1c21d19b...` model has `psi_by_feature: {}` in its metadata; the dossier consequently reports "No PSI data recorded". Backfill computes per-feature PSI between the bundle's stored `feature_distributions` (training reference) and a fresh `DataGenerator` batch, writes the result into `mv.training_metadata.psi_by_feature`. Idempotent: refuses to overwrite without `--force`.
+
+**Files:**
+- Create: `backend/apps/ml_engine/management/commands/backfill_psi_by_feature.py`
+- Test: `backend/tests/test_backfill_psi_by_feature.py` (NEW)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/test_backfill_psi_by_feature.py`:
+
+```python
+"""Tests for the backfill_psi_by_feature management command.
+
+Mirror of the test_backfill_reference_distribution structure: stub
+ModelVersion with a bundle that has feature_distributions but no
+training_metadata.psi_by_feature, run command, assert mirror is now
+populated. Then re-run and verify idempotent refusal + --force overwrite.
+"""
+
+import joblib
+import numpy as np
+import pytest
+from django.core.management import call_command
+from django.test import override_settings
+from sklearn.linear_model import LogisticRegression
+
+from apps.ml_engine.models import ModelVersion
+
+
+@pytest.fixture
+def stub_model(tmp_path):
+    bundle_path = tmp_path / "psi_stub.joblib"
+    X = np.array([[600], [700], [800], [550], [720]])
+    y = np.array([0, 1, 1, 0, 1])
+    model = LogisticRegression().fit(X, y)
+    bundle = {
+        "model": model,
+        "scaler": None,
+        "feature_cols": ["credit_score"],
+        "categorical_cols": [],
+        "numeric_cols": ["credit_score"],
+        "reference_distribution": {
+            "probability_distribution": [0.2, 0.5, 0.8],
+            "feature_distributions": {"credit_score": [600, 650, 700, 750, 800]},
+        },
+        "imputation_values": {"credit_score": 650.0},
+        "conformal_scores": [],
+        "feature_bounds": {},
+        "group_thresholds": {},
+    }
+    joblib.dump(bundle, bundle_path)
+
+    with override_settings(ML_MODELS_DIR=str(tmp_path)):
+        mv = ModelVersion.objects.create(
+            algorithm="rf", version="psi-stub",
+            file_path=str(bundle_path), is_active=True,
+            optimal_threshold=0.5,
+            training_metadata={"reference_probabilities": [0.2, 0.5, 0.8]},
+        )
+    return mv, bundle_path, tmp_path
+
+
+def _patch_predictor(monkeypatch, model, feature_cols):
+    """Stub ModelPredictor so tests don't need a full bundle pipeline."""
+
+    def _fake_init(self, model_version=None, **kwargs):
+        self.model_version = model_version
+        self.model = model
+        self.feature_cols = feature_cols
+
+    def _fake_transform(self, df):
+        return df  # passthrough
+
+    monkeypatch.setattr(
+        "apps.ml_engine.services.predictor.ModelPredictor.__init__",
+        _fake_init,
+    )
+    monkeypatch.setattr(
+        "apps.ml_engine.services.predictor.ModelPredictor._transform",
+        _fake_transform,
+    )
+
+
+def _fitted_test_model():
+    """Tiny fitted model the predictor stub returns."""
+    return LogisticRegression().fit(np.array([[600], [700], [800]]), np.array([0, 1, 1]))
+
+
+@pytest.mark.django_db
+def test_backfill_populates_psi_by_feature(stub_model, monkeypatch):
+    mv, _bundle_path, tmp_path = stub_model
+
+    import pandas as pd
+    monkeypatch.setattr(
+        "apps.ml_engine.services.data_generator.DataGenerator.generate",
+        lambda self, num_records=100, random_seed=42, label_noise_rate=0.05:
+            pd.DataFrame({"credit_score": [620, 660, 690, 740, 780] * (num_records // 5)}),
+    )
+    _patch_predictor(monkeypatch, _fitted_test_model(), ["credit_score"])
+
+    with override_settings(ML_MODELS_DIR=str(tmp_path)):
+        call_command("backfill_psi_by_feature", "--all-active", "--sample", "20")
+
+    mv.refresh_from_db()
+    psi = (mv.training_metadata or {}).get("psi_by_feature") or {}
+    assert "credit_score" in psi
+    assert isinstance(psi["credit_score"], float)
+
+
+@pytest.mark.django_db
+def test_backfill_refuses_without_force_when_present(stub_model, monkeypatch, capsys):
+    mv, _bundle_path, tmp_path = stub_model
+    mv.training_metadata = {**(mv.training_metadata or {}), "psi_by_feature": {"credit_score": 0.5}}
+    mv.save(update_fields=["training_metadata"])
+
+    import pandas as pd
+    monkeypatch.setattr(
+        "apps.ml_engine.services.data_generator.DataGenerator.generate",
+        lambda self, num_records=100, random_seed=42, label_noise_rate=0.05:
+            pd.DataFrame({"credit_score": [700] * num_records}),
+    )
+    _patch_predictor(monkeypatch, _fitted_test_model(), ["credit_score"])
+
+    with override_settings(ML_MODELS_DIR=str(tmp_path)):
+        call_command("backfill_psi_by_feature", "--all-active", "--sample", "10")
+
+    out = capsys.readouterr().out
+    assert "skip" in out.lower() or "already populated" in out.lower()
+    mv.refresh_from_db()
+    assert (mv.training_metadata or {}).get("psi_by_feature") == {"credit_score": 0.5}
+
+
+@pytest.mark.django_db
+def test_backfill_force_overwrites(stub_model, monkeypatch):
+    mv, _bundle_path, tmp_path = stub_model
+    mv.training_metadata = {**(mv.training_metadata or {}), "psi_by_feature": {"credit_score": 0.5}}
+    mv.save(update_fields=["training_metadata"])
+
+    import pandas as pd
+    monkeypatch.setattr(
+        "apps.ml_engine.services.data_generator.DataGenerator.generate",
+        lambda self, num_records=100, random_seed=42, label_noise_rate=0.05:
+            pd.DataFrame({"credit_score": [620, 660, 690, 740, 780] * (num_records // 5)}),
+    )
+    _patch_predictor(monkeypatch, _fitted_test_model(), ["credit_score"])
+
+    with override_settings(ML_MODELS_DIR=str(tmp_path)):
+        call_command("backfill_psi_by_feature", "--all-active", "--sample", "20", "--force")
+
+    mv.refresh_from_db()
+    psi = (mv.training_metadata or {}).get("psi_by_feature") or {}
+    assert psi != {"credit_score": 0.5}
+    assert "credit_score" in psi
+```
+
+- [ ] **Step 2: Run, verify all 3 fail**
+
+```bash
+docker exec loan-approval-ai-system-backend-1 python -m pytest tests/test_backfill_psi_by_feature.py -v
+```
+
+Expected: 3 FAILs with `Unknown command: backfill_psi_by_feature`.
+
+- [ ] **Step 3: Implement the management command**
+
+Create `backend/apps/ml_engine/management/commands/backfill_psi_by_feature.py`:
+
+```python
+"""Backfill training_metadata.psi_by_feature on existing model versions.
+
+Models trained before the trainer's psi_by_feature mirror landed have
+empty `mv.training_metadata.psi_by_feature`, so the dossier prints
+"No PSI data recorded" even when reference distributions exist in the
+bundle. This command computes per-feature PSI between the bundle's
+stored feature_distributions (training reference) and a fresh
+DataGenerator batch (the proxy for "current" data), and writes the
+result into mv.training_metadata.psi_by_feature.
+
+Idempotent — refuses to overwrite without --force.
+"""
+
+import joblib
+import pandas as pd
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.ml_engine.models import ModelVersion
+from apps.ml_engine.services.metrics import psi_by_feature
+from apps.ml_engine.services.prediction_cache import _validate_model_path
+
+
+class Command(BaseCommand):
+    help = "Backfill ModelVersion.training_metadata.psi_by_feature for models that pre-date the trainer mirror."
+
+    def add_arguments(self, parser):
+        target = parser.add_mutually_exclusive_group(required=True)
+        target.add_argument("--model-id", type=str, help="UUID of a specific ModelVersion to backfill.")
+        target.add_argument("--all-active", action="store_true", help="Backfill every is_active=True ModelVersion.")
+        parser.add_argument(
+            "--sample", type=int, default=5000,
+            help="DataGenerator sample size used as the 'current' frame for PSI (default 5000).",
+        )
+        parser.add_argument(
+            "--force", action="store_true",
+            help="Overwrite existing training_metadata.psi_by_feature. Default refuses.",
+        )
+
+    def handle(self, *args, **options):
+        if options["all_active"]:
+            targets = list(ModelVersion.objects.filter(is_active=True))
+        else:
+            try:
+                targets = [ModelVersion.objects.get(id=options["model_id"])]
+            except ModelVersion.DoesNotExist:
+                raise CommandError(f"ModelVersion {options['model_id']} not found")
+
+        if not targets:
+            self.stdout.write("No matching models found.")
+            return
+
+        for mv in targets:
+            self._backfill_one(mv, options["sample"], options["force"])
+
+    def _backfill_one(self, mv: ModelVersion, sample_size: int, force: bool) -> None:
+        from apps.ml_engine.services.data_generator import DataGenerator
+        from apps.ml_engine.services.predictor import ModelPredictor
+
+        meta = dict(mv.training_metadata or {})
+        if meta.get("psi_by_feature") and not force:
+            self.stdout.write(
+                f"[skip] {mv.algorithm} v{mv.version}: psi_by_feature already populated; "
+                f"pass --force to overwrite."
+            )
+            return
+
+        try:
+            bundle_path = _validate_model_path(mv.file_path)
+        except (ValueError, FileNotFoundError) as exc:
+            raise CommandError(f"Bundle path invalid for {mv.id}: {exc}")
+
+        bundle = joblib.load(bundle_path)
+        ref_dist = bundle.get("reference_distribution") or {}
+        feature_distributions = ref_dist.get("feature_distributions") or {}
+        if not feature_distributions:
+            raise CommandError(
+                f"Bundle for {mv.id} has no feature_distributions in reference_distribution; "
+                f"run backfill_reference_distribution first."
+            )
+
+        # Build the "training reference" DataFrame from the bundle's stored samples.
+        train_df = pd.DataFrame({col: vals for col, vals in feature_distributions.items()})
+
+        # Build the "current" DataFrame: a fresh DataGenerator batch passed
+        # through the predictor's transform pipeline so feature engineering
+        # matches what the bundle was trained against.
+        gen_df = DataGenerator().generate(num_records=sample_size, random_seed=42, label_noise_rate=0.05)
+        for target_col in ("default_flag", "approved", "is_default"):
+            if target_col in gen_df.columns:
+                gen_df = gen_df.drop(columns=[target_col])
+
+        try:
+            predictor = ModelPredictor(model_version=mv)
+        except Exception as exc:
+            raise CommandError(f"Could not load predictor for {mv.id}: {exc}")
+
+        try:
+            current_df = predictor._transform(gen_df.copy())
+        except Exception as exc:
+            raise CommandError(f"Feature transformation failed for {mv.id}: {exc}")
+
+        # Restrict to the columns that exist in the training-reference frame
+        # (those are the columns the bundle stored samples for).
+        feature_cols = [c for c in feature_distributions.keys() if c in current_df.columns]
+        if not feature_cols:
+            raise CommandError(
+                f"No overlap between bundle feature_distributions and predictor output for {mv.id}; "
+                f"cannot compute PSI."
+            )
+
+        try:
+            psi_map = psi_by_feature(train_df, current_df, feature_cols)
+        except Exception as exc:
+            raise CommandError(f"psi_by_feature computation failed for {mv.id}: {exc}")
+
+        meta["psi_by_feature"] = psi_map
+        mv.training_metadata = meta
+        mv.save(update_fields=["training_metadata"])
+
+        self.stdout.write(self.style.SUCCESS(
+            f"[ok] {mv.algorithm} v{mv.version}: wrote psi_by_feature with {len(psi_map)} feature columns"
+        ))
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+docker exec loan-approval-ai-system-backend-1 python -m pytest tests/test_backfill_psi_by_feature.py -v
+```
+
+Expected: 3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/Admin/loan-approval-ai-system"
+git add backend/apps/ml_engine/management/commands/backfill_psi_by_feature.py backend/tests/test_backfill_psi_by_feature.py
+git commit -m "$(cat <<'EOF'
+feat(ml): backfill_psi_by_feature mgmt command
+
+One-shot patch for ModelVersions that pre-date the trainer's
+psi_by_feature mirror. Computes per-feature PSI between the bundle's
+stored feature_distributions and a fresh DataGenerator batch passed
+through the predictor's _transform pipeline, then writes
+mv.training_metadata.psi_by_feature so the dossier renders the table.
+Idempotent -- refuses to overwrite without --force.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Strict gate defaults in `settings/base.py`
+
+**Goal:** Flip the three gate-mode defaults from advisory (`shadow` / `warn` / `warn`) to enforcement (`enforce` / `block` / `block`). Operators can still override via env vars for emergency rollback.
+
+**Files:**
+- Modify: `backend/config/settings/base.py:241,252,263`
+- Test: `backend/tests/test_settings_strict_gate_defaults.py` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_settings_strict_gate_defaults.py`:
+
+```python
+"""Pin the strict default gate modes in base settings.
+
+Defaults must be enforcement-by-default so a non-compliant model cannot
+silently activate. Env vars can still relax the modes for emergency
+rollback.
+"""
+
+import os
+
+import pytest
+
+
+def test_credit_policy_overlay_mode_default_is_enforce(monkeypatch):
+    monkeypatch.delenv("CREDIT_POLICY_OVERLAY_MODE", raising=False)
+    import importlib
+    from django.conf import settings as django_settings
+    from config.settings import base
+    importlib.reload(base)
+    assert base.CREDIT_POLICY_OVERLAY_MODE == "enforce"
+
+
+def test_ml_fairness_gate_mode_default_is_block(monkeypatch):
+    monkeypatch.delenv("ML_FAIRNESS_GATE_MODE", raising=False)
+    import importlib
+    from config.settings import base
+    importlib.reload(base)
+    assert base.ML_FAIRNESS_GATE_MODE == "block"
+
+
+def test_ml_promotion_gate_mode_default_is_block(monkeypatch):
+    monkeypatch.delenv("ML_PROMOTION_GATE_MODE", raising=False)
+    import importlib
+    from config.settings import base
+    importlib.reload(base)
+    assert base.ML_PROMOTION_GATE_MODE == "block"
+
+
+def test_env_var_override_still_works(monkeypatch):
+    """An operator setting ML_FAIRNESS_GATE_MODE=warn must still see warn."""
+    monkeypatch.setenv("ML_FAIRNESS_GATE_MODE", "warn")
+    import importlib
+    from config.settings import base
+    importlib.reload(base)
+    assert base.ML_FAIRNESS_GATE_MODE == "warn"
+```
+
+- [ ] **Step 2: Run, verify the first three fail**
+
+```bash
+docker exec loan-approval-ai-system-backend-1 python -m pytest tests/test_settings_strict_gate_defaults.py -v
+```
+
+Expected: 3 FAILs (defaults still advisory); `test_env_var_override_still_works` PASS.
+
+- [ ] **Step 3: Apply the default flips**
+
+Edit `backend/config/settings/base.py`. Three single-line changes around lines 241, 252, 263.
+
+Find:
+
+```python
+CREDIT_POLICY_OVERLAY_MODE = os.environ.get("CREDIT_POLICY_OVERLAY_MODE", "shadow")
+```
+
+Replace with:
+
+```python
+CREDIT_POLICY_OVERLAY_MODE = os.environ.get("CREDIT_POLICY_OVERLAY_MODE", "enforce")
+```
+
+Find:
+
+```python
+ML_FAIRNESS_GATE_MODE = os.environ.get("ML_FAIRNESS_GATE_MODE", "warn")
+```
+
+Replace with:
+
+```python
+ML_FAIRNESS_GATE_MODE = os.environ.get("ML_FAIRNESS_GATE_MODE", "block")
+```
+
+Find:
+
+```python
+ML_PROMOTION_GATE_MODE = os.environ.get("ML_PROMOTION_GATE_MODE", "warn")
+```
+
+Replace with:
+
+```python
+ML_PROMOTION_GATE_MODE = os.environ.get("ML_PROMOTION_GATE_MODE", "block")
+```
+
+- [ ] **Step 4: Run tests to verify all 4 pass**
+
+```bash
+docker exec loan-approval-ai-system-backend-1 python -m pytest tests/test_settings_strict_gate_defaults.py -v
+```
+
+Expected: 4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/Admin/loan-approval-ai-system"
+git add backend/config/settings/base.py backend/tests/test_settings_strict_gate_defaults.py
+git commit -m "$(cat <<'EOF'
+fix(config): strict gate-mode defaults (enforce/block/block)
+
+Defaults flipped from advisory to enforcement so a non-compliant model
+cannot silently activate (Codex adversarial review finding #1):
+
+  CREDIT_POLICY_OVERLAY_MODE: shadow -> enforce
+  ML_FAIRNESS_GATE_MODE:     warn -> block
+  ML_PROMOTION_GATE_MODE:    warn -> block
+
+Env var override semantics preserved -- operators can still set
+ML_FAIRNESS_GATE_MODE=warn for emergency rollback per RUNBOOK.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Revert `frontend/next-env.d.ts`
+
+**Goal:** Drop the dev-only `./.next/dev/types/routes.d.ts` import path; restore the standard Next-generated content. Next.js regenerates this file on every dev / build run from a clean checkout.
+
+**Files:**
+- Modify: `frontend/next-env.d.ts`
+
+- [ ] **Step 1: Replace the file with the standard content**
+
+Set `frontend/next-env.d.ts` to:
+
+```typescript
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+```
+
+If the file already matches the master version (e.g. someone else reverted it), no change is needed — proceed to commit detection.
+
+- [ ] **Step 2: Verify the change is reverted (no untracked diff)**
+
+```bash
+cd "C:/Users/Admin/loan-approval-ai-system"
+git diff frontend/next-env.d.ts
+```
+
+Expected: no diff vs the committed master version (the file matches HEAD), OR a clean revert diff that drops the `./.next/dev/types/routes.d.ts` import.
+
+If there is a diff, proceed to commit. If `git diff` shows nothing AND `git status` shows no modifications, the file was already at the standard content; skip to Task 6.
+
+- [ ] **Step 3: Commit (only if there was a diff)**
+
+```bash
+cd "C:/Users/Admin/loan-approval-ai-system"
+git add frontend/next-env.d.ts
+git commit -m "$(cat <<'EOF'
+fix(frontend): revert next-env.d.ts to standard Next-generated content
+
+Drops the hand-edited `./.next/dev/types/routes.d.ts` import which is
+specific to a dev build tree. Clean CI / production builds emit the
+non-dev path, so the previous content risked breaking typecheck outside
+the local dev environment (Codex adversarial review finding #3).
+
+Next.js regenerates this file on every dev / build run.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: RUNBOOK — strict gate defaults section
+
+**Goal:** Document the new defaults, the env-var rollback, and the operator playbook for what happens when a fairness gate refuses activation.
+
+**Files:**
+- Modify: `backend/docs/RUNBOOK.md` (append a new section)
+
+- [ ] **Step 1: Append the section**
+
+Open `backend/docs/RUNBOOK.md`. Find the last line of the file. Append:
+
+```markdown
+
+## Strict gate defaults — when and how to relax
+
+The deployment defaults to enforcement on three model-governance gates:
+
+| Variable | Default | Effect when default is active |
+|---|---|---|
+| `ML_FAIRNESS_GATE_MODE` | `block` | A new training run that fails the 4/5ths fairness rule raises `FairnessGateBlocked` BEFORE atomic activation. Old segment model stays `is_active=True`. |
+| `ML_PROMOTION_GATE_MODE` | `block` | A new model that fails champion-challenger promotion gates (PSI / calibration / KS) is rejected pre-activation. |
+| `CREDIT_POLICY_OVERLAY_MODE` | `enforce` | Out-of-scope predictions (commercial lending, applicants outside AU residency, etc.) are routed to manual review automatically rather than silently scored. |
+
+### What you see when a gate fires
+
+Training task wrapper releases the lock and surfaces the blocked condition in:
+
+- Celery worker logs (`docker compose logs celery_worker_ml`)
+- Flower UI (`http://localhost:5555` → failed task with the gate exception class in the traceback)
+- `ModelVersion.training_metadata` on the most recent training run carries `fairness_gate_mode` / `promotion_gate_mode` plus the rejection reason
+
+### Decision tree when a real violation surfaces
+
+1. **Re-train with adjusted features.** Most fairness violations come from a single feature with strong protected-class correlation. Re-binning, dropping, or interacting it with a less-correlated feature usually clears the gate without sacrificing AUC.
+2. **Accept the violation explicitly.** If the violation is unavoidable for the segment (e.g. limited training data for a protected group), set the env var to `warn` for ONE training run, document the operator decision in the model's MRM dossier, then flip back to `block`.
+3. **Skip activation.** Train the model; do not promote. The blocked state is not destructive — the existing active model continues serving.
+
+### Emergency rollback
+
+If a gate misfires (false positive, e.g. due to a bug in the gate logic itself rather than a real violation), relax the relevant variable in `.env`:
+
+```bash
+ML_FAIRNESS_GATE_MODE=warn
+ML_PROMOTION_GATE_MODE=warn
+CREDIT_POLICY_OVERLAY_MODE=shadow
+```
+
+Restart `backend` and `celery_worker_ml`:
+
+```bash
+docker compose restart backend celery_worker_ml
+```
+
+Confirm via `docker compose logs backend` that the new mode is active. Re-trigger the training run. Once the underlying issue is fixed, restore the env vars to enforcement defaults and restart again.
+
+See [`docs/superpowers/specs/2026-05-07-ml-fairness-gate-mode-design.md`](../../docs/superpowers/specs/2026-05-07-ml-fairness-gate-mode-design.md) for the gate-mode machinery internals.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd "C:/Users/Admin/loan-approval-ai-system"
+git add backend/docs/RUNBOOK.md
+git commit -m "$(cat <<'EOF'
+docs(runbook): strict gate defaults section
+
+Documents the three enforcement-by-default gate modes
+(ML_FAIRNESS_GATE_MODE, ML_PROMOTION_GATE_MODE, CREDIT_POLICY_OVERLAY_MODE),
+what an operator sees when a gate fires, the decision tree for handling a
+real violation, and the emergency rollback procedure.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Live verification on the dev stack
+
+**Goal:** Run the new backfill against the active `1c21d19b...` model, regenerate its dossier, confirm §6 Calibration and §7 PSI sections render real tables instead of "not recorded" stubs.
+
+- [ ] **Step 1: Backfill the active model**
+
+```bash
+docker exec loan-approval-ai-system-backend-1 \
+  python manage.py backfill_psi_by_feature --all-active --sample 5000
+```
+
+Expected output: `[ok] xgb v20260508_174941: wrote psi_by_feature with N feature columns` (where N matches the bundle's `feature_distributions` keys, ~21).
+
+- [ ] **Step 2: Regenerate the dossier**
+
+```bash
+docker exec loan-approval-ai-system-backend-1 \
+  python manage.py generate_mrm_dossier --model-id 1c21d19b-f1a9-43ce-a115-fdef602d410d
+```
+
+Expected: command exits 0, dossier file at `backend/ml_models/1c21d19b-.../mrm.md` is rewritten.
+
+- [ ] **Step 3: Verify the dossier sections**
+
+```bash
+sed -n '/## 6. Calibration/,/## 7. /p' backend/ml_models/1c21d19b-f1a9-43ce-a115-fdef602d410d/mrm.md
+sed -n '/## 7. PSI/,/## 8. /p' backend/ml_models/1c21d19b-f1a9-43ce-a115-fdef602d410d/mrm.md
+```
+
+Expected:
+- §6 Calibration: a table of decile rows (decile / actual rate / predicted rate / count), NOT the "Decile calibration not recorded" stub.
+- §7 PSI by feature: a table of feature rows with PSI values, NOT the "No PSI data recorded" stub.
+
+- [ ] **Step 4: Final marker commit**
+
+```bash
+cd "C:/Users/Admin/loan-approval-ai-system"
+git commit --allow-empty -m "$(cat <<'EOF'
+chore(ml): manual verification — codex adversarial findings closed
+
+Confirmed against live active model 1c21d19b-f1a9-43ce-a115-fdef602d410d:
+- backfill_psi_by_feature populated mv.training_metadata.psi_by_feature
+- regenerated dossier shows real Calibration (§6) and PSI (§7) tables
+- gate-mode defaults flipped to enforce/block/block; env-var override path
+  still works (verified via test_settings_strict_gate_defaults.py)
+- next-env.d.ts back to Next-generated standard content
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-review checklist (post-execution)
+
+After all tasks land, verify against the spec:
+
+- [ ] Dossier reads `decile_analysis.deciles` first (spec §Components.1) — ✓ Task 1
+- [ ] Trainer mirrors `psi_by_feature` into `metrics["training_metadata"]` (spec §Components.2) — ✓ Task 2
+- [ ] `backfill_psi_by_feature` exists with `--model-id`, `--all-active`, `--sample`, `--force` (spec §Components.3) — ✓ Task 3
+- [ ] All three gate-mode defaults flipped (spec §Components.4) — ✓ Task 4
+- [ ] `next-env.d.ts` matches standard Next-generated content (spec §Components.5) — ✓ Task 5
+- [ ] RUNBOOK has "Strict gate defaults — when and how to relax" section (spec §Components.6) — ✓ Task 6
+- [ ] All four named test files exist and pass (spec §Components.7) — ✓ Tasks 1, 2, 3, 4
+- [ ] Live verification: dossier renders deciles + PSI tables (spec §Testing manual block) — ✓ Task 7

--- a/docs/superpowers/specs/2026-05-09-codex-adversarial-response-design.md
+++ b/docs/superpowers/specs/2026-05-09-codex-adversarial-response-design.md
@@ -1,0 +1,260 @@
+# Codex Adversarial Review Response — Design
+
+**Date**: 2026-05-09
+**Status**: Approved (trust-delegated, scope chosen by implementer)
+**Scope**: backend `ml_engine` (dossier + trainer + settings + tests) + `frontend/next-env.d.ts` revert + RUNBOOK addendum
+
+## Problem
+
+Codex's adversarial review of the working tree returned `verdict=needs-attention` with three findings:
+
+1. **[high]** Active model `1c21d19b-f1a9-43ce-a115-fdef602d410d` (xgb v20260508_174941) is marked `Active: True` and `Compliance status: NON-COMPLIANT` (fairness 80%-rule fails on `state` and `employment_type`), while the deployment runs the policy overlay in `shadow` mode where out-of-scope predictions are *not blocked*. The gate machinery exists but defaults to advisory rather than enforcement.
+2. **[high]** The dossier for the same active model says decile calibration was not recorded and no PSI-by-feature data exists. For an active credit model that leaves no concrete evidence of probability calibration or train/test drift before rollout.
+3. **[medium]** `frontend/next-env.d.ts` was hand-edited to import from `./.next/dev/types/routes.d.ts`, a dev-build-tree-specific path that may not exist in CI / production builds.
+
+Investigation confirmed the findings are real but more nuanced than Codex framed them:
+
+- **Finding #2 calibration sub-finding is a dossier bug, not a data bug.** `mrm_dossier.py:233` reads `mv.calibration_data["deciles"]`, but deciles actually live at the separate `mv.decile_analysis["deciles"]` JSONField. The DB confirms `mv.decile_analysis.deciles` has 10 entries for the active model. The trainer is correct; the dossier path is wrong.
+- **Finding #2 PSI sub-finding is a mirror bug.** `trainer.py:952` writes `metrics["psi_by_feature"]` at the top level of the metrics dict, but the dossier reads `mv.training_metadata["psi_by_feature"]`. `tasks.py:149` populates `training_metadata=metrics.get("training_metadata", {})` — the top-level `psi_by_feature` is dropped on the floor before it reaches the DB. Same shape of bug we fixed for `reference_probabilities` in Task 4 of `2026-05-08-drift-tiles-design.md`.
+- **Finding #1 is real**: `backend/config/settings/base.py:241,252,263` defaults all three gate modes to advisory (`shadow` for `CREDIT_POLICY_OVERLAY_MODE`, `warn` for `ML_FAIRNESS_GATE_MODE` and `ML_PROMOTION_GATE_MODE`). The non-compliant model passed activation because nothing was set to refuse it.
+- **Finding #3 is real and trivial**: pre-existing local WIP, unrelated to any feature work, easy to revert.
+
+## Goal
+
+Close all three Codex findings without breaking existing flows. After this work:
+
+- Newly trained models that fail fairness or promotion gates **block** activation by default rather than silently activating with a warning.
+- Out-of-scope predictions are **enforced** by the policy overlay rather than observed in shadow.
+- The dossier accurately reports calibration deciles + per-feature PSI when the underlying data exists.
+- The active model `1c21d19b...` has its `training_metadata.psi_by_feature` backfilled so its dossier renders correctly without forcing a retrain.
+- `frontend/next-env.d.ts` matches what Next.js regenerates from a clean checkout.
+
+The currently-active non-compliant model is **not auto-demoted**. Surfacing the issue clearly via the now-correct dossier + new strict defaults gives the operator a deliberate decision: re-train (next training run will be blocked from activation if still non-compliant) or manually deactivate via Django admin. Auto-demotion is destructive and exceeds the scope of "fix Codex findings".
+
+## Approach
+
+Seven deliverables organised by component. Each is a small atomic commit. Frontend touches are limited to one file revert.
+
+1. **Dossier path fix** — `mrm_dossier.py` reads deciles from `mv.decile_analysis["deciles"]` (the correct JSONField) instead of `mv.calibration_data["deciles"]`.
+2. **Trainer PSI mirror** — `trainer.py` writes `psi_by_feature` into `metrics["training_metadata"]` so it propagates to `ModelVersion.training_metadata` via the existing `tasks.py:149` path.
+3. **Active-model backfill** — small management command `backfill_psi_by_feature` that recomputes `psi_by_feature` for any `is_active=True` ModelVersion missing the field, by loading the bundle, generating a fresh DataGenerator batch, and computing PSI between training reference and the new batch. Idempotent.
+4. **Strict gate defaults** — `config/settings/base.py` defaults `ML_FAIRNESS_GATE_MODE`, `ML_PROMOTION_GATE_MODE` to `block` and `CREDIT_POLICY_OVERLAY_MODE` to `enforce`. Existing env-var override behaviour is preserved.
+5. **`next-env.d.ts` revert** — revert to the standard Next-generated content (`/// <reference types="next" />`, `/// <reference types="next/image-types/global" />`, `import "./.next/types/routes.d.ts";`, no edits).
+6. **RUNBOOK addendum** — document the new strict defaults, when/how to set the env vars to relax to `warn`/`shadow` for emergency rollback, and the operator playbook for what to do when a fairness gate refuses activation (re-train with adjusted features, or skip activation, or override per-incident).
+7. **Tests** — covers (a) dossier rendering against a ModelVersion with deciles + psi_by_feature populated, (b) trainer writes `training_metadata.psi_by_feature` on training, (c) backfill command populates the field idempotently, (d) settings default to strict gate modes, (e) regression: existing fairness-gate `block` rejection path still raises and surfaces the failure reason cleanly.
+
+## Components
+
+### 1. Dossier path fix
+
+**File**: `backend/apps/ml_engine/services/mrm_dossier.py:231-238`
+
+Current:
+
+```python
+def _calibration_section(mv) -> str:
+    """§6 — Calibration report (decile table)."""
+    calibration = mv.calibration_data or {}
+    deciles = calibration.get("deciles") or calibration.get("decile_analysis") or []
+    if not deciles:
+        return (
+            "## 6. Calibration report\n\n"
+            "Decile calibration not recorded. Re-train with v1.9.0+ trainer which "
+            "emits `calibration_data.deciles` on every run."
+        )
+```
+
+Replacement: read deciles from `mv.decile_analysis` (the separate JSONField), keeping the existing fallback for legacy bundles that stored deciles inside `calibration_data`. The existing fallback ordering matters — preserve it.
+
+```python
+def _calibration_section(mv) -> str:
+    """§6 — Calibration report (decile table)."""
+    decile_analysis = mv.decile_analysis or {}
+    calibration = mv.calibration_data or {}
+    deciles = (
+        decile_analysis.get("deciles")
+        or calibration.get("deciles")
+        or calibration.get("decile_analysis")
+        or []
+    )
+    if not deciles:
+        return (
+            "## 6. Calibration report\n\n"
+            "Decile calibration not recorded. Re-train with v1.9.0+ trainer which "
+            "emits `decile_analysis.deciles` on every run."
+        )
+```
+
+The change is one line plus updating the empty-state message to reflect the canonical path.
+
+### 2. Trainer PSI mirror
+
+**File**: `backend/apps/ml_engine/services/trainer.py:945-953`
+
+Current trainer block (around the `psi_by_feature` write):
+
+```python
+try:
+    metrics["psi_by_feature"] = psi_by_feature(
+        X_train if isinstance(X_train, pd.DataFrame) else pd.DataFrame(X_train, columns=feature_cols),
+        X_test if isinstance(X_test, pd.DataFrame) else pd.DataFrame(X_test, columns=feature_cols),
+        feature_cols,
+    )
+except Exception as _psi_exc:
+    logger.warning("psi_by_feature computation failed: %s", _psi_exc)
+    metrics["psi_by_feature"] = {}
+```
+
+Augment the `metrics["training_metadata"] = { ... }` block (around line 986-1014) to mirror the value into `training_metadata`:
+
+Find the line `"reference_probabilities": list(...),` and insert immediately before it:
+
+```python
+"psi_by_feature": dict(metrics.get("psi_by_feature") or {}),
+```
+
+This keeps the top-level metrics["psi_by_feature"] write site untouched (other consumers may rely on it) and adds a mirror under `training_metadata` for the dossier.
+
+### 3. `backfill_psi_by_feature` management command
+
+**File (new)**: `backend/apps/ml_engine/management/commands/backfill_psi_by_feature.py`
+
+Args:
+
+```
+python manage.py backfill_psi_by_feature
+    [--model-id <uuid> | --all-active]
+    [--sample 5000]
+    [--force]
+```
+
+Behavior:
+
+- Resolve target model(s). Default `--all-active`.
+- Skip targets whose `training_metadata.psi_by_feature` is already populated unless `--force`.
+- For each target:
+  - Load bundle via `_validate_model_path` + `joblib.load`.
+  - Generate a fresh `DataGenerator` batch of `--sample` rows.
+  - Apply `predictor._transform` to get the engineered DataFrame in the same shape the trainer used (mirrors the pattern from `backfill_reference_distribution`).
+  - Use the bundle's stored `reference_distribution.feature_distributions` (populated by Task 3 of `2026-05-08-drift-tiles-design.md`) as the "train" side. Use the engineered DataGenerator output as the "test" side.
+  - Call `psi_by_feature(train_df, test_df, feature_cols)` (the existing helper in `apps.ml_engine.services.metrics`).
+  - Write the resulting dict into `mv.training_metadata["psi_by_feature"]` with `mv.save(update_fields=["training_metadata"])`.
+- Refuses to overwrite without `--force`.
+
+### 4. Strict gate defaults
+
+**File**: `backend/config/settings/base.py:241,252,263`
+
+Three single-line edits:
+
+```python
+CREDIT_POLICY_OVERLAY_MODE = os.environ.get("CREDIT_POLICY_OVERLAY_MODE", "enforce")
+...
+ML_FAIRNESS_GATE_MODE = os.environ.get("ML_FAIRNESS_GATE_MODE", "block")
+...
+ML_PROMOTION_GATE_MODE = os.environ.get("ML_PROMOTION_GATE_MODE", "block")
+```
+
+Existing env-var override semantics are preserved — operators can set `ML_FAIRNESS_GATE_MODE=warn` in `.env` to relax for emergency rollback. The change is the safe default, not the locked-down behaviour.
+
+### 5. `next-env.d.ts` revert
+
+**File**: `frontend/next-env.d.ts`
+
+Restore to the master content:
+
+```typescript
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+```
+
+The dev-only `./.next/dev/types/routes.d.ts` import path is dropped. Next.js regenerates this file on every dev / build run; the committed copy is the standard auto-generated content.
+
+### 6. RUNBOOK addendum
+
+**File**: `backend/docs/RUNBOOK.md` (append a new section)
+
+New section: `## Strict gate defaults — when and how to relax`. Documents:
+
+- The three env-var defaults flipped from advisory → enforcement.
+- What "fairness gate refuses activation" looks like operationally (training task raises `FairnessGateBlocked`; old segment model stays active).
+- Emergency rollback: `ML_FAIRNESS_GATE_MODE=warn` in `.env` + service restart.
+- Decision tree when a real fairness violation surfaces: re-train with adjusted feature engineering / re-bin / etc, or accept the violation with explicit operator sign-off and flip to `warn` for one training run.
+- Pointer to existing `2026-05-07-ml-fairness-gate-mode-design.md` for the underlying gate machinery.
+
+### 7. Tests
+
+- `backend/tests/test_mrm_dossier_calibration.py` — unit test that builds a stub ModelVersion with `decile_analysis.deciles` populated and asserts the dossier renders the calibration table (not the "not recorded" empty-state).
+- `backend/tests/test_trainer_psi_mirror.py` — unit test that builds a synthetic training run and asserts `metrics["training_metadata"]["psi_by_feature"]` is populated with the same keys as `metrics["psi_by_feature"]`.
+- `backend/tests/test_backfill_psi_by_feature.py` — three tests: populates_missing, refuses_without_force_when_present, force_overwrites (mirrors the structure of `test_backfill_reference_distribution.py`).
+- `backend/tests/test_settings_strict_gate_defaults.py` — asserts `settings.ML_FAIRNESS_GATE_MODE == "block"`, `settings.ML_PROMOTION_GATE_MODE == "block"`, `settings.CREDIT_POLICY_OVERLAY_MODE == "enforce"` when no env vars set.
+- Regression: confirm the existing `test_fairness_gate_block_mode` style test still passes (the gate logic itself is unchanged; only the default mode changes).
+
+## Data flow
+
+The trainer pipeline is unchanged at the metric-computation level; only the metadata mirror is added:
+
+```
+trainer.train() ──► metrics dict
+                       ├─ "psi_by_feature": <dict>            (top-level, unchanged)
+                       └─ "training_metadata": {
+                            ...,
+                            "psi_by_feature": <dict>          (NEW mirror, this PR)
+                            ...
+                          }
+                       │
+                       ▼
+                 tasks.py:149 → ModelVersion.training_metadata = metrics["training_metadata"]
+                       │
+                       ▼
+                 mrm_dossier.py:_psi_section() reads training_metadata.psi_by_feature → renders table
+```
+
+Backfill command operates on existing rows that lack the mirror — it computes PSI from the bundle's stored reference distribution + a fresh DataGenerator batch, writes into the same `training_metadata.psi_by_feature` slot.
+
+## Error handling
+
+| Component | Failure mode | Behavior |
+|---|---|---|
+| Dossier path fix | `mv.decile_analysis` is None or empty dict | Existing fallback chain still applies; empty-state line renders. No new exception path. |
+| Trainer PSI mirror | `metrics["psi_by_feature"]` missing | `dict(metrics.get("psi_by_feature") or {})` → empty dict mirrored. Non-blocking. |
+| Backfill cmd | Bundle path invalid | Existing `_validate_model_path` raises; command exits non-zero with clear message. |
+| Backfill cmd | Field already populated, no `--force` | Refuse with stderr message; exit 0 (cron-friendly). |
+| Backfill cmd | `psi_by_feature` computation fails (e.g., feature shape drift) | `try/except`, log warning, write empty dict, exit 0. Drift-readiness is opportunistic. |
+| Strict defaults | New training fails fairness gate after deploy | Existing `FairnessGateBlocked` exception raises; outer training task wrapper releases the lock; old segment model stays active. Operator sees the failure in Celery logs + flower. |
+| `next-env.d.ts` revert | None — pure file revert | n/a |
+
+## Testing
+
+- `pytest backend/tests/test_mrm_dossier_calibration.py -v` → asserts dossier reads from `decile_analysis`.
+- `pytest backend/tests/test_trainer_psi_mirror.py -v` → asserts mirror is written.
+- `pytest backend/tests/test_backfill_psi_by_feature.py -v` → 3/3 idempotency tests pass.
+- `pytest backend/tests/test_settings_strict_gate_defaults.py -v` → settings default assertions.
+- Manual: `python manage.py backfill_psi_by_feature --all-active` against the live `1c21d19b` model populates `training_metadata.psi_by_feature` with non-empty keys; re-running without `--force` skips; with `--force` overwrites.
+- Manual: regenerate the dossier for the active model (`python manage.py generate_mrm_dossier --model-id 1c21d19b...`) — verify §6 Calibration and §7 PSI sections render real tables, not "not recorded" stubs.
+- Manual: `npm run build` in `frontend/` from a clean checkout (after the revert) succeeds; typecheck passes.
+
+## File touch list
+
+- MODIFY `backend/apps/ml_engine/services/mrm_dossier.py` (calibration section path fix).
+- MODIFY `backend/apps/ml_engine/services/trainer.py` (psi_by_feature mirror in training_metadata block).
+- NEW `backend/apps/ml_engine/management/commands/backfill_psi_by_feature.py`.
+- MODIFY `backend/config/settings/base.py` (3 default flips: shadow→enforce, warn→block, warn→block).
+- MODIFY `frontend/next-env.d.ts` (revert).
+- MODIFY `backend/docs/RUNBOOK.md` (append "Strict gate defaults" section).
+- NEW `backend/tests/test_mrm_dossier_calibration.py`.
+- NEW `backend/tests/test_trainer_psi_mirror.py`.
+- NEW `backend/tests/test_backfill_psi_by_feature.py`.
+- NEW `backend/tests/test_settings_strict_gate_defaults.py`.
+
+## Out of scope
+
+- **Auto-demotion of the current non-compliant `1c21d19b` active model.** Destructive; user decides via re-train or admin. Surfacing-only is the contract here.
+- **Runtime check that prevents inference on a non-compliant active model.** Affects the prediction path; bigger blast radius. File as follow-up if desired.
+- **Refactoring duplicate gate-mode env-var reads** (multiple files use `getattr(settings, "ML_FAIRNESS_GATE_MODE", "warn")` patterns). Mechanical change; orthogonal.
+- **Re-running the GMSC benchmark** to confirm no regression after the gate-mode flip. The flip is pure config; no model behaviour changes.
+- **Codex-flagged "Block activation of models that do not emit calibration deciles and PSI metrics"**: the trainer already always emits these (Task 4 of drift-tiles + this PR's mirror). Adding a *block-on-missing-evidence* enforcement check is YAGNI given the data is now reliably present. File as follow-up if desired.


### PR DESCRIPTION
## Summary

Closes the three findings from the Codex adversarial review run on the working tree: gate-mode defaults too lax, dossier reading the wrong field for calibration, and `next-env.d.ts` hand-edit. Stacked on top of #182 (drift-tiles fix).

## Findings closed

### Finding #1 [high] — Active model can silently activate while non-compliant

The deployment defaulted to advisory modes on three governance gates (`shadow` for `CREDIT_POLICY_OVERLAY_MODE`, `warn` for both `ML_FAIRNESS_GATE_MODE` and `ML_PROMOTION_GATE_MODE`). The active model `1c21d19b...` (xgb v20260508_174941) was marked `Compliance status: NON-COMPLIANT` (4/5ths fairness rule fails on `state` and `employment_type`) and yet got activated.

**Fix:** flipped defaults to `enforce` / `block` / `block` in `backend/config/settings/base.py`. Env-var override semantics preserved — operators can still set `ML_FAIRNESS_GATE_MODE=warn` for emergency rollback (documented in RUNBOOK).

The currently-active non-compliant model is **not auto-demoted**. Going forward, any future training run that fails the fairness gate will be blocked from activating; the existing active model stays in place. Operator decides re-train (must clear fairness) or admin-deactivate. Auto-demotion was deliberately scoped out — too destructive for "fix Codex findings".

### Finding #2 [high] — Dossier reports calibration + PSI missing while data exists

Two separate bugs in the same finding:

**(a) Wrong field lookup in `mrm_dossier.py`.** `_calibration_section` read `mv.calibration_data["deciles"]`, but the trainer stores deciles on the separate `mv.decile_analysis` JSONField. Even on freshly trained models the dossier rendered "Decile calibration not recorded".

**(b) Mirror gap in `trainer.py`.** `psi_by_feature` was written to top-level `metrics["psi_by_feature"]`, but `ModelVersion.training_metadata` is populated from `metrics["training_metadata"]` only — so the field never reached the DB. The dossier reads `mv.training_metadata.psi_by_feature` and consequently always rendered "No PSI data recorded".

**Fixes:**
- `mrm_dossier._calibration_section` now reads `mv.decile_analysis.deciles` first, with the legacy `calibration_data` paths as fallbacks. Also reshaped the table to match what `compute_decile_analysis` actually emits (`actual_rate`, `cumulative_rate`, `lift`, `count`) — the previous "Expected PD" column had no source data.
- Trainer mirrors `psi_by_feature` into `metrics["training_metadata"]` so it propagates via the existing `tasks.py:149` path.
- New `backfill_psi_by_feature` mgmt command for models that pre-date the trainer mirror — computes per-feature PSI between the bundle's stored `feature_distributions` (training reference) and a fresh DataGenerator batch.
- Same lookup-chain fix applied to `mrm_compliance.py:48` (caught by final review — same bug class would have flagged every newly-trained model as missing calibration evidence).

### Finding #3 [medium] — `next-env.d.ts` hand-edit

The file already matched master content on this branch — no commit needed. Codex was reviewing the working tree state which had pre-existing user WIP that wasn't tracked.

## Live verification

Before this PR, the active `1c21d19b...` model's dossier §6 + §7 rendered the "not recorded" stubs. After running the new commands locally:

```bash
$ docker exec ... python manage.py backfill_psi_by_feature --all-active --sample 5000
[ok] xgb v20260508_174941: wrote psi_by_feature with 79 feature columns

$ docker exec ... python manage.py generate_mrm_dossier 1c21d19b-f1a9-43ce-a115-fdef602d410d
Dossier written: /app/ml_models/1c21d19b-.../mrm.md
```

§6 Calibration now renders 10 decile rows (actual_rate 0.12 → 0.95 monotonic, lift 0.22 → 1.69). §7 PSI renders 79 feature rows sorted desc — top drift `dti_x_rate_sensitivity = 0.1119 ⚠ moderate`.

## Tests

12/12 new tests passing:

- `test_mrm_dossier_calibration.py` — 4 tests: canonical path, legacy fallback, observed-key fallback, empty state
- `test_trainer_psi_mirror.py` — 1 test: 300-row training run mirrors `psi_by_feature` into `training_metadata`
- `test_backfill_psi_by_feature.py` — 3 tests: populates / refuses-without-force / force-overwrites
- `test_settings_strict_gate_defaults.py` — 4 tests: each default + env-var override path

## Diff stats

9 commits, 7 source files touched. ~+200 / −16 lines (excluding plan + spec docs).

## Deliberate divergences from spec

- `backfill_psi_by_feature` raises `CommandError` on PSI compute failure rather than writing `{}` and exiting 0. Spec error-handling table said write-empty; implementer chose fail-loud, which I'm endorsing — silent empty would mask real upstream issues.

## Follow-ups

- `test_settings_strict_gate_defaults.py` could use a session-scope teardown that reloads `base` once after the suite to avoid leaking the last test's monkeypatched env into any future settings-reading test.
- An auto-demotion runtime check that prevents inference on a non-compliant active model was deliberately out of scope (affects the prediction path; bigger blast radius).

## Test plan

- [x] 12/12 unit tests pass
- [x] Live: backfill + dossier regeneration on active `1c21d19b...` model produces real Calibration and PSI tables
- [x] Live: env-var override of gate mode still respected
- [ ] Reviewer to confirm `git diff feat/drift-tiles-fix...HEAD --stat` shows only this PR's scope
- [ ] **Stacked PR retarget reminder:** if #182 (parent) is merged with `--delete-branch`, retarget this PR to master BEFORE the delete to avoid auto-close.

## Closes

- Codex adversarial review (run via `/codex:adversarial-review` 2026-05-09)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>