### PR TITLE
perf(email): wire Anthropic prompt caching for the denial-email path

### DIFF
--- a/backend/apps/agents/services/api_budget.py
+++ b/backend/apps/agents/services/api_budget.py
@@ -46,10 +46,38 @@ MODEL_PRICING = {
 _DEFAULT_PRICING = {"input": 3.00, "output": 15.00}
 
 
-def estimate_cost_usd(input_tokens, output_tokens, model=""):
-    """Estimate cost in USD for a single API call."""
+# Anthropic prompt-caching multipliers, applied to the model's normal
+# input rate. Cache writes (cache_creation_input_tokens) cost 1.25× the
+# base input rate as a one-time write penalty; cache reads
+# (cache_read_input_tokens) cost 0.10× — the savings that make caching
+# worth it. Without these multipliers, every cached call silently
+# under-reports cost vs the actual Anthropic invoice.
+# Docs: https://docs.claude.com/en/docs/build-with-claude/prompt-caching
+CACHE_WRITE_MULTIPLIER = 1.25
+CACHE_READ_MULTIPLIER = 0.10
+
+
+def estimate_cost_usd(
+    input_tokens,
+    output_tokens,
+    model="",
+    cache_creation_input_tokens=0,
+    cache_read_input_tokens=0,
+):
+    """Estimate cost in USD for a single API call.
+
+    Splits input cost across three buckets per Anthropic's caching billing:
+    standard input (1×), cache writes (1.25×), cache reads (0.10×). Callers
+    that don't use prompt caching pass 0 for the cache fields and get the
+    same answer as before.
+    """
     pricing = MODEL_PRICING.get(model, _DEFAULT_PRICING)
-    cost = (input_tokens * pricing["input"] + output_tokens * pricing["output"]) / 1_000_000
+    cost = (
+        input_tokens * pricing["input"]
+        + cache_creation_input_tokens * pricing["input"] * CACHE_WRITE_MULTIPLIER
+        + cache_read_input_tokens * pricing["input"] * CACHE_READ_MULTIPLIER
+        + output_tokens * pricing["output"]
+    ) / 1_000_000
     return round(cost, 6)
 
 
@@ -156,8 +184,21 @@ class ApiBudgetGuard:
                 e,
             )
 
-    def record_call(self, input_tokens=0, output_tokens=0, model=""):
-        """Increment daily call counter, token usage, and dollar cost."""
+    def record_call(
+        self,
+        input_tokens=0,
+        output_tokens=0,
+        model="",
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+    ):
+        """Increment daily call counter, token usage, and dollar cost.
+
+        ``cache_creation_input_tokens`` and ``cache_read_input_tokens`` come
+        from ``response.usage`` when Anthropic prompt caching is active.
+        They are billed at 1.25× and 0.10× the model's input rate
+        respectively — see ``estimate_cost_usd``.
+        """
         try:
             r = self._get_redis()
             pipe = r.pipeline()
@@ -167,25 +208,53 @@ class ApiBudgetGuard:
             cost_key = self._daily_key("cost_cents")
 
             # Calculate cost in cents for integer-safe Redis storage
-            cost_usd = estimate_cost_usd(input_tokens, output_tokens, model)
+            cost_usd = estimate_cost_usd(
+                input_tokens,
+                output_tokens,
+                model,
+                cache_creation_input_tokens=cache_creation_input_tokens,
+                cache_read_input_tokens=cache_read_input_tokens,
+            )
             cost_cents = max(1, int(cost_usd * 100))  # minimum 1 cent per call
+
+            # Total wire-tokens covers all three input buckets plus output —
+            # the daily "tokens" stat should reflect the real volume Anthropic
+            # processed, not just the un-cached portion.
+            total_wire_tokens = (
+                input_tokens
+                + output_tokens
+                + cache_creation_input_tokens
+                + cache_read_input_tokens
+            )
 
             pipe.incr(calls_key)
             pipe.expire(calls_key, self.KEY_TTL)
-            pipe.incrby(tokens_key, input_tokens + output_tokens)
+            pipe.incrby(tokens_key, total_wire_tokens)
             pipe.expire(tokens_key, self.KEY_TTL)
             pipe.incrby(cost_key, cost_cents)
             pipe.expire(cost_key, self.KEY_TTL)
 
             pipe.execute()
 
-            logger.info(
-                "API call recorded: %d in + %d out tokens, model=%s, cost=$%.4f",
-                input_tokens,
-                output_tokens,
-                model or "unknown",
-                cost_usd,
-            )
+            if cache_creation_input_tokens or cache_read_input_tokens:
+                logger.info(
+                    "API call recorded: %d in + %d out + %d cache_create + %d cache_read tokens, "
+                    "model=%s, cost=$%.4f",
+                    input_tokens,
+                    output_tokens,
+                    cache_creation_input_tokens,
+                    cache_read_input_tokens,
+                    model or "unknown",
+                    cost_usd,
+                )
+            else:
+                logger.info(
+                    "API call recorded: %d in + %d out tokens, model=%s, cost=$%.4f",
+                    input_tokens,
+                    output_tokens,
+                    model or "unknown",
+                    cost_usd,
+                )
         except (redis.RedisError, ConnectionError, TimeoutError) as e:
             logger.warning("Failed to record API call (Redis): %s", e)
 
@@ -318,11 +387,25 @@ def guarded_api_call(client, **kwargs):
         budget.record_failure()
         raise
 
-    # Track cost from actual usage
+    # Track cost from actual usage. Anthropic splits input across three
+    # buckets when prompt caching is active — record all three so the
+    # daily budget matches the real invoice (not the un-cached portion).
     usage = getattr(response, "usage", None)
     input_tokens = getattr(usage, "input_tokens", 0) if usage else 0
     output_tokens = getattr(usage, "output_tokens", 0) if usage else 0
-    budget.record_call(input_tokens=input_tokens, output_tokens=output_tokens, model=model)
+    cache_creation_input_tokens = (
+        getattr(usage, "cache_creation_input_tokens", 0) if usage else 0
+    ) or 0
+    cache_read_input_tokens = (
+        getattr(usage, "cache_read_input_tokens", 0) if usage else 0
+    ) or 0
+    budget.record_call(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        model=model,
+        cache_creation_input_tokens=cache_creation_input_tokens,
+        cache_read_input_tokens=cache_read_input_tokens,
+    )
     budget.record_success()
 
     # Log API call for PII cross-border audit (Privacy Act APP 8)

--- a/backend/apps/email_engine/metrics.py
+++ b/backend/apps/email_engine/metrics.py
@@ -3,7 +3,7 @@
 Backs the `email_generation_total` SLO documented in `docs/slo.md`
 (98 % success rate over 30-day window).
 
-Labels:
+Labels on `email_generation_total`:
 - `decision` — approved | denied
 - `source`   — claude_api | template_fallback
 - `status`   — success | guardrail_fail | api_error
@@ -13,6 +13,13 @@ non-warning guardrail check passing. Guardrail-fail counts emails that
 generated but tripped a blocker (e.g. regulatory phrase, hallucinated
 number) and thus did not reach the customer. `api_error` covers Claude
 API failures that end up falling back to the template path.
+
+`email_llm_input_tokens_total` exposes the three input-token buckets
+Anthropic reports when prompt caching is active. Cache hit ratio in
+production is
+``sum(cache_read) / sum(standard) + sum(cache_create) + sum(cache_read)``
+— without this metric you can't see whether the cache is actually paying
+off after `EMAIL_GENERATION_MODE` is flipped to `api`.
 """
 
 from prometheus_client import Counter
@@ -21,4 +28,10 @@ email_generation_total = Counter(
     "email_generation_total",
     "Email generation outcomes by decision, source, and status",
     labelnames=["decision", "source", "status"],
+)
+
+email_llm_input_tokens_total = Counter(
+    "email_llm_input_tokens_total",
+    "Claude API input tokens by category — standard, cache_create (write), cache_read (hit)",
+    labelnames=["decision", "type"],
 )

--- a/backend/apps/email_engine/services/email_generator.py
+++ b/backend/apps/email_engine/services/email_generator.py
@@ -5,12 +5,13 @@ import time
 import anthropic
 import httpx
 
+from utils.api_helpers import build_cached_call_kwargs
 from utils.sanitization import sanitize_prompt_input as _sanitize_prompt_input
 
 from .documentation import build_documentation_checklist
 from .guardrails import GuardrailChecker
 from .pricing import calculate_loan_pricing
-from .prompts import APPROVAL_EMAIL_PROMPT, DENIAL_EMAIL_PROMPT
+from .prompts import APPROVAL_EMAIL_PROMPT, DENIAL_DATA_TEMPLATE, DENIAL_EMAIL_INSTRUCTIONS
 
 _metrics_logger = logging.getLogger("email_engine.metrics")
 
@@ -268,7 +269,12 @@ class EmailGenerator:
                 decision_obj.feature_importances if decision_obj else None,
                 shap_values=decision_obj.shap_values if decision_obj else None,
             )
-            prompt = DENIAL_EMAIL_PROMPT.format(
+            # Denial path: instructions in cached system prompt
+            # (DENIAL_EMAIL_INSTRUCTIONS, ~4.5k tokens, identical every call →
+            # Anthropic prompt caching applies), dynamic data in user message.
+            # Approval still uses the old single-string format until its
+            # template is split the same way.
+            prompt = DENIAL_DATA_TEMPLATE.format(
                 applicant_name=applicant_name,
                 loan_amount=float(application.loan_amount),
                 purpose=application.get_purpose_display(),
@@ -332,6 +338,17 @@ class EmailGenerator:
             max_api_retries = 3
             response = None
             _model = "claude-sonnet-4-6"
+            # Construct call kwargs once. Denial path uses the cached
+            # system prompt + dynamic user message (build_cached_call_kwargs);
+            # approval path still uses the legacy single user message until
+            # its template is split the same way.
+            if decision == "approved":
+                api_kwargs = {"messages": [{"role": "user", "content": prompt}]}
+            else:
+                api_kwargs = build_cached_call_kwargs(
+                    system_text=DENIAL_EMAIL_INSTRUCTIONS,
+                    user_text=prompt,
+                )
             for api_attempt in range(max_api_retries):
                 try:
                     response = guarded_api_call(
@@ -339,9 +356,9 @@ class EmailGenerator:
                         model=_model,
                         max_tokens=token_limit,
                         temperature=getattr(django_settings, "AI_TEMPERATURE_DECISION_EMAIL", 0.0),
-                        messages=[{"role": "user", "content": prompt}],
                         tools=[EMAIL_SUBMIT_TOOL],
                         tool_choice={"type": "tool", "name": "submit_email"},
+                        **api_kwargs,
                     )
                     break  # Success — exit retry loop
                 except BudgetExhausted:

--- a/backend/apps/email_engine/services/email_generator.py
+++ b/backend/apps/email_engine/services/email_generator.py
@@ -14,6 +14,7 @@ from .pricing import calculate_loan_pricing
 from .prompts import APPROVAL_EMAIL_PROMPT, DENIAL_DATA_TEMPLATE, DENIAL_EMAIL_INSTRUCTIONS
 
 _metrics_logger = logging.getLogger("email_engine.metrics")
+_generator_logger = logging.getLogger("email_engine.generator")
 
 
 def _record_email_metric(decision: str, source: str, passed_guardrails: bool) -> None:
@@ -29,6 +30,31 @@ def _record_email_metric(decision: str, source: str, passed_guardrails: bool) ->
         ).inc()
     except Exception as exc:  # noqa: BLE001 — metric emission is best-effort
         _metrics_logger.debug("email_generation_total emission failed: %s", exc)
+
+
+def _record_token_usage_metric(
+    decision: str,
+    input_tokens: int,
+    cache_creation_input_tokens: int,
+    cache_read_input_tokens: int,
+) -> None:
+    """Emit `email_llm_input_tokens_total` so dashboards can see cache
+    hit ratio in production. Best-effort — never breaks the email path."""
+    try:
+        from apps.email_engine.metrics import email_llm_input_tokens_total
+
+        decision_label = decision or "unknown"
+        for token_type, count in (
+            ("standard", input_tokens),
+            ("cache_create", cache_creation_input_tokens),
+            ("cache_read", cache_read_input_tokens),
+        ):
+            if count > 0:
+                email_llm_input_tokens_total.labels(
+                    decision=decision_label, type=token_type
+                ).inc(count)
+    except Exception as exc:  # noqa: BLE001 — metric emission is best-effort
+        _metrics_logger.debug("email_llm_input_tokens_total emission failed: %s", exc)
 
 
 EMAIL_SUBMIT_TOOL = {
@@ -331,6 +357,8 @@ class EmailGenerator:
 
         input_tokens = 0
         output_tokens = 0
+        cache_creation_input_tokens = 0
+        cache_read_input_tokens = 0
         try:
             # Retry with exponential backoff on rate limit (429) errors.
             # The org-level limit is 30k input tokens/min — with prompts
@@ -366,9 +394,7 @@ class EmailGenerator:
                 except anthropic.RateLimitError:
                     if api_attempt < max_api_retries - 1:
                         wait = 2**api_attempt * 30  # 30s, 60s, 120s
-                        import logging
-
-                        logging.getLogger(__name__).warning(
+                        _generator_logger.warning(
                             "Rate limited (429), retrying in %ds (attempt %d/%d)",
                             wait,
                             api_attempt + 1,
@@ -378,11 +404,22 @@ class EmailGenerator:
                     else:
                         raise  # Final attempt — propagate to outer handler
 
-            # Read actual token usage from the response
+            # Read actual token usage from the response. Anthropic splits
+            # input across three buckets when prompt caching is active:
+            # `input_tokens` (standard, 1×), `cache_creation_input_tokens`
+            # (1.25× one-time write penalty), `cache_read_input_tokens`
+            # (0.10× cache hit savings). The `or 0` guards against the SDK
+            # returning None on calls that didn't touch the cache.
             usage = getattr(response, "usage", None)
             if usage:
-                input_tokens = getattr(usage, "input_tokens", 0)
-                output_tokens = getattr(usage, "output_tokens", 0)
+                input_tokens = getattr(usage, "input_tokens", 0) or 0
+                output_tokens = getattr(usage, "output_tokens", 0) or 0
+                cache_creation_input_tokens = (
+                    getattr(usage, "cache_creation_input_tokens", 0) or 0
+                )
+                cache_read_input_tokens = (
+                    getattr(usage, "cache_read_input_tokens", 0) or 0
+                )
         except BudgetExhausted:
             return self._generate_fallback(application, decision, context, start_time)
         # Failure accounting (record_failure, circuit-breaker tripping) happens
@@ -425,6 +462,12 @@ class EmailGenerator:
             )
 
         _record_email_metric(decision=decision, source="claude_api", passed_guardrails=all_passed)
+        _record_token_usage_metric(
+            decision=decision,
+            input_tokens=input_tokens,
+            cache_creation_input_tokens=cache_creation_input_tokens,
+            cache_read_input_tokens=cache_read_input_tokens,
+        )
 
         return {
             "subject": subject,
@@ -438,19 +481,17 @@ class EmailGenerator:
             "template_fallback": False,
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
+            "cache_creation_input_tokens": cache_creation_input_tokens,
+            "cache_read_input_tokens": cache_read_input_tokens,
         }
 
     def _parse_tool_response(self, response):
         """Extract subject and body from tool_use structured response."""
-        import logging
-
-        logger = logging.getLogger("email_engine.generator")
-
         # Detect truncation: stop_reason == 'max_tokens' means the response
         # was cut off and the tool_use JSON is likely incomplete/empty.
         stop_reason = getattr(response, "stop_reason", None)
         if stop_reason == "max_tokens":
-            logger.warning(
+            _generator_logger.warning(
                 "Claude response truncated (stop_reason=max_tokens) — max_tokens too low for this email template"
             )
 
@@ -462,12 +503,12 @@ class EmailGenerator:
                 return subject, body
             # Tool block found but body is empty — likely truncated
             if subject and not body:
-                logger.warning(
+                _generator_logger.warning(
                     "Tool response has subject but empty body (stop_reason=%s) — falling back to text parse",
                     stop_reason,
                 )
         except (StopIteration, AttributeError) as exc:
-            logger.debug(
+            _generator_logger.debug(
                 "tool_block_missing_falling_back_to_text",
                 extra={"error": type(exc).__name__, "stop_reason": stop_reason},
             )
@@ -507,11 +548,8 @@ class EmailGenerator:
         Sends a minimal 1-token request. Returns False on billing, auth,
         or connection errors so the caller can fall back to templates.
         """
-        import logging
-
-        logger = logging.getLogger("email_engine.generator")
         if self.client is None:
-            logger.info("No API client configured — using template fallback")
+            _generator_logger.info("No API client configured — using template fallback")
             return False
         try:
             self.client.messages.create(
@@ -521,15 +559,15 @@ class EmailGenerator:
             )
             return True
         except anthropic.AuthenticationError:
-            logger.warning("Claude API auth failed — using template fallback")
+            _generator_logger.warning("Claude API auth failed — using template fallback")
             return False
         except anthropic.BadRequestError as e:
             if "credit" in str(e).lower() or "balance" in str(e).lower():
-                logger.warning("Claude API credit insufficient — using template fallback")
+                _generator_logger.warning("Claude API credit insufficient — using template fallback")
                 return False
             return True  # other bad request errors may be prompt-specific
         except (anthropic.APIConnectionError, anthropic.APITimeoutError):
-            logger.warning("Claude API unreachable — using template fallback")
+            _generator_logger.warning("Claude API unreachable — using template fallback")
             return False
         except Exception:
             return True  # let the main flow handle unexpected errors
@@ -626,4 +664,6 @@ class EmailGenerator:
             "template_fallback": True,
             "input_tokens": 0,
             "output_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
         }

--- a/backend/apps/email_engine/services/prompts.py
+++ b/backend/apps/email_engine/services/prompts.py
@@ -236,16 +236,9 @@ This communication is confidential and intended solely for the named recipient.
 (End of template. Reproduce this template EXACTLY for this applicant, substituting ONLY: the applicant's name, loan type derived from purpose, loan amount, loan term if available, documentation checklist items from the DOCUMENTATION section above, and any LOAN PRICING figures if provided. Every other word stays identical.)
 """
 
-DENIAL_EMAIL_PROMPT = """You are drafting a formal decline letter from AussieLoanAI, an Australian lender. Under the 2025 Banking Code of Practice (paragraph 81), you must tell the customer the general reason their loan was not approved. The email should be professional but genuinely empathetic and customer-service-friendly.
+DENIAL_EMAIL_INSTRUCTIONS = """You are drafting a formal decline letter from AussieLoanAI, an Australian lender. Under the 2025 Banking Code of Practice (paragraph 81), you must tell the customer the general reason their loan was not approved. The email should be professional but genuinely empathetic and customer-service-friendly.
 
-Application details:
-- Applicant Name: {applicant_name}
-- Loan Amount Requested: ${loan_amount:,.2f}
-- Loan Purpose: {purpose}
-- Principal Reasons for Decision: {reasons}
-
-=== BANKING RELATIONSHIP ===
-{banking_context}
+The applicant-specific details (name, loan amount, purpose, principal reasons for decision, banking relationship) are provided in the user message that follows these instructions. Use those values when generating the email — never invent your own.
 
 === EMAIL FORMAT AND STRUCTURE ===
 
@@ -439,4 +432,20 @@ Email: info@afca.org.au
 This communication is confidential and intended solely for the named recipient.
 
 (End of template. Reproduce this template EXACTLY for this applicant, substituting ONLY: the applicant's name, loan type derived from purpose, loan amount, reference number, the assessment factor bullets based on the denial reasons provided, the corresponding improvement step bullets, and the "We'd Still Like to Help" paragraph if a specific alternative applies. Every other word stays identical.)
+"""
+
+
+# Per-call dynamic data block for the denial email. Filled at call time
+# in email_generator.py and sent as the user message. The INSTRUCTIONS
+# constant above is sent as the system prompt with cache_control so
+# Anthropic can cache the ~4.5k-token instructions across calls — see
+# utils/api_helpers.py:build_cached_call_kwargs and prompt-caching docs.
+DENIAL_DATA_TEMPLATE = """=== APPLICATION DATA (use these specific values when generating the decline email) ===
+- Applicant Name: {applicant_name}
+- Loan Amount Requested: ${loan_amount:,.2f}
+- Loan Purpose: {purpose}
+- Principal Reasons for Decision: {reasons}
+
+=== BANKING RELATIONSHIP ===
+{banking_context}
 """

--- a/backend/tests/test_api_budget.py
+++ b/backend/tests/test_api_budget.py
@@ -51,6 +51,140 @@ def test_record_call_increments():
     pipe.execute.assert_called_once()
 
 
+# ---------------------------------------------------------------------------
+# Prompt-caching cost math — cache writes (1.25×) and reads (0.10×)
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_cost_no_caching_unchanged():
+    """Without cache fields, cost math matches the pre-caching behavior."""
+    from apps.agents.services.api_budget import estimate_cost_usd
+
+    # claude-sonnet-4-6: $3/M input, $15/M output
+    # 1000 in + 500 out = 1000*3/1M + 500*15/1M = $0.003 + $0.0075 = $0.0105
+    cost = estimate_cost_usd(
+        input_tokens=1000, output_tokens=500, model="claude-sonnet-4-6"
+    )
+    assert cost == round(0.0105, 6)
+
+
+def test_estimate_cost_cache_write_uses_1_25x_multiplier():
+    """cache_creation_input_tokens cost 1.25× the model's normal input
+    rate — the one-time write penalty. A 1000-token write on Sonnet
+    should cost $3 * 1000 * 1.25 / 1M = $0.00375."""
+    from apps.agents.services.api_budget import estimate_cost_usd
+
+    cost = estimate_cost_usd(
+        input_tokens=0,
+        output_tokens=0,
+        model="claude-sonnet-4-6",
+        cache_creation_input_tokens=1000,
+    )
+    expected = round(1000 * 3.00 * 1.25 / 1_000_000, 6)
+    assert cost == expected
+    assert cost > 0.0  # sanity: actually charges something
+
+
+def test_estimate_cost_cache_read_uses_0_10x_multiplier():
+    """cache_read_input_tokens cost 0.10× the model's normal input
+    rate — the cache-hit savings. A 1000-token read on Sonnet should
+    cost $3 * 1000 * 0.10 / 1M = $0.0003."""
+    from apps.agents.services.api_budget import estimate_cost_usd
+
+    cost = estimate_cost_usd(
+        input_tokens=0,
+        output_tokens=0,
+        model="claude-sonnet-4-6",
+        cache_read_input_tokens=1000,
+    )
+    expected = round(1000 * 3.00 * 0.10 / 1_000_000, 6)
+    assert cost == expected
+
+
+def test_estimate_cost_combined_buckets():
+    """Realistic denial-email shape on a cache hit:
+    - 4000 cached system tokens read at 0.10×
+    -  500 dynamic user tokens at 1.00× (standard input)
+    -  800 output tokens at output rate
+    All three should add into the final cost."""
+    from apps.agents.services.api_budget import estimate_cost_usd
+
+    cost = estimate_cost_usd(
+        input_tokens=500,
+        output_tokens=800,
+        model="claude-sonnet-4-6",
+        cache_read_input_tokens=4000,
+    )
+    # $3 * 500 / 1M + $3 * 4000 * 0.10 / 1M + $15 * 800 / 1M
+    # = 0.0015 + 0.0012 + 0.012 = 0.0147
+    expected = round(
+        (500 * 3.00 + 4000 * 3.00 * 0.10 + 800 * 15.00) / 1_000_000, 6
+    )
+    assert cost == expected
+
+
+def test_record_call_passes_cache_tokens_to_cost_math(monkeypatch):
+    """record_call must hand cache tokens to estimate_cost_usd so the
+    daily Redis budget reflects real Anthropic billing, not the
+    un-cached portion only."""
+    from apps.agents.services import api_budget
+
+    received = {}
+
+    def fake_estimate(input_tokens, output_tokens, model="", **kw):
+        received["args"] = (input_tokens, output_tokens, model)
+        received["kw"] = kw
+        return 0.001  # any positive cost
+
+    monkeypatch.setattr(api_budget, "estimate_cost_usd", fake_estimate)
+
+    r = MagicMock()
+    pipe = MagicMock()
+    r.pipeline.return_value = pipe
+    _guard(r).record_call(
+        input_tokens=500,
+        output_tokens=200,
+        model="claude-sonnet-4-6",
+        cache_creation_input_tokens=4000,
+        cache_read_input_tokens=0,
+    )
+
+    assert received["args"] == (500, 200, "claude-sonnet-4-6")
+    assert received["kw"]["cache_creation_input_tokens"] == 4000
+    assert received["kw"]["cache_read_input_tokens"] == 0
+
+
+def test_record_call_total_tokens_includes_cache(monkeypatch):
+    """The daily `tokens` Redis counter must include cache_create + cache_read
+    so the dashboard reflects total wire activity, not just the un-cached portion."""
+    from apps.agents.services import api_budget
+
+    monkeypatch.setattr(
+        api_budget, "estimate_cost_usd", lambda *a, **kw: 0.001
+    )
+
+    r = MagicMock()
+    pipe = MagicMock()
+    r.pipeline.return_value = pipe
+    _guard(r).record_call(
+        input_tokens=500,
+        output_tokens=200,
+        model="claude-sonnet-4-6",
+        cache_creation_input_tokens=4000,
+        cache_read_input_tokens=100,
+    )
+
+    # The tokens key should have been incremented by 500 + 200 + 4000 + 100
+    incrby_calls = pipe.incrby.call_args_list
+    tokens_increments = [
+        call.args[1] for call in incrby_calls if "tokens" in str(call.args[0])
+    ]
+    assert 4800 in tokens_increments, (
+        f"expected total tokens increment of 4800 (500+200+4000+100), "
+        f"got {tokens_increments}"
+    )
+
+
 @override_settings(AI_CIRCUIT_BREAKER_THRESHOLD=3, AI_CIRCUIT_BREAKER_COOLDOWN=600)
 def test_failures_trip_breaker():
     """After threshold consecutive failures, circuit breaker key is set."""

--- a/backend/tests/test_prompt_caching.py
+++ b/backend/tests/test_prompt_caching.py
@@ -1,0 +1,292 @@
+"""Prompt caching wiring — denial path + helper.
+
+The helper (``utils.api_helpers.build_cached_call_kwargs``) wraps the
+static instruction block in Anthropic prompt caching's ``cache_control:
+ephemeral`` form. The denial email path uses it so the ~4.5k-token
+DENIAL_EMAIL_INSTRUCTIONS get cached server-side for 5 min — bringing
+input cost on cache hits down to 10% of the normal rate.
+
+Coverage:
+- helper produces the expected shape
+- denial path API call carries cache_control on the system block
+- denial path API call sends the dynamic application data as the user
+  message (not in the cached system block)
+- approval path is untouched — still single user-message format
+- the cached instructions are large enough to actually trigger
+  caching (Sonnet minimum is 1024 tokens)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from utils.api_helpers import build_cached_call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Helper shape
+# ---------------------------------------------------------------------------
+
+
+def test_helper_returns_system_and_messages():
+    kw = build_cached_call_kwargs(
+        system_text="Static instructions here.",
+        user_text="Dynamic user data here.",
+    )
+    assert "system" in kw and "messages" in kw
+    assert isinstance(kw["system"], list)
+    assert len(kw["system"]) == 1
+
+
+def test_helper_system_block_has_cache_control():
+    kw = build_cached_call_kwargs(
+        system_text="Some instructions.",
+        user_text="Data.",
+    )
+    block = kw["system"][0]
+    assert block["type"] == "text"
+    assert block["text"] == "Some instructions."
+    assert block["cache_control"] == {"type": "ephemeral"}
+
+
+def test_helper_user_message_carries_dynamic_text():
+    kw = build_cached_call_kwargs(
+        system_text="Instructions",
+        user_text="Applicant: Jane Doe, Loan: $50k",
+    )
+    assert kw["messages"] == [
+        {"role": "user", "content": "Applicant: Jane Doe, Loan: $50k"}
+    ]
+
+
+def test_helper_passes_through_extra_kwargs():
+    kw = build_cached_call_kwargs(
+        system_text="x",
+        user_text="y",
+        model="claude-sonnet-4-6",
+        max_tokens=2048,
+        temperature=0.0,
+        tools=[{"name": "submit_email"}],
+        tool_choice={"type": "tool", "name": "submit_email"},
+    )
+    assert kw["model"] == "claude-sonnet-4-6"
+    assert kw["max_tokens"] == 2048
+    assert kw["temperature"] == 0.0
+    assert kw["tools"] == [{"name": "submit_email"}]
+    assert kw["tool_choice"] == {"type": "tool", "name": "submit_email"}
+
+
+# ---------------------------------------------------------------------------
+# DENIAL_EMAIL_INSTRUCTIONS — large enough to actually cache
+# ---------------------------------------------------------------------------
+
+
+def test_denial_instructions_meets_sonnet_cache_minimum():
+    """Anthropic prompt caching needs ≥1024 tokens for Sonnet to
+    actually cache; below that the cache_control directive is a no-op.
+    Rough char heuristic: 4 chars/token for English. We check 4096 chars
+    as a conservative floor (1024 tokens). The real template is ~17k
+    chars; this guards against future shrinking that would silently
+    disable caching."""
+    from apps.email_engine.services.prompts import DENIAL_EMAIL_INSTRUCTIONS
+
+    assert len(DENIAL_EMAIL_INSTRUCTIONS) >= 4096, (
+        f"DENIAL_EMAIL_INSTRUCTIONS is {len(DENIAL_EMAIL_INSTRUCTIONS)} chars "
+        f"(~{len(DENIAL_EMAIL_INSTRUCTIONS) // 4} tokens) — below the Sonnet "
+        "cache-eligibility minimum of ~1024 tokens. Cache_control will be a no-op."
+    )
+
+
+def test_denial_instructions_has_no_format_placeholders():
+    """The instructions block becomes the cached system prompt. If it
+    contains ``{}`` placeholders, ``.format()`` calls in callers
+    accidentally hitting the wrong constant would either KeyError or
+    silently substitute, and the cache key would shift per call.
+    The dynamic data lives in DENIAL_DATA_TEMPLATE instead."""
+    from apps.email_engine.services.prompts import DENIAL_EMAIL_INSTRUCTIONS
+
+    # No bare {placeholder} patterns. We allow {{ }} literal braces
+    # (none present today, but defensive in case future edits add them).
+    import re
+
+    placeholders = re.findall(r"(?<!\{)\{[a-z_]+[^{}]*\}(?!\})", DENIAL_EMAIL_INSTRUCTIONS)
+    assert placeholders == [], (
+        f"DENIAL_EMAIL_INSTRUCTIONS still contains placeholders: {placeholders}. "
+        "Move dynamic values to DENIAL_DATA_TEMPLATE so the instructions stay "
+        "byte-identical across calls (required for prompt caching)."
+    )
+
+
+def test_denial_data_template_has_all_required_placeholders():
+    """The data template is what gets .format()ed at call time. The
+    full set is fixed by the caller in email_generator; missing one
+    would crash on send."""
+    from apps.email_engine.services.prompts import DENIAL_DATA_TEMPLATE
+
+    for placeholder in (
+        "{applicant_name}",
+        "{loan_amount:,.2f}",
+        "{purpose}",
+        "{reasons}",
+        "{banking_context}",
+    ):
+        assert placeholder in DENIAL_DATA_TEMPLATE, f"missing {placeholder}"
+
+
+# ---------------------------------------------------------------------------
+# email_generator denial path — actual API kwargs carry cache_control
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def captured_api_call():
+    """Patch guarded_api_call so we can inspect the kwargs the generator
+    sends to Anthropic without making a real API call."""
+    with patch(
+        "apps.agents.services.api_budget.guarded_api_call"
+    ) as mock_call:
+        # Return a response shaped like a successful tool_use call so
+        # the generator's downstream parsing doesn't crash.
+        fake_response = MagicMock()
+        fake_response.content = [
+            MagicMock(
+                type="tool_use",
+                input={
+                    "subject": "Update on Your Personal Loan Application",
+                    "body": "Dear Test,\n\nThank you for applying...",
+                },
+            )
+        ]
+        fake_response.usage = MagicMock(input_tokens=4000, output_tokens=800, cache_read_input_tokens=0)
+        fake_response.stop_reason = "tool_use"
+        mock_call.return_value = fake_response
+        yield mock_call
+
+
+@pytest.fixture
+def mock_email_application():
+    """Build a minimal application-like mock that the generator can
+    walk without needing a full ORM round-trip."""
+    app = MagicMock()
+    app.applicant.first_name = "Test"
+    app.applicant.last_name = "Applicant"
+    app.applicant.username = "testuser"
+    app.loan_amount = 50000
+    app.credit_score = 720  # needed by approval-path pricing engine
+    app.loan_term_months = 60
+    app.annual_income = 95000
+    app.debt_to_income = 2.0
+    app.employment_length = 5
+    app.purpose = "personal"
+    app.get_purpose_display.return_value = "Personal"
+    app.get_employment_type_display.return_value = "PAYG Permanent"
+    app.get_applicant_type_display.return_value = "Single"
+    app.has_cosigner = False
+    app.has_hecs = False
+    # Profile + decision setups
+    app.applicant.profile = None
+    app.decision = None
+    return app
+
+
+@patch("apps.agents.services.api_budget.ApiBudgetGuard")
+@patch("apps.email_engine.services.email_generator.anthropic.Anthropic")
+def test_denial_path_uses_cached_system_block(
+    mock_anthropic_cls,
+    mock_budget_cls,
+    captured_api_call,
+    mock_email_application,
+    monkeypatch,
+):
+    """End-to-end on the denial branch: the kwargs handed to
+    guarded_api_call must contain a ``system`` list with cache_control
+    on a block that holds the DENIAL_EMAIL_INSTRUCTIONS text."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    # Budget check passes
+    mock_budget = MagicMock()
+    mock_budget.check_budget.return_value = None
+    mock_budget_cls.return_value = mock_budget
+    mock_anthropic_cls.return_value = MagicMock()
+
+    from apps.email_engine.services.email_generator import EmailGenerator
+    from apps.email_engine.services.prompts import DENIAL_EMAIL_INSTRUCTIONS
+
+    gen = EmailGenerator()
+    # Make sure the generator believes the API is available
+    gen._api_available = lambda: True
+
+    gen.generate(
+        application=mock_email_application,
+        decision="denied",
+        confidence=0.45,
+    )
+
+    # The captured fixture patches the api_budget module path; the
+    # generator imports it lazily inside .generate so the patch hits.
+    assert captured_api_call.called, "guarded_api_call was not invoked"
+    kwargs = captured_api_call.call_args.kwargs
+
+    # cache_control must be set on the system block
+    assert "system" in kwargs, f"no system block in kwargs: {list(kwargs.keys())}"
+    system_block = kwargs["system"][0]
+    assert system_block["cache_control"] == {"type": "ephemeral"}, (
+        f"cache_control wrong or missing: {system_block.get('cache_control')!r}"
+    )
+    # The cached text must actually be the denial instructions
+    assert system_block["text"] == DENIAL_EMAIL_INSTRUCTIONS
+
+    # The dynamic data (applicant name etc.) must be in the user message,
+    # NOT in the cached system block (else cache key shifts per call).
+    user_msg = kwargs["messages"][0]
+    assert user_msg["role"] == "user"
+    assert "Test Applicant" in user_msg["content"], (
+        "applicant name should be in dynamic user message"
+    )
+    assert "Test Applicant" not in system_block["text"], (
+        "applicant name leaked into cached system block — would break caching"
+    )
+
+
+@patch("apps.agents.services.api_budget.ApiBudgetGuard")
+@patch("apps.email_engine.services.email_generator.anthropic.Anthropic")
+def test_approval_path_unchanged_no_system_block(
+    mock_anthropic_cls,
+    mock_budget_cls,
+    captured_api_call,
+    mock_email_application,
+    monkeypatch,
+):
+    """Until the approval template is also split, the approval path
+    keeps the legacy single user-message format — no system block,
+    no cache_control. Guards against the denial refactor accidentally
+    bleeding into approvals."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    mock_budget = MagicMock()
+    mock_budget.check_budget.return_value = None
+    mock_budget_cls.return_value = mock_budget
+    mock_anthropic_cls.return_value = MagicMock()
+
+    from apps.email_engine.services.email_generator import EmailGenerator
+
+    gen = EmailGenerator()
+    gen._api_available = lambda: True
+
+    gen.generate(
+        application=mock_email_application,
+        decision="approved",
+        confidence=0.91,
+    )
+
+    if not captured_api_call.called:
+        # Approval may have short-circuited to template fallback for
+        # other reasons (missing fields) — skip if so.
+        pytest.skip("approval path took template fallback in this fixture")
+
+    kwargs = captured_api_call.call_args.kwargs
+    assert "system" not in kwargs, (
+        "approval path leaked a system block — should remain on the legacy "
+        "single user-message format until its template is split"
+    )
+    assert "messages" in kwargs

--- a/backend/tests/test_prompt_caching.py
+++ b/backend/tests/test_prompt_caching.py
@@ -83,19 +83,46 @@ def test_helper_passes_through_extra_kwargs():
 # ---------------------------------------------------------------------------
 
 
-def test_denial_instructions_meets_sonnet_cache_minimum():
-    """Anthropic prompt caching needs ≥1024 tokens for Sonnet to
-    actually cache; below that the cache_control directive is a no-op.
-    Rough char heuristic: 4 chars/token for English. We check 4096 chars
-    as a conservative floor (1024 tokens). The real template is ~17k
-    chars; this guards against future shrinking that would silently
-    disable caching."""
+# Anthropic prompt-caching minimums by model family (in tokens). The
+# cache_control directive is silently a no-op below these thresholds, so
+# the prompt must clear the floor for the active model.
+# Docs: https://docs.claude.com/en/docs/build-with-claude/prompt-caching
+_CACHE_MIN_TOKENS_BY_MODEL = {
+    "claude-opus-4-7": 1024,
+    "claude-opus-4-6": 1024,
+    "claude-sonnet-4-6": 1024,
+    "claude-sonnet-4-20250514": 1024,
+    "claude-haiku-4-5-20251001": 2048,  # Haiku family needs 2× the tokens
+    "claude-haiku-4-20250514": 2048,
+}
+
+# The email generator currently hardcodes this model at
+# email_generator.py:_model (inside .generate). If you swap it, update
+# this constant — the floor changes by family, and the test below catches
+# the case where someone moves to Haiku but the prompt stays the same
+# length and caching silently no-ops.
+_ACTIVE_EMAIL_MODEL = "claude-sonnet-4-6"
+
+
+def test_denial_instructions_meets_active_model_cache_minimum():
+    """The cache_control directive on DENIAL_EMAIL_INSTRUCTIONS only
+    actually caches if the block clears the active model's token floor.
+    We use a conservative 4-char/token heuristic — real English averages
+    closer to 3.5, so this floor is on the safe side. The real template
+    is ~17k chars; this guards against (a) future shrinking that drops
+    below the Sonnet floor, and (b) a model swap to Haiku that silently
+    raises the floor without anyone noticing the regression."""
     from apps.email_engine.services.prompts import DENIAL_EMAIL_INSTRUCTIONS
 
-    assert len(DENIAL_EMAIL_INSTRUCTIONS) >= 4096, (
+    min_tokens = _CACHE_MIN_TOKENS_BY_MODEL[_ACTIVE_EMAIL_MODEL]
+    floor_chars = min_tokens * 4  # 4 chars/token conservative heuristic
+
+    assert len(DENIAL_EMAIL_INSTRUCTIONS) >= floor_chars, (
         f"DENIAL_EMAIL_INSTRUCTIONS is {len(DENIAL_EMAIL_INSTRUCTIONS)} chars "
-        f"(~{len(DENIAL_EMAIL_INSTRUCTIONS) // 4} tokens) — below the Sonnet "
-        "cache-eligibility minimum of ~1024 tokens. Cache_control will be a no-op."
+        f"(~{len(DENIAL_EMAIL_INSTRUCTIONS) // 4} tokens) — below the "
+        f"{_ACTIVE_EMAIL_MODEL} cache-eligibility minimum of ~{min_tokens} "
+        f"tokens ({floor_chars} chars at 4 char/token). cache_control will be "
+        "a silent no-op until the prompt grows back above the floor."
     )
 
 
@@ -290,3 +317,108 @@ def test_approval_path_unchanged_no_system_block(
         "single user-message format until its template is split"
     )
     assert "messages" in kwargs
+
+
+# ---------------------------------------------------------------------------
+# Cache stability — system block must be byte-identical across calls
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_application(**overrides):
+    """Build a denial-path-friendly mock application with overridable fields."""
+    app = MagicMock()
+    app.applicant.first_name = overrides.get("first_name", "Test")
+    app.applicant.last_name = overrides.get("last_name", "Applicant")
+    app.applicant.username = overrides.get("username", "testuser")
+    app.loan_amount = overrides.get("loan_amount", 50000)
+    app.credit_score = overrides.get("credit_score", 720)
+    app.loan_term_months = overrides.get("loan_term_months", 60)
+    app.annual_income = overrides.get("annual_income", 95000)
+    app.debt_to_income = overrides.get("debt_to_income", 2.0)
+    app.employment_length = overrides.get("employment_length", 5)
+    app.purpose = overrides.get("purpose", "personal")
+    app.get_purpose_display.return_value = overrides.get("purpose_display", "Personal")
+    app.get_employment_type_display.return_value = overrides.get(
+        "employment_type_display", "PAYG Permanent"
+    )
+    app.get_applicant_type_display.return_value = overrides.get(
+        "applicant_type_display", "Single"
+    )
+    app.has_cosigner = overrides.get("has_cosigner", False)
+    app.has_hecs = overrides.get("has_hecs", False)
+    app.applicant.profile = None
+    app.decision = None
+    return app
+
+
+@patch("apps.agents.services.api_budget.ApiBudgetGuard")
+@patch("apps.email_engine.services.email_generator.anthropic.Anthropic")
+def test_denial_system_block_byte_identical_across_calls(
+    mock_anthropic_cls,
+    mock_budget_cls,
+    captured_api_call,
+    monkeypatch,
+):
+    """Prompt caching only hits if the cached prefix is byte-identical
+    across calls. This test makes two denial-path calls with completely
+    different applicant data and asserts the ``system`` block text is
+    the same both times — while the ``user`` message (where the dynamic
+    data lives) differs. A failure here means something is leaking
+    per-call state (timestamp, applicant data, env var, app version)
+    into the cached block, which silently defeats the cache."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    mock_budget = MagicMock()
+    mock_budget.check_budget.return_value = None
+    mock_budget_cls.return_value = mock_budget
+    mock_anthropic_cls.return_value = MagicMock()
+
+    from apps.email_engine.services.email_generator import EmailGenerator
+
+    gen = EmailGenerator()
+    gen._api_available = lambda: True
+
+    # First call — applicant A
+    app_a = _make_mock_application(
+        first_name="Alice",
+        last_name="Anderson",
+        loan_amount=50000,
+        purpose_display="Personal",
+    )
+    gen.generate(application=app_a, decision="denied", confidence=0.45)
+    first_kwargs = captured_api_call.call_args.kwargs
+    first_system_text = first_kwargs["system"][0]["text"]
+    first_user_content = first_kwargs["messages"][0]["content"]
+
+    # Second call — applicant B (completely different data)
+    captured_api_call.reset_mock()
+    app_b = _make_mock_application(
+        first_name="Bob",
+        last_name="Brown",
+        loan_amount=125000,
+        purpose_display="Vehicle",
+        employment_type_display="Contract",
+        applicant_type_display="Joint",
+        has_cosigner=True,
+        has_hecs=True,
+    )
+    gen.generate(application=app_b, decision="denied", confidence=0.30)
+    second_kwargs = captured_api_call.call_args.kwargs
+    second_system_text = second_kwargs["system"][0]["text"]
+    second_user_content = second_kwargs["messages"][0]["content"]
+
+    # The whole point of caching: system block IDENTICAL → cache hits
+    assert first_system_text == second_system_text, (
+        "system block drifted between calls — would defeat prompt caching. "
+        "Check for per-call state (timestamps, applicant data, version "
+        "stamps) leaking into DENIAL_EMAIL_INSTRUCTIONS."
+    )
+    # Positive control — confirm the test isn't trivially passing because
+    # both calls hit the same fixture. The user messages MUST differ since
+    # they carry the per-applicant data.
+    assert first_user_content != second_user_content, (
+        "user message content was identical for two different applicants — "
+        "the dynamic data isn't actually flowing through, so the byte-identical "
+        "system check above tells us nothing"
+    )
+    assert "Alice" in first_user_content
+    assert "Bob" in second_user_content

--- a/backend/utils/api_helpers.py
+++ b/backend/utils/api_helpers.py
@@ -37,11 +37,20 @@ def build_cached_call_kwargs(
     """Build a kwargs dict for ``client.messages.create`` with the system
     block cached via Anthropic prompt caching (5-min ephemeral TTL).
 
-    The static instructions in ``system_text`` become the cache key.
-    ``user_text`` is the dynamic per-call payload (not cached). Any
-    additional keyword arguments — ``model``, ``max_tokens``,
-    ``temperature``, ``tools``, ``tool_choice``, etc. — pass through.
+    Cache key: the entire prompt prefix up to and including the
+    ``cache_control`` marker. That covers ``system_text`` PLUS any earlier
+    static blocks Anthropic processes before it — most notably the
+    ``tools`` list passed via ``**other_kwargs``. Mutating any of those
+    pieces (system text, tools schema, tool choice) invalidates the cache,
+    so keep them byte-identical across calls in the same 5-min window.
 
+    ``user_text`` is the dynamic per-call payload — it sits in the
+    ``messages`` array AFTER the cached prefix and is not part of the
+    cache key. Put applicant data, retry feedback, and anything
+    per-call here.
+
+    Any additional keyword arguments — ``model``, ``max_tokens``,
+    ``temperature``, ``tools``, ``tool_choice``, etc. — pass through.
     Returns a dict you can splat into ``client.messages.create(**kw)``
     or any wrapper (e.g. ``guarded_api_call(client, **kw)``).
     """

--- a/backend/utils/api_helpers.py
+++ b/backend/utils/api_helpers.py
@@ -1,0 +1,58 @@
+"""Shared helpers for Anthropic API call construction.
+
+The main export is ``build_cached_call_kwargs`` — it constructs the
+``client.messages.create(**kwargs)`` payload with Anthropic prompt
+caching turned on for the static instructions block. Use it anywhere
+the prompt has a stable instruction block ≥1024 tokens that repeats
+across calls (Sonnet/Opus minimum; Haiku needs ≥2048).
+
+Pattern:
+    1. Move all the static rules / format / template instructions into a
+       single string passed as ``system_text``.
+    2. Move all per-call dynamic data (applicant name, banking context,
+       reasons, ...) into a single string passed as ``user_text``.
+    3. The helper wraps the system text in a ``cache_control: ephemeral``
+       block — Anthropic stores its processed form server-side for 5 min,
+       charging 0.1× the normal input rate on subsequent hits in that
+       window. Misses pay 1.25× (small one-time write cost), so the
+       break-even is ~2-3 calls per 5-min window.
+
+Docs: https://docs.claude.com/en/docs/build-with-claude/prompt-caching
+
+Tools / temperature / max_tokens / model and any other kwargs pass
+through unchanged via ``**other_kwargs``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_cached_call_kwargs(
+    *,
+    system_text: str,
+    user_text: str,
+    **other_kwargs: Any,
+) -> dict[str, Any]:
+    """Build a kwargs dict for ``client.messages.create`` with the system
+    block cached via Anthropic prompt caching (5-min ephemeral TTL).
+
+    The static instructions in ``system_text`` become the cache key.
+    ``user_text`` is the dynamic per-call payload (not cached). Any
+    additional keyword arguments — ``model``, ``max_tokens``,
+    ``temperature``, ``tools``, ``tool_choice``, etc. — pass through.
+
+    Returns a dict you can splat into ``client.messages.create(**kw)``
+    or any wrapper (e.g. ``guarded_api_call(client, **kw)``).
+    """
+    return {
+        "system": [
+            {
+                "type": "text",
+                "text": system_text,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+        "messages": [{"role": "user", "content": user_text}],
+        **other_kwargs,
+    }

--- a/docs/superpowers/specs/2026-05-07-codex-adversarial-response-v1-10-7-design.md
+++ b/docs/superpowers/specs/2026-05-07-codex-adversarial-response-v1-10-7-design.md
@@ -1,0 +1,510 @@
+# Codex Adversarial Review — v1.10.7 Response
+
+**Date:** 2026-05-07
+**Status:** Approved design, pending implementation plan
+**Scope:** All four findings from the 2026-05-07 whole-project Codex adversarial review
+**Codex verdict:** `needs-attention` — diff vs root commit `096110e6`
+**Predecessor:** v1.10.6 release (master `1d98ef8`)
+
+## Context
+
+After v1.10.6 shipped, a project-wide Codex adversarial review surfaced four findings:
+
+| # | Finding | File | Codex severity | My severity | Disposition |
+|---|---|---|---|---|---|
+| 1 | `ModelActivateView` deactivates **every** active segment, then turns one back on — silently breaks scoring for other segments | `backend/apps/ml_engine/views.py:370-377` | high | **high** | In scope |
+| 2 | Training path promotes `is_active=True` without consulting `ModelValidationReport`; governance metadata is documentation-only | `backend/apps/ml_engine/tasks.py:119-143` | high | **medium** | In scope (warn-mode default) |
+| 3 | `StaffCustomerListView` / `StaffCustomerProfileView` / `StaffCustomerActivityView` accept any `user_id`, including staff — officers can enumerate admin/officer accounts and auto-create `CustomerProfile` rows for them | `backend/apps/accounts/views.py:272-309` | medium | **high** (PII) | In scope |
+| 4 | `rotate_encryption_key` re-encrypts opaque ciphertext as if it were plaintext when `from_db_value` falls back on `InvalidToken` — irreversible double-encryption | `backend/apps/accounts/management/commands/rotate_encryption_key.py:38-46` | medium | **medium** | In scope |
+
+**My critical assessment of Codex's review.** All four findings were verified against the actual code (read into context before writing this spec). Codex's recommendations are sound. I'm reordering severity to put the staff endpoint privilege escalation as **high** (it's a live PII trust-boundary leak today, not a future-state outage path) and Finding 2 as **medium** (existing fairness/promotion gates from PRs #163-#165 already block on poor metrics; the validation-report layer is governance maturity, not safety). I'm taking 4/4 of Codex's recommendations with the following adjustments:
+
+- **#1**: Take the segment-scoped fix as written. Add the "refuse if it leaves a previously-served segment uncovered with no `unified` fallback" guard — Codex called this out and it's right.
+- **#2**: Take the gate enforcement. Default to `warn` mode (Codex didn't specify; precedent from PRs #163-#165 is `warn` first, flip to `block` after operator readiness). Add a `force=true` break-glass on manual activate with audit log.
+- **#3**: Take filtering. Add stronger guard: officers cannot fetch OTHER officer/admin profiles either, only customers. Codex implied this; I'm making it explicit.
+- **#4**: Take the explicit-decrypt fix. **Make `--dry-run` the default** and require `--apply` to write — go further than Codex's "preferably with a dry-run mode". Better ergonomics for an irreversible operation.
+
+Packaging rationale: four atomic PRs stacked on master under a new `v1.10.7 — Codex adversarial response` CHANGELOG section, plus a release PR. Mirrors v1.9.3 / v1.9.4 / v1.10.3 patterns. Each fix has a distinct file surface and test surface; bundling would muddy revert boundaries and break the retarget-before-delete-merge discipline.
+
+## PR #A — Segment-safe manual model activation (Finding 1, high)
+
+**Problem.** `ModelActivateView.post()` runs `ModelVersion.objects.filter(is_active=True).update(is_active=False, traffic_percentage=0)` with no segment filter, then activates the requested model. In a deployment with separate `personal` / `home` / `unified` champions, activating a `personal` challenger silently drops the `home` and `unified` champions to `is_active=False`. Subsequent scoring for those segments hits `No active model version found for segment ...` until an operator manually repairs traffic.
+
+The training path at `tasks.py:119-122` already filters by segment when deactivating during a fresh model creation. Manual activation should mirror that invariant.
+
+**Chosen approach.** Filter the deactivation step by `version.segment`. Add a defensive guard: if activating this version would leave a previously-served segment with no active model and no `unified` fallback, refuse with HTTP 409 and a structured error explaining what's missing. Allow first-activation of a brand-new segment (no previously-active model in that segment is the legitimate path).
+
+**Design.**
+
+Edit `backend/apps/ml_engine/views.py`:
+
+```python
+class ModelActivateView(APIView):
+    permission_classes = [IsAdmin]
+
+    def post(self, request, pk):
+        try:
+            version = ModelVersion.objects.get(pk=pk)
+        except ModelVersion.DoesNotExist:
+            return Response({"error": "Model not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        # Coverage guard: enumerate segments that currently have an active model.
+        # If activating `version` (a non-unified model) would leave a previously-served
+        # non-unified segment with no active model AND no unified fallback, refuse.
+        active_segments = set(
+            ModelVersion.objects.filter(is_active=True)
+            .values_list("segment", flat=True)
+        )
+        unified_active = "unified" in active_segments
+        target_segment = version.segment
+
+        if target_segment != "unified":
+            # Segments that would lose coverage: every non-unified active segment
+            # except this one's own segment, IF that segment had only this model
+            # (impossible since version is currently inactive) — really we just
+            # need to not touch other segments. Filter scopes that.
+            pass  # Coverage is preserved by segment-scoped filter below.
+
+        with transaction.atomic():
+            ModelVersion.objects.filter(
+                is_active=True,
+                segment=target_segment,
+            ).update(is_active=False, traffic_percentage=0)
+            version.is_active = True
+            version.traffic_percentage = 100
+            version.save()
+
+            AuditLog.objects.create(
+                user=request.user,
+                action="model_activate",
+                resource_type="ModelVersion",
+                resource_id=str(version.id),
+                details={
+                    "version": version.version,
+                    "segment": target_segment,
+                    "previous_active_segments": sorted(active_segments),
+                },
+                ip_address=request.META.get("REMOTE_ADDR"),
+            )
+
+        return Response({
+            "message": f"Model {version.version} activated as champion for segment '{target_segment}'",
+            "model_id": str(version.id),
+            "segment": target_segment,
+        })
+```
+
+The "coverage guard" branch above is deliberately a no-op in the simple form — the segment-scoped filter alone preserves coverage by construction (we only deactivate same-segment models). The explanatory comment captures intent so future readers understand why no extra logic is needed.
+
+**Behavior change risk.** Existing callers expecting "activate this and nothing else changes" get exactly that. Existing callers (if any) relying on the side effect of clearing other segments will break — but that side effect is the bug.
+
+**Tests** in `backend/apps/ml_engine/tests/test_model_activate.py` (new file or extend existing):
+
+- `test_manual_activate_does_not_touch_other_segments` — fixture: active `personal` + `home` + `unified`. Activate a new `personal` challenger. Assert `home` and `unified` remain `is_active=True` and `traffic_percentage=100`.
+- `test_manual_activate_first_time_for_segment` — fixture: only `unified` active. Activate first `home` model. Assert `home` activates, `unified` stays untouched.
+- `test_manual_activate_writes_audit_log` — assert `AuditLog` row with action `model_activate` and the previous-active-segments snapshot.
+
+## PR #B — Validation sign-off gate on promotion (Finding 2, medium → enforced as warn)
+
+**Problem.** The `validate_model` management command and `ModelValidationReport` model define a governance sign-off layer (a validator approves a candidate model with `signed_off=True, outcome="approved"`). The training path in `tasks.py` and the manual `ModelActivateView` both promote `is_active=True` without consulting that artifact. Under operational pressure, an admin can ship an unvalidated model directly to production. The existing fairness gate (PR #163) and promotion gate (PRs #164–#165) check **performance metrics**; this layer is the missing **governance** check.
+
+**Chosen approach.** Add a third gate, `evaluate_validation_signoff_gate(candidate, mode)`, that mirrors the `warn|block|off` dispatch pattern from PRs #163–#165. Apply it in both promotion paths. Default mode is `warn` so the demo flow keeps working — operators flip to `block` once they've established a sign-off cadence. Manual activation accepts a `force=true` query param that bypasses the gate with a dedicated audit log entry (break-glass).
+
+**Design.**
+
+New service module `backend/apps/ml_engine/services/validation_gate.py`:
+
+```python
+"""Validation sign-off gate. Mirrors the warn|block|off pattern from
+the fairness gate (PR #163) and promotion gate (PRs #164-#165)."""
+
+from typing import Optional
+
+from apps.ml_engine.models import ModelValidationReport
+
+
+class ValidationSignoffBlocked(Exception):
+    """Raised when validation gate is in `block` mode and signoff is missing."""
+
+    def __init__(self, reason: str, payload: dict):
+        super().__init__(reason)
+        self.payload = payload
+
+
+def evaluate_validation_signoff_gate(
+    candidate,
+    mode: str = "warn",
+    bypass: bool = False,
+) -> dict:
+    """Check that the candidate model has an approved, signed-off
+    ModelValidationReport. Returns a structured decision dict.
+
+    `mode`:
+        - `block`: raise ValidationSignoffBlocked on missing/unapproved signoff
+        - `warn`: log + return decision but allow activation
+        - `off`: skip the check entirely
+
+    `bypass`: caller has provided an audited break-glass override.
+    """
+
+    if mode == "off" or bypass:
+        return {
+            "mode": mode,
+            "bypass": bypass,
+            "result": "skipped",
+            "reason": "gate disabled" if mode == "off" else "break-glass override",
+        }
+
+    report = (
+        ModelValidationReport.objects
+        .filter(version_str=candidate.version, segment=candidate.segment)
+        .order_by("-created_at")
+        .first()
+    )
+
+    if report is None:
+        decision = {
+            "mode": mode,
+            "result": "blocked",
+            "reason": "no_validation_report",
+            "candidate_version": candidate.version,
+            "segment": candidate.segment,
+        }
+    elif not report.signed_off or report.outcome != "approved":
+        decision = {
+            "mode": mode,
+            "result": "blocked",
+            "reason": "report_not_approved",
+            "report_id": str(report.id),
+            "outcome": report.outcome,
+            "signed_off": report.signed_off,
+        }
+    else:
+        decision = {
+            "mode": mode,
+            "result": "passed",
+            "report_id": str(report.id),
+        }
+
+    if decision["result"] == "blocked" and mode == "block":
+        raise ValidationSignoffBlocked(decision["reason"], decision)
+
+    return decision
+```
+
+Apply in `backend/apps/ml_engine/tasks.py` immediately after the existing `promotion_gate_decision` line:
+
+```python
+from apps.ml_engine.services.validation_gate import evaluate_validation_signoff_gate
+
+validation_mode = getattr(settings, "ML_VALIDATION_SIGNOFF_GATE_MODE", "warn")
+validation_decision = evaluate_validation_signoff_gate(candidate_stub, validation_mode)
+```
+
+Persist the decision into `mv.training_metadata` alongside the existing `fairness_gate_mode` and `promotion_gate_mode` keys.
+
+Apply in `ModelActivateView` (PR #A's edit):
+
+```python
+def post(self, request, pk):
+    # ... existing 404 check ...
+    force = request.query_params.get("force", "").lower() == "true"
+    validation_mode = getattr(settings, "ML_VALIDATION_SIGNOFF_GATE_MODE", "warn")
+    try:
+        validation_decision = evaluate_validation_signoff_gate(
+            version, validation_mode, bypass=force,
+        )
+    except ValidationSignoffBlocked as exc:
+        return Response(
+            {"error": "validation_signoff_required", "details": exc.payload},
+            status=status.HTTP_409_CONFLICT,
+        )
+
+    # ... existing activation block ...
+
+    AuditLog.objects.create(
+        user=request.user,
+        action="model_activate_force" if force else "model_activate",
+        # ...
+        details={
+            # ...
+            "validation_decision": validation_decision,
+        },
+    )
+```
+
+**Settings.** Add to `backend/config/settings.py`:
+
+```python
+ML_VALIDATION_SIGNOFF_GATE_MODE = os.getenv("ML_VALIDATION_SIGNOFF_GATE_MODE", "warn")
+# 'warn' (default) | 'block' | 'off'
+```
+
+**Tests** in `backend/apps/ml_engine/tests/test_validation_gate.py` (new):
+
+- `test_no_report_blocks_in_block_mode` — mode `block`, no report → `ValidationSignoffBlocked`.
+- `test_no_report_warns_in_warn_mode` — mode `warn`, no report → returns `{result: blocked}` without raising.
+- `test_off_mode_skips_check` — mode `off` → returns `{result: skipped}` regardless of report state.
+- `test_unapproved_report_blocks` — report with `signed_off=False` or `outcome="conditional"` → blocked.
+- `test_approved_report_passes` — report with `signed_off=True, outcome="approved"` → passed.
+- `test_force_bypasses_gate_and_audits` — manual activate with `?force=true` → 200, audit log action is `model_activate_force` and details include the bypass marker.
+
+## PR #C — Customer-only filter on staff endpoints (Finding 3, high)
+
+**Problem.** The three "Staff Customer" endpoints accept any `CustomUser` regardless of role:
+
+- `StaffCustomerListView.get_queryset` returns `CustomUser.objects.all()` with no `role="customer"` filter.
+- `StaffCustomerProfileView.get_object` runs `get_object_or_404(CustomUser, pk=user_id)` (no role check) then `CustomerProfile.objects.get_or_create(user_id=user_id)` — creating a `CustomerProfile` row attached to admin/officer accounts.
+- `StaffCustomerActivityView.get` accepts any `user_id` and serves their applications/emails/agent runs.
+
+An officer can enumerate admin emails via `/customers/?search=`, fetch admin profile data via `/customers/<admin_id>/`, and pollute the database with phantom `CustomerProfile` rows attached to staff accounts. This is a trust-boundary leak: the route contract says "customer surface" but the implementation exposes the entire user table.
+
+**Chosen approach.** Three small edits, one PR. Filter by `role="customer"` at every read site. For the profile endpoint, the role check has to happen before the `get_or_create` so we never create a `CustomerProfile` for a non-customer user.
+
+**Design.**
+
+Edit `backend/apps/accounts/views.py`:
+
+```python
+class StaffCustomerListView(generics.ListAPIView):
+    serializer_class = UserSerializer
+    permission_classes = (IsAdminOrOfficer,)
+
+    def get_queryset(self):
+        qs = (
+            CustomUser.objects
+            .filter(role="customer")
+            .select_related("profile")
+            .order_by("-created_at")
+        )
+        # ...search filter unchanged...
+        return qs
+
+
+class StaffCustomerProfileView(generics.RetrieveUpdateAPIView):
+    permission_classes = (IsAdminOrOfficer,)
+    lookup_field = "user_id"
+    lookup_url_kwarg = "user_id"
+
+    def get_object(self):
+        user_id = self.kwargs["user_id"]
+        user = get_object_or_404(CustomUser, pk=user_id, role="customer")
+        profile, _ = (
+            CustomerProfile.objects
+            .select_related("user")
+            .get_or_create(user=user)
+        )
+        return profile
+
+
+class StaffCustomerActivityView(generics.GenericAPIView):
+    permission_classes = (IsAdminOrOfficer,)
+
+    def get(self, request, user_id):
+        try:
+            customer = CustomUser.objects.get(pk=user_id, role="customer")
+        except CustomUser.DoesNotExist:
+            return Response(
+                {"error": "Customer not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        # ...rest unchanged...
+```
+
+**Behavior change risk.** Officers attempting to access non-customer rows now receive 404 instead of 200 with admin/officer data. This is the intended change. The list endpoint will return fewer rows (customers only); existing UI consumers should already expect this — if any UI code paginated through "all users" via `/customers/`, that was a latent bug.
+
+**Tests** in `backend/apps/accounts/tests/test_staff_customer_endpoints.py` (new or extend existing):
+
+- `test_list_excludes_admin_and_officer_rows` — fixture: 1 admin, 1 officer, 2 customers. Officer hits `/customers/`, asserts response has 2 rows, none with `role` admin/officer.
+- `test_list_search_does_not_leak_admin_email` — admin with email `admin@example.com`, officer searches `?search=admin`, asserts admin row not returned.
+- `test_profile_404_for_admin_target` — officer hits `/customers/<admin_id>/`, asserts 404.
+- `test_profile_404_for_officer_target` — officer hits `/customers/<other_officer_id>/`, asserts 404.
+- `test_profile_does_not_create_phantom_row_for_admin` — before request, no `CustomerProfile` for admin. Officer hits `/customers/<admin_id>/`, asserts response is 404 AND `CustomerProfile.objects.filter(user_id=admin_id).count() == 0`.
+- `test_activity_404_for_non_customer_target` — officer hits `/customers/<admin_id>/activity/`, asserts 404.
+- `test_customer_target_still_works` — officer hits `/customers/<customer_id>/`, asserts 200 with profile data.
+
+## PR #D — Safe key rotation with explicit decrypt + dry-run-default (Finding 4, medium)
+
+**Problem.** `rotate_encryption_key` walks each profile and, for every encrypted field, fetches `getattr(profile, field_name, None)`. That triggers `EncryptedCharField.from_db_value` which silently returns the **raw ciphertext** when decryption fails (`InvalidToken`). The command then marks the field as "changed" because the value is non-empty, calls `profile.save(update_fields=encrypted_fields)`, and re-encrypts that opaque ciphertext as if it were plaintext. A recoverable key-gap incident becomes permanent data loss.
+
+**Chosen approach.** Replace the `getattr → save` loop with explicit decryption using a `MultiFernet` over the configured keyring. Track per-row decrypt errors. Abort the command if any row fails decryption unless `--allow-failures` is explicitly provided. Make `--dry-run` the default — operators must pass `--apply` to actually write. This is the single most useful guardrail for an irreversible operation; Codex suggested it as nice-to-have, I'm making it default.
+
+**Design.**
+
+Rewrite `backend/apps/accounts/management/commands/rotate_encryption_key.py`:
+
+```python
+"""Re-encrypt all PII fields with the current primary Fernet key.
+
+Workflow:
+    1. Generate a new key: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+    2. Prepend new key to FIELD_ENCRYPTION_KEY (comma-separated): NEW_KEY,OLD_KEY
+    3. python manage.py rotate_encryption_key            # dry-run by default
+    4. python manage.py rotate_encryption_key --apply    # commit changes
+    5. After successful rotation, remove the old key from FIELD_ENCRYPTION_KEY
+"""
+
+from cryptography.fernet import Fernet, InvalidToken, MultiFernet
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from apps.accounts.models import CustomerProfile
+
+ENCRYPTED_FIELDS = [
+    "primary_id_number",
+    "secondary_id_number",
+    "phone",
+    "address_line_1",
+    "address_line_2",
+    "employer_name",
+    "date_of_birth",
+    "gross_annual_income",
+    "other_income",
+    "partner_annual_income",
+]
+
+
+class Command(BaseCommand):
+    help = "Re-encrypt all PII fields with the current primary Fernet key. Dry-run by default."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Actually write changes. Without this flag the command runs in dry-run mode.",
+        )
+        parser.add_argument(
+            "--allow-failures",
+            action="store_true",
+            help="Continue past rows that fail decryption (audit-logged). Without this flag, the command aborts on the first failure.",
+        )
+
+    def handle(self, *args, **options):
+        apply_changes = options["apply"]
+        allow_failures = options["allow_failures"]
+
+        keys = self._load_keys()
+        multi_fernet = MultiFernet([Fernet(k.encode() if isinstance(k, str) else k) for k in keys])
+        primary_fernet = Fernet(keys[0].encode() if isinstance(keys[0], str) else keys[0])
+
+        profiles = CustomerProfile.objects.all()
+        total = profiles.count()
+        rotated = 0
+        skipped_failures = []
+
+        mode_label = "APPLY" if apply_changes else "DRY-RUN"
+        self.stdout.write(f"[{mode_label}] Rotating {total} profiles across {len(ENCRYPTED_FIELDS)} fields...")
+
+        # Use raw .values() to fetch ciphertext bytes without going through from_db_value.
+        rows = profiles.values("id", *ENCRYPTED_FIELDS).iterator(chunk_size=100)
+
+        for row in rows:
+            decrypted = {}
+            row_errors = []
+            for field in ENCRYPTED_FIELDS:
+                ciphertext = row[field]
+                if not ciphertext:
+                    continue
+                try:
+                    plaintext = multi_fernet.decrypt(
+                        ciphertext.encode() if isinstance(ciphertext, str) else ciphertext
+                    )
+                    decrypted[field] = plaintext
+                except InvalidToken:
+                    row_errors.append(field)
+
+            if row_errors:
+                skipped_failures.append({"profile_id": str(row["id"]), "fields": row_errors})
+                if not allow_failures:
+                    self.stdout.write(self.style.ERROR(
+                        f"Profile {row['id']} failed decryption on fields: {row_errors}. "
+                        f"Aborting. Use --allow-failures to skip and continue."
+                    ))
+                    raise CommandError("Rotation aborted: decryption failures.")
+                else:
+                    self.stdout.write(self.style.WARNING(
+                        f"Skipping profile {row['id']}: decrypt failures on {row_errors}"
+                    ))
+                    continue
+
+            if not decrypted:
+                continue
+
+            if apply_changes:
+                with transaction.atomic():
+                    update_kwargs = {
+                        field: primary_fernet.encrypt(plaintext).decode()
+                        for field, plaintext in decrypted.items()
+                    }
+                    CustomerProfile.objects.filter(pk=row["id"]).update(**update_kwargs)
+            rotated += 1
+
+        verb = "Re-encrypted" if apply_changes else "Would re-encrypt"
+        self.stdout.write(self.style.SUCCESS(f"{verb} {rotated} of {total} profiles."))
+        if skipped_failures:
+            self.stdout.write(self.style.WARNING(
+                f"Skipped {len(skipped_failures)} profiles with decryption failures: {skipped_failures}"
+            ))
+        if not apply_changes:
+            self.stdout.write(self.style.NOTICE("DRY-RUN: no database changes written. Re-run with --apply to commit."))
+
+    def _load_keys(self):
+        raw = getattr(settings, "FIELD_ENCRYPTION_KEY", "") or ""
+        keys = [k.strip() for k in raw.split(",") if k.strip()]
+        if not keys:
+            raise CommandError("FIELD_ENCRYPTION_KEY is not configured.")
+        return keys
+```
+
+**Note on raw ciphertext access.** Using `.values()` bypasses `from_db_value` because we're asking the ORM for the raw column dictionary, not model instances. The encrypted column type is stored as a string/bytea and `.values()` returns it untouched.
+
+**Caveat: PR #D depends on the actual storage shape of `EncryptedCharField` in this codebase.** If the local field implementation already returns raw ciphertext from `.values()`, the design above works as-is. If it intercepts at a deeper level, the implementation plan needs to fetch the raw column via `connection.cursor()`. The first executor task for PR #D is to verify this assumption against the field code in `backend/apps/accounts/fields.py` (or wherever `EncryptedCharField` lives) before writing the rotation logic.
+
+**Tests** in `backend/apps/accounts/tests/test_rotate_encryption_key.py` (new):
+
+- `test_dry_run_is_default_no_writes` — call command without `--apply`, assert no `CustomerProfile` row was modified (snapshot field values before/after).
+- `test_apply_re_encrypts_with_primary_key` — set keyring to `[NEW, OLD]`, encrypt fixture data with `OLD`, run with `--apply`, assert fields decrypt cleanly using only `[NEW]`.
+- `test_corrupt_ciphertext_aborts_without_allow_failures` — poison one field with raw bytes that aren't valid Fernet ciphertext, run with `--apply` only, assert `CommandError` and zero rows modified.
+- `test_corrupt_ciphertext_skipped_with_allow_failures` — same poison, run with `--apply --allow-failures`, assert healthy rows are re-encrypted, poisoned row is left untouched, command exits 0.
+- `test_dry_run_reports_what_would_happen` — capture stdout, assert the "Would re-encrypt N of M" summary appears.
+
+## PR #E — Release v1.10.7
+
+- Bump `APP_VERSION` in `backend/config/settings.py` from `1.10.6` to `1.10.7`.
+- Bump `version` in `frontend/package.json` from `1.10.6` to `1.10.7`.
+- Add `CHANGELOG.md` entry:
+
+  ```markdown
+  ## v1.10.7 — 2026-05-07 — Codex adversarial response
+
+  Codex graded `needs-attention` on the v1.10.6 master tree. Four findings, four atomic PRs:
+
+  - **PR #A** (#TBD): Segment-safe manual model activation (`ModelActivateView`)
+  - **PR #B** (#TBD): Validation sign-off gate on promotion (warn-mode default, configurable to `block`/`off` via `ML_VALIDATION_SIGNOFF_GATE_MODE`)
+  - **PR #C** (#TBD): Customer-only filter on staff endpoints (closes a PII trust-boundary leak)
+  - **PR #D** (#TBD): Safe key rotation with explicit decrypt + dry-run-default (`--apply` required to write)
+  ```
+
+- Tag `v1.10.7` after merge to master.
+
+## Sequencing
+
+PRs A, C, D are independent — can land in any order. PR B's `validation_gate.py` plugs into existing settings infrastructure from PRs #163–#165, so it can also land independently — but its application sites in `tasks.py` and `views.py` overlap with PR A's edits to `views.py`, so **PR B must rebase onto PR A's branch** if A merges first.
+
+Suggested merge order: **C → D → A → B → E**. C and D are pure file-isolated; A is the smaller of the two ML changes; B builds on A's audit-log additions.
+
+Apply retarget-before-delete-merge discipline at each step (per `feedback_stacked_pr_merges.md` in memory).
+
+## Out of scope (deliberate)
+
+- 2FA on staff accounts (deferred since v1.9.4)
+- Per-segment traffic split UI
+- Refactoring `EncryptedCharField` itself — fix the rotation tool, leave field semantics alone
+- Rate-limiting on the staff customer search endpoint (out of scope for this round; track separately if needed)
+
+## Risk acknowledgements
+
+- **PR #B with `block` mode** could halt the demo flow if no validation reports exist. Defaulting to `warn` mitigates; document the cutover procedure in the release notes alongside the existing fairness/promotion gate runbook.
+- **PR #D** may surface latent decrypt failures in production data. That's the correct behavior; operators should always run without `--apply` first to discover what's broken before committing.
+- **PR #A** is a behavior change for any caller that relied on the global-deactivation side effect. The training path is the only documented caller; ad-hoc manual scripts (if any) need to know the new contract.


### PR DESCRIPTION
## Summary

Wires Anthropic prompt caching on the denial email's static instructions template (~4.5k tokens). Cache hits within the 5-minute TTL window pay 0.1× the normal input rate; misses pay 1.25× (small one-time write cost). Net realistic saving on a tight batch of denial emails: ~4-5× cheaper input cost.

## What changed

| File | Change |
|---|---|
| `utils/api_helpers.py` (new) | `build_cached_call_kwargs(system_text, user_text, **other_kwargs)` constructs the kwargs dict for `client.messages.create` with `cache_control: ephemeral` on the system block |
| `email_engine/services/prompts.py` | Split `DENIAL_EMAIL_PROMPT` into `DENIAL_EMAIL_INSTRUCTIONS` (placeholder-free, cacheable) + `DENIAL_DATA_TEMPLATE` (per-call dynamic data) |
| `email_engine/services/email_generator.py` | Denial branch uses the new helper; approval branch unchanged (single-message format) |
| `tests/test_prompt_caching.py` (new) | Helper shape, cache-eligibility guards, schema guards, denial integration |

## Cost math (Sonnet 4.6, $3/M input · $15/M output)

Per denial email, input cost only:

| Scenario | Without caching | With caching |
|---|---|---|
| First call (cache write) | $0.014 | $0.017 (1.25× write penalty) |
| Subsequent calls in 5-min window | $0.014 each | **$0.0014 each** — 90% cheaper |
| 10 emails in a burst | $0.135 input | $0.017 + 9 × $0.0014 = **$0.030 input** |
| 50 emails in a burst | $0.685 input | $0.017 + 49 × $0.0014 = **$0.086 input** |

Break-even at 2-3 calls in a 5-min window. Steady production traffic should sit firmly in the savings zone; one-off demo calls pay a tiny write penalty.

Output cost is unchanged — each email is still uniquely generated.

## Why scope down to denial only

The approval (~4.7k tokens) and marketing (~1.4k tokens) prompts are also large enough to cache, but they have dynamic interpolations woven through the template body (loan details section, pricing examples, banking context blocks). Splitting them cleanly is more invasive and risks subtle email-quality shifts that need a separate PR with careful before/after testing.

Denial was the cleanest test case — only the top "Application details" block and one `banking_context` spot were dynamic, both at the start of the prompt. Splitting them was surgical.

## Cache integrity guards

Tests in `tests/test_prompt_caching.py` exist purely to catch silent regressions:

1. **`test_denial_instructions_meets_active_model_cache_minimum`** — model-aware floor check. The cache_control directive silently no-ops if the prompt drops below the active model's token minimum (Sonnet/Opus: 1024 tokens, Haiku: 2048). The test maps the hardcoded `_ACTIVE_EMAIL_MODEL` to the right floor so a future model swap can't silently disable caching.
2. **`test_denial_instructions_has_no_format_placeholders`** — asserts no `{placeholder}` patterns remain in the instructions. A stray placeholder would either KeyError or (worse) substitute and shift the cache key per call.
3. **`test_denial_system_block_byte_identical_across_calls`** — two denial calls with completely different applicants must produce identical `system` block text. Failure means per-call state (timestamp, applicant data, version stamp) is leaking into the cached block and silently defeating the cache. Positive control asserts the `user` messages differ so the test can't trivially pass.

---

## Review-response addendum (commit `709f9a6`)

Self-review of the original commit surfaced one HIGH-severity gap: the cache mechanics worked, but you couldn't see or measure savings in production. Specifically the budget tracker silently undercounted cost once caching was live, and there was no metric to verify cache hit ratio. Addressed all findings:

### 🔴 HIGH — fixed

**Budget tracker now matches the real Anthropic invoice.** `estimate_cost_usd` accepts `cache_creation_input_tokens` (1.25× multiplier) and `cache_read_input_tokens` (0.10× multiplier); `record_call` threads them through; `guarded_api_call` pulls them from `response.usage`. Without this, the daily Redis budget would have systematically diverged from real billing — invisible to ops until the monthly invoice landed.

**Production cache visibility.** New `email_llm_input_tokens_total{decision,type}` Prometheus counter splits input tokens across standard / cache_create / cache_read buckets. Dashboards can compute cache hit ratio as `sum(cache_read) / sum(all three)` once `EMAIL_GENERATION_MODE=api` is flipped.

### 🟠 MEDIUM — fixed

- `EmailGenerator.generate` result dict now propagates `cache_creation_input_tokens` and `cache_read_input_tokens` for downstream consumers (Celery task result, audit log).
- `build_cached_call_kwargs` docstring corrected: the cache key spans the whole prompt prefix up to the `cache_control` marker (which includes `tools`), not just `system_text`.
- Added `test_denial_system_block_byte_identical_across_calls` — the load-bearing invariant prompt caching depends on.

### 🟡 LOW — cleanup

- Removed three redundant inline `import logging` calls in `email_generator.py`; replaced with module-level `_generator_logger`.
- Replaced `test_denial_instructions_meets_sonnet_cache_minimum` with model-aware version that picks the right floor per model family.

### Verification

- 14/14 `test_api_budget.py` pass (8 original + 6 new for cache cost math)
- 10/10 `test_prompt_caching.py` pass (1 replaced, 1 added)
- 4/4 `test_email_generator.py` pass
- 1409 non-DB backend tests pass; 278 DB-dependent tests error in this local environment due to missing Docker postgres (`failed to resolve host 'db'`) — pre-existing, unrelated to this PR.

### Dashboard query after API mode is flipped

```promql
# cache hit ratio over 5-min window
sum(rate(email_llm_input_tokens_total{type="cache_read"}[5m]))
  / sum(rate(email_llm_input_tokens_total[5m]))
```

---

## Deferred follow-ups

- **Approval email caching** — same pattern, bigger template restructure. Worth doing once we observe cost behavior on this PR.
- **Marketing email caching** — `MARKETING_EMAIL_PROMPT` is ~1.4k tokens, right around the cache-eligibility floor. Marginal value, defer until approval+denial pattern is settled.
- **Bias detection caching** — too small (~700 tokens static) to be eligible for Sonnet caching. Either inflate the prompt with more guidance to clear the 1024-token floor, or accept it's not worth caching.
- **Persist cache token columns on `APICallLog`** — would need a Django migration, deferred to keep this PR migration-free. The Prometheus counter + result-dict propagation cover the immediate observability need.

## Notes

- Default is still `EMAIL_GENERATION_MODE=template` so production cost remains $0 unless the API toggle is flipped. This PR makes the API mode cheaper if/when you do flip it.
- No new dependencies, no migrations, no config changes.
- The `2026-05-07-codex-adversarial-response-v1-10-7-design.md` doc rides along on this branch from an earlier v1.10.7 cycle that never landed. Doesn't affect the perf-caching work; left in to avoid destructive history rewriting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)