### PR TITLE
chore(deps): bump django, idna, urllib3 to close 8 HIGH CVEs

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,7 +23,7 @@ cloudpickle==3.1.2
 colorlog==6.10.1
 cryptography==46.0.7
 distro==1.9.0
-django[argon2]==5.2.13
+django[argon2]==5.2.14
 django-celery-results==2.6.0
 django-cors-headers==4.9.0
 django-csp==4.0
@@ -40,7 +40,7 @@ gunicorn==25.3.0
 h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1
-idna==3.11
+idna==3.15
 inflection==0.5.1
 jiter==0.14.0
 joblib==1.5.3
@@ -89,7 +89,7 @@ typing-inspection==0.4.2
 tzdata==2026.1
 tzlocal==5.3.1
 uritemplate==4.2.0
-urllib3==2.6.3
+urllib3==2.7.0
 vine==5.1.0
 wcwidth==0.6.0
 xgboost==3.2.0


### PR DESCRIPTION
## Summary

Closes the security CVEs that pip-audit and Trivy currently flag on every open PR in this repo. All three are patch/minor bumps within the same major series — no API changes.

| Package | Bump |
|---|---|
| `django[argon2]` | 5.2.13 → 5.2.14 |
| `idna` | 3.11 → 3.15 |
| `urllib3` | 2.6.3 → 2.7.0 |

## CVEs closed

| Package | CVE | Severity | Description |
|---|---|---|---|
| django | PYSEC-2026-50 | medium | Response headers do not vary on cookies when `SESSION_SAVE_EVERY_REQUEST=True` — remote attacker can steal a user's session after they visit a cached public page |
| django | PYSEC-2026-54 | medium | ASGI requests with missing/understated `Content-Length` header bypass `FILE_UPLOAD_MAX_MEMORY_SIZE` — potentially loads large files into memory and causes service degradation |
| django | PYSEC-2026-55 | medium | `django.middleware.cache.UpdateCacheMiddleware` erroneously caches requests where `Vary` contained an asterisk — leads to private data being stored and served |
| idna | CVE-2026-45409 | medium | DoS via long Unicode inputs to `idna.encode()` (extension of CVE-2024-3651) |
| urllib3 | PYSEC-2026-141 | medium | Cross-origin redirects via `ProxyManager.connection_from_url().urlopen(..., assert_same_host=False)` still forward sensitive headers |
| urllib3 | PYSEC-2026-142 | medium | `HTTPResponse.read(amt=N)` and `drain_conn()` could fully decompress brotli-encoded responses — excessive CPU + memory allocation |
| urllib3 | CVE-2026-44431 | **HIGH** | Information disclosure via cross-origin redirects forwarding sensitive headers (Trivy) |
| urllib3 | CVE-2026-44432 | **HIGH** | DoS via excessive HTTP response decompression (Trivy) |

## Why now

`pip-audit` and Trivy scans started failing across every open PR this week, blocking CI on 20 PRs simultaneously. Fixing in one focused dep-bump PR unblocks all of them.

## Test plan

- [x] `python -m pip install --upgrade "django[argon2]==5.2.14" "idna==3.15" "urllib3==2.7.0"` clean
- [x] Smoke test: import django/idna/urllib3 — all OK; IDNA encode round-trip works for `example.com`, `xn--…`, `münchen.de`, `pythön.org`; urllib3 `PoolManager` instantiates
- [x] 12/12 baseline DB-free tests pass (`test_api_budget`, `test_email_generator`, `apps/email_engine/`)
- [ ] Full pip-audit will run on Linux CI (local Windows can't install `nvidia-nccl-cu12` which is Linux-only)

## Notes

- No `requirements.in` changes needed — the loose pins (`Django>=5.2,<5.3`) already permit these versions. Only the pinned `requirements.txt` lockfile needed updating.
- No application code changes. No migration. No config change.
- The three bumps are independent — if one needs to be reverted for any reason, the others can stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)