### PR TITLE
chore(release): bump APP_VERSION to 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Final suite: backend **1743 passed / 34 skipped / 0 failed**, frontend **327 pas
 - **`BIAS_FAILURE_MODE` defaults to `block`** — an intended behaviour change. A bias-detection infra outage now withholds the email rather than shipping it; set `BIAS_FAILURE_MODE=off` to restore the legacy fail-open.
 - **Celery `broker_transport_options` fail-fast flags are global** — run a healthy-broker worker-connect smoke (`docker compose up`, confirm workers connect) before deploying.
 - **`POST /ml/predict/{id}/` is disabled by default** — enable via `ML_STANDALONE_PREDICT_ENABLED=true` if a non-orchestrator caller needs it (and make it AgentRun/ADM-consistent first).
-- No `APP_VERSION` bump yet (unreleased); bump at release time.
+- Released 2026-06-03: PR #207 merged to master (merge commit `eb21013`); `APP_VERSION` bumped to `1.11.0` and tagged `v1.11.0`. This release also bundles the post-milestone hardening landed on the same branch — a 17-finding senior audit + Python/npm CVE bumps, a 7-area pre-merge review (1 HIGH + 4 mediums fixed, all with regression tests), and metric-drift/k8s-probe doc fixes — bringing the suite to backend **1752 passed / 34 skipped**, frontend **327 passed**.
 
 ## v1.10.6 — Renderer XSS Hardening + External Benchmark + Realism Audit (2026-04-20)
 

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -11,7 +11,7 @@ import sentry_sdk
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 # Application version (synced with CHANGELOG.md)
-APP_VERSION = "1.10.6"
+APP_VERSION = "1.11.0"
 
 DEBUG = os.environ.get("DJANGO_DEBUG", "False").lower() in ("true", "1", "yes")
 


### PR DESCRIPTION
Syncs `APP_VERSION` (`backend/config/settings/base.py`) from `1.10.6` to **`1.11.0`** to match the `CHANGELOG.md` v1.11.0 milestone that landed via #207 (Decision Transparency, Contestability & Audit Remediation).

One-line version bump ahead of tagging `v1.11.0`. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)