### PR TITLE
chore(ci): green the build — pin ruff, bump Django 5.2.15, raise size caps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
           cache: pip
 
       - name: Install linters
-        run: pip install ruff
+        run: pip install ruff==0.15.8  # keep in sync with backend/requirements-dev.txt
 
       - name: Lint with Ruff
         working-directory: backend

--- a/backend/apps/accounts/permissions.py
+++ b/backend/apps/accounts/permissions.py
@@ -18,10 +18,6 @@ class IsCustomer(BasePermission):
 
 class IsAdminOrOfficer(BasePermission):
     def has_permission(self, request, view):
-        return (
-            request.user.is_authenticated
-            and (
-                getattr(request.user, "role", None) in ("admin", "officer")
-                or request.user.is_superuser
-            )
+        return request.user.is_authenticated and (
+            getattr(request.user, "role", None) in ("admin", "officer") or request.user.is_superuser
         )

--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -361,9 +361,11 @@ class StaffCustomerActivityView(generics.GenericAPIView):
             .order_by("-created_at")
             .values_list("id", flat=True)[:50]
         )
-        emails_qs = GeneratedEmail.objects.filter(id__in=top_email_ids).prefetch_related(
-            "guardrail_checks"
-        ).order_by("-created_at")
+        emails_qs = (
+            GeneratedEmail.objects.filter(id__in=top_email_ids)
+            .prefetch_related("guardrail_checks")
+            .order_by("-created_at")
+        )
 
         emails = []
         for email in emails_qs:

--- a/backend/apps/agents/services/human_review_handler.py
+++ b/backend/apps/agents/services/human_review_handler.py
@@ -213,8 +213,7 @@ class HumanReviewHandler:
                                 application.save(update_fields=["status"])
                         agent_run.status = "escalated"
                         agent_run.error = (
-                            f"Resumed email re-flagged by bias detector "
-                            f"(score={bias_result['score']}) — re-escalated"
+                            f"Resumed email re-flagged by bias detector (score={bias_result['score']}) — re-escalated"
                         )
                         self.tracker.finalize_run(agent_run, steps, start_time)
                         return agent_run

--- a/backend/apps/agents/services/marketing_agent.py
+++ b/backend/apps/agents/services/marketing_agent.py
@@ -146,14 +146,10 @@ class MarketingAgent:
         # and could contain injection payloads; loyalty_factors and denial_reasons
         # may also carry user-supplied data through the pipeline.  applicant_name
         # and applicant_first_name are already sanitized above.
-        sanitized_denial_reasons = _sanitize_prompt_input(
-            denial_reasons or "Not specified", max_length=500
-        )
+        sanitized_denial_reasons = _sanitize_prompt_input(denial_reasons or "Not specified", max_length=500)
         raw_loyalty = ", ".join(nbo_result.get("loyalty_factors", [])) or "N/A"
         sanitized_loyalty_factors = _sanitize_prompt_input(raw_loyalty, max_length=300)
-        sanitized_nbo_analysis = _sanitize_prompt_input(
-            nbo_result.get("analysis", "N/A"), max_length=500
-        )
+        sanitized_nbo_analysis = _sanitize_prompt_input(nbo_result.get("analysis", "N/A"), max_length=500)
 
         prompt = MARKETING_EMAIL_PROMPT.format(
             applicant_name=applicant_name,
@@ -240,18 +236,12 @@ class MarketingAgent:
                 return self._marketing_template_fallback(application, nbo_amounts, start_time, nbo_result=nbo_result)
             elif "credit" in str(api_err).lower() or "balance" in str(api_err).lower():
                 _logger.warning("Marketing email API credit insufficient — using template")
-                return self._marketing_template_fallback(
-                    application, nbo_amounts, start_time, nbo_result=nbo_result
-                )
+                return self._marketing_template_fallback(application, nbo_amounts, start_time, nbo_result=nbo_result)
             else:
-                _logger.error(
-                    "Marketing email API client error (%d, not retryable): %s", api_err.status_code, api_err
-                )
+                _logger.error("Marketing email API client error (%d, not retryable): %s", api_err.status_code, api_err)
                 raise
         except Exception as api_err:
-            _logger.critical(
-                "Marketing email API UNEXPECTED failure: %s", api_err, exc_info=True
-            )
+            _logger.critical("Marketing email API UNEXPECTED failure: %s", api_err, exc_info=True)
             raise
 
         response_text = response.content[0].text

--- a/backend/apps/agents/services/orchestrator.py
+++ b/backend/apps/agents/services/orchestrator.py
@@ -494,9 +494,7 @@ class PipelineOrchestrator:
         # handled above and returns early.  Reaching this point with escalated=True
         # would mean the two None-triple shapes are ambiguous — assert the paths
         # are mutually exclusive so a future refactor cannot silently mis-route (M18).
-        assert not escalated, (
-            "escalated=True should have been handled by the bias block path before reaching here"
-        )
+        assert not escalated, "escalated=True should have been handled by the bias block path before reaching here"
         if email_result is None and generated_email is None and bias_result is None:
             # Email generation failed — find the error from the last step
             last_step = steps[-1] if steps else {}

--- a/backend/apps/agents/tasks.py
+++ b/backend/apps/agents/tasks.py
@@ -35,6 +35,7 @@ class _OrchestrateTask(Task):
         # directly without Celery's full task machinery.
         Task.on_failure(self, exc, task_id, args, kwargs, einfo)
 
+
 # Redis dedup lock TTL — slightly longer than the task soft time limit
 _DEDUP_LOCK_TTL = 600
 

--- a/backend/apps/agents/tests/test_marketing_agent.py
+++ b/backend/apps/agents/tests/test_marketing_agent.py
@@ -671,9 +671,7 @@ class TestPromptInjectionSanitizationLLMFields:
     def test_nbo_analysis_injection_is_neutralised(self, mock_call, mock_anthropic_cls):
         """Injection payload in nbo_analysis (raw LLM output) must be stripped."""
         mock_anthropic_cls.return_value = MagicMock()
-        mock_call.return_value = _make_mock_text_response(
-            "Subject: Next steps\n\nDear Jane,\n\nCall 1300 000 000."
-        )
+        mock_call.return_value = _make_mock_text_response("Subject: Next steps\n\nDear Jane,\n\nCall 1300 000 000.")
         agent = MarketingAgent()
         app = _make_mock_application()
 
@@ -691,9 +689,7 @@ class TestPromptInjectionSanitizationLLMFields:
     def test_denial_reasons_injection_is_neutralised(self, mock_call, mock_anthropic_cls):
         """Injection payload in denial_reasons must be stripped."""
         mock_anthropic_cls.return_value = MagicMock()
-        mock_call.return_value = _make_mock_text_response(
-            "Subject: Next steps\n\nDear Jane,\n\nCall 1300 000 000."
-        )
+        mock_call.return_value = _make_mock_text_response("Subject: Next steps\n\nDear Jane,\n\nCall 1300 000 000.")
         agent = MarketingAgent()
         app = _make_mock_application()
 
@@ -712,9 +708,7 @@ class TestPromptInjectionSanitizationLLMFields:
     def test_loyalty_factors_injection_is_neutralised(self, mock_call, mock_anthropic_cls):
         """Injection payload in loyalty_factors (LLM output) must be stripped."""
         mock_anthropic_cls.return_value = MagicMock()
-        mock_call.return_value = _make_mock_text_response(
-            "Subject: Next steps\n\nDear Jane,\n\nCall 1300 000 000."
-        )
+        mock_call.return_value = _make_mock_text_response("Subject: Next steps\n\nDear Jane,\n\nCall 1300 000 000.")
         agent = MarketingAgent()
         app = _make_mock_application()
 
@@ -734,9 +728,7 @@ class TestPromptInjectionSanitizationLLMFields:
     def test_clean_nbo_analysis_passes_through(self, mock_call, mock_anthropic_cls):
         """Clean NBO analysis text must appear in the prompt (not over-stripped)."""
         mock_anthropic_cls.return_value = MagicMock()
-        mock_call.return_value = _make_mock_text_response(
-            "Subject: Next steps\n\nDear Jane,\n\nCall 1300 000 000."
-        )
+        mock_call.return_value = _make_mock_text_response("Subject: Next steps\n\nDear Jane,\n\nCall 1300 000 000.")
         agent = MarketingAgent()
         app = _make_mock_application()
 

--- a/backend/apps/agents/tests/test_marketing_pipeline_nbo_failure.py
+++ b/backend/apps/agents/tests/test_marketing_pipeline_nbo_failure.py
@@ -76,11 +76,10 @@ class TestNboDbFailureDoesNotRaiseNameError:
         agent_run = _make_mock_agent_run()
         steps = []
 
-        with patch(
-            "apps.agents.services.marketing_pipeline.NextBestOfferGenerator"
-        ) as mock_gen_cls, patch(
-            "apps.agents.services.marketing_pipeline.NextBestOffer"
-        ) as mock_nbo_model:
+        with (
+            patch("apps.agents.services.marketing_pipeline.NextBestOfferGenerator") as mock_gen_cls,
+            patch("apps.agents.services.marketing_pipeline.NextBestOffer") as mock_nbo_model,
+        ):
             # LLM generate() succeeds and returns a valid result with offers
             mock_gen_cls.return_value.generate.return_value = _valid_nbo_result()
 
@@ -108,11 +107,10 @@ class TestNboDbFailureDoesNotRaiseNameError:
         agent_run = _make_mock_agent_run()
         steps = []
 
-        with patch(
-            "apps.agents.services.marketing_pipeline.NextBestOfferGenerator"
-        ) as mock_gen_cls, patch(
-            "apps.agents.services.marketing_pipeline.NextBestOffer"
-        ) as mock_nbo_model:
+        with (
+            patch("apps.agents.services.marketing_pipeline.NextBestOfferGenerator") as mock_gen_cls,
+            patch("apps.agents.services.marketing_pipeline.NextBestOffer") as mock_nbo_model,
+        ):
             mock_gen_cls.return_value.generate.return_value = _valid_nbo_result()
             mock_nbo_model.objects.create.side_effect = Exception("DB write failed")
 
@@ -138,11 +136,10 @@ class TestNboDbFailureDoesNotRaiseNameError:
         agent_run = _make_mock_agent_run()
         steps = []
 
-        with patch(
-            "apps.agents.services.marketing_pipeline.NextBestOfferGenerator"
-        ) as mock_gen_cls, patch(
-            "apps.agents.services.marketing_pipeline.NextBestOffer"
-        ) as mock_nbo_model:
+        with (
+            patch("apps.agents.services.marketing_pipeline.NextBestOfferGenerator") as mock_gen_cls,
+            patch("apps.agents.services.marketing_pipeline.NextBestOffer") as mock_nbo_model,
+        ):
             mock_gen_cls.return_value.generate.return_value = _valid_nbo_result()
             mock_nbo_model.objects.create.side_effect = Exception("DB write failed")
 
@@ -171,9 +168,7 @@ class TestNboDbFailureDoesNotRaiseNameError:
         agent_run = _make_mock_agent_run()
         steps = []
 
-        with patch(
-            "apps.agents.services.marketing_pipeline.NextBestOfferGenerator"
-        ) as mock_gen_cls:
+        with patch("apps.agents.services.marketing_pipeline.NextBestOfferGenerator") as mock_gen_cls:
             # LLM call itself fails
             mock_gen_cls.return_value.generate.side_effect = ConnectionError("timeout")
 

--- a/backend/apps/agents/tests/test_orchestrate_lock_release.py
+++ b/backend/apps/agents/tests/test_orchestrate_lock_release.py
@@ -70,9 +70,7 @@ class TestOrchestrateTaskOnFailure:
 
         _invoke_on_failure(retries=3, max_retries=3, args=[app_id], kwargs={})
 
-        assert cache.get(lock_key) is None, (
-            "Dedup lock must be released after max_retries exhausted"
-        )
+        assert cache.get(lock_key) is None, "Dedup lock must be released after max_retries exhausted"
 
     @CACHE_OVERRIDE
     def test_lock_kept_during_retry(self):
@@ -88,9 +86,7 @@ class TestOrchestrateTaskOnFailure:
         _invoke_on_failure(retries=1, max_retries=3, args=[app_id], kwargs={})
 
         # Lock must still be held so the next retry is protected (M22)
-        assert cache.get(lock_key) is not None, (
-            "Dedup lock must be kept alive during retries (M22)"
-        )
+        assert cache.get(lock_key) is not None, "Dedup lock must be kept alive during retries (M22)"
 
     @CACHE_OVERRIDE
     def test_lock_released_when_application_id_from_kwargs(self):

--- a/backend/apps/email_engine/tests/test_email_view_contracts.py
+++ b/backend/apps/email_engine/tests/test_email_view_contracts.py
@@ -101,9 +101,7 @@ def test_list_endpoint_excludes_body(email_with_guardrails, staff_user):
     assert len(results) >= 1
 
     for item in results:
-        assert "body" not in item, (
-            "LIST endpoint must not include body — it is large and unused by the list view"
-        )
+        assert "body" not in item, "LIST endpoint must not include body — it is large and unused by the list view"
 
 
 @pytest.mark.django_db
@@ -151,9 +149,7 @@ def test_list_guardrail_checks_include_quality_score(email_with_guardrails, staf
 
     for item in results:
         for check in item.get("guardrail_checks", []):
-            assert "quality_score" in check, (
-                "LIST guardrail_checks must include quality_score"
-            )
+            assert "quality_score" in check, "LIST guardrail_checks must include quality_score"
 
 
 @pytest.mark.django_db

--- a/backend/apps/ml_engine/services/counterfactual_engine.py
+++ b/backend/apps/ml_engine/services/counterfactual_engine.py
@@ -104,8 +104,7 @@ class CounterfactualEngine:
         current_term = int(original["loan_term_months"])
         max_term = 84  # 7 years max
         candidate_terms = [
-            t for t in [current_term + 12, current_term + 24, current_term + 36]
-            if t <= max_term and t != current_term
+            t for t in [current_term + 12, current_term + 24, current_term + 36] if t <= max_term and t != current_term
         ]
         for candidate_term in candidate_terms:
             test_df = features_df.copy()

--- a/backend/apps/ml_engine/services/loan_performance_simulator.py
+++ b/backend/apps/ml_engine/services/loan_performance_simulator.py
@@ -18,9 +18,7 @@ class LoanPerformanceSimulator:
     Extracted from DataGenerator to isolate loan performance simulation logic.
     """
 
-    def simulate_loan_performance(
-        self, df: pd.DataFrame, *, rng: np.random.Generator | None = None
-    ) -> pd.DataFrame:
+    def simulate_loan_performance(self, df: pd.DataFrame, *, rng: np.random.Generator | None = None) -> pd.DataFrame:
         """Simulate loan performance outcomes for approved loans.
 
         For each approved loan, runs month-by-month Markov chain simulation

--- a/backend/apps/ml_engine/services/model_card.py
+++ b/backend/apps/ml_engine/services/model_card.py
@@ -126,9 +126,7 @@ class ModelCardGenerator:
 
         return {
             "protected_attributes": (
-                list(fairness.keys())
-                if fairness
-                else ["employment_type", "applicant_type", "state"]
+                list(fairness.keys()) if fairness else ["employment_type", "applicant_type", "state"]
             ),
             "disparate_impact_ratio": disparate_impact,
             "mitigation": "Fairness reweighting during training",

--- a/backend/apps/ml_engine/services/prediction_cache.py
+++ b/backend/apps/ml_engine/services/prediction_cache.py
@@ -75,9 +75,7 @@ def _verify_model_hash(file_path, expected_hash, version_id=None):
     """
     if not expected_hash:
         if os.environ.get("DJANGO_DEBUG", "False").lower() not in ("true", "1"):
-            raise ValueError(
-                f"Model version {version_id} has no file_hash — hash verification required in production"
-            )
+            raise ValueError(f"Model version {version_id} has no file_hash — hash verification required in production")
         logger.warning("No file_hash stored for model version %s — skipping integrity check (dev mode)", version_id)
         return
     sha256 = hashlib.sha256()

--- a/backend/apps/ml_engine/services/trainer.py
+++ b/backend/apps/ml_engine/services/trainer.py
@@ -1123,9 +1123,7 @@ class ModelTrainer:
         # all candidate features — not just the subset that survived IV pruning.
         _woe_cols = getattr(self, "_original_numeric_cols", None) or list(self.NUMERIC_COLS)
         try:
-            woe_iv = self.metrics_service.compute_all_woe_iv(
-                df_test_raw[_woe_cols], y_test, _woe_cols, n_bins=10
-            )
+            woe_iv = self.metrics_service.compute_all_woe_iv(df_test_raw[_woe_cols], y_test, _woe_cols, n_bins=10)
             metrics["woe_iv"] = {
                 col: {"iv": v["iv"], "interpretation": v["iv_interpretation"]}
                 for col, v in woe_iv.items()
@@ -1290,9 +1288,7 @@ class ModelTrainer:
             import sklearn as _sklearn
 
             if cv_fit_params and _sklearn.__version__ >= "1.4":
-                scores = cross_val_score(
-                    model, X_train, y_train, cv=cv, scoring="roc_auc", params=cv_fit_params
-                )
+                scores = cross_val_score(model, X_train, y_train, cv=cv, scoring="roc_auc", params=cv_fit_params)
             else:
                 # sklearn <1.4: pass sample_weight via fit_params (deprecated in 1.4)
                 if cv_fit_params:

--- a/backend/apps/ml_engine/tests/test_drift_psi_consistency.py
+++ b/backend/apps/ml_engine/tests/test_drift_psi_consistency.py
@@ -125,6 +125,5 @@ class TestPsiConsistency:
 
         result = _psi_from_histogram(hist_counts, hist_edges, data)
         assert result["psi"] == pytest.approx(0.0, abs=0.01), (
-            f"Old eps inflation would push PSI above 0 even for identical data; "
-            f"got {result['psi']}"
+            f"Old eps inflation would push PSI above 0 even for identical data; got {result['psi']}"
         )

--- a/backend/apps/ml_engine/tests/test_metrics_production_grade.py
+++ b/backend/apps/ml_engine/tests/test_metrics_production_grade.py
@@ -287,10 +287,12 @@ def test_ece_is_population_weighted():
     """
     svc = MetricsService()
     y_prob = np.concatenate([np.full(90, 0.05), np.full(10, 0.85)])
-    y_true = np.concatenate([
-        np.array([1] * 9 + [0] * 81),   # 9/90 positive in low bin
-        np.array([1] * 5 + [0] * 5),     # 5/10 positive in high bin
-    ])
+    y_true = np.concatenate(
+        [
+            np.array([1] * 9 + [0] * 81),  # 9/90 positive in low bin
+            np.array([1] * 5 + [0] * 5),  # 5/10 positive in high bin
+        ]
+    )
 
     result = svc.compute_calibration_data(y_true, y_prob, n_bins=10)
 

--- a/backend/config/celery.py
+++ b/backend/config/celery.py
@@ -64,9 +64,7 @@ app.conf.accept_content = ["json"]
 # Worker restart every N tasks to mitigate memory leaks (common with
 # ML worker processes importing large libs). Env-var override available for
 # tuning without a redeploy; production.py no longer duplicates this value.
-app.conf.worker_max_tasks_per_child = int(
-    os.environ.get("CELERY_WORKER_MAX_TASKS_PER_CHILD", "1000")
-)
+app.conf.worker_max_tasks_per_child = int(os.environ.get("CELERY_WORKER_MAX_TASKS_PER_CHILD", "1000"))
 
 # Surface broker enqueue failures instead of silently dropping (L23).
 # For the Redis transport, fail fast on publish-time connection errors so
@@ -83,9 +81,7 @@ app.conf.broker_transport_options = {
 # Retry broker connection on startup so workers survive a brief Redis restart
 # or a race during docker compose bring-up (H27). Set CELERY_RETRY_ON_STARTUP=false
 # to disable in environments where a clean fail-fast is preferred.
-app.conf.broker_connection_retry_on_startup = (
-    os.environ.get("CELERY_RETRY_ON_STARTUP", "true").lower() != "false"
-)
+app.conf.broker_connection_retry_on_startup = os.environ.get("CELERY_RETRY_ON_STARTUP", "true").lower() != "false"
 
 app.conf.task_routes = {
     "apps.ml_engine.tasks.*": {"queue": "ml"},

--- a/backend/config/settings/production.py
+++ b/backend/config/settings/production.py
@@ -15,6 +15,7 @@ _hosts = os.environ.get("DJANGO_ALLOWED_HOSTS", "")
 ALLOWED_HOSTS = [h.strip() for h in _hosts.split(",") if h.strip()]
 if not ALLOWED_HOSTS:
     from django.core.exceptions import ImproperlyConfigured
+
     raise ImproperlyConfigured(
         "DJANGO_ALLOWED_HOSTS must be set to a non-empty comma-separated list in production. "
         "Example: DJANGO_ALLOWED_HOSTS=yourdomain.com,www.yourdomain.com"

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -8,7 +8,7 @@ pytest-cov>=5.0
 hypothesis>=6.100
 schemathesis>=3.36
 pre-commit>=4.0
-ruff>=0.8.6
+ruff==0.15.8  # pinned: CI runs `ruff format --check`; an unpinned floor let CI drift to a newer ruff whose formatter reflowed files, reddening Backend Lint
 pip-audit>=2.7
 vulture>=2.13
 mypy>=1.13

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,7 +22,7 @@ cloudpickle==3.1.2
 colorlog==6.10.1
 cryptography==46.0.7
 distro==1.9.0
-django[argon2]==5.2.14  # PYSEC-2026-50/54/55 fix (session Vary cache leak, Vary:* cache poisoning, ASGI upload-limit bypass)
+django[argon2]==5.2.15  # PYSEC-2026-197..201 fix (signed-cookie salt derivation, Vary/Cache-Control cache leaks, SMTP STARTTLS reuse)
 django-celery-results==2.6.0
 django-cors-headers==4.9.0
 django-csp==4.0

--- a/backend/tests/test_guardrail_hallucinated_numbers.py
+++ b/backend/tests/test_guardrail_hallucinated_numbers.py
@@ -40,9 +40,7 @@ def test_fabricated_sub5k_amount_is_flagged(checker):
         "nbo_amounts": [20000],
     }
     result = checker.check_hallucinated_numbers(text, context)
-    assert not result["passed"], (
-        "Expected $4,999 to be flagged as an unrecognised hallucinated amount"
-    )
+    assert not result["passed"], "Expected $4,999 to be flagged as an unrecognised hallucinated amount"
     assert "4,999" in result["details"] or "4999" in result["details"], result["details"]
 
 
@@ -61,9 +59,7 @@ def test_completely_invented_small_amount_flagged(checker):
         "nbo_amounts": [50000],
     }
     result = checker.check_hallucinated_numbers(text, context)
-    assert not result["passed"], (
-        "Expected $333 (not derivable from $50k offer) to be flagged"
-    )
+    assert not result["passed"], "Expected $333 (not derivable from $50k offer) to be flagged"
 
 
 # ---------------------------------------------------------------------------
@@ -90,9 +86,7 @@ def test_annual_interest_passess(checker):
     }
     result = checker.check_hallucinated_numbers(text, context)
     # $2,850 must be within ±10% of $3,000 (10000 × 0.30) → allowed
-    assert result["passed"], (
-        f"Legitimately derived annual interest $2,850 should pass: {result['details']}"
-    )
+    assert result["passed"], f"Legitimately derived annual interest $2,850 should pass: {result['details']}"
 
 
 def test_monthly_repayment_derived_from_nbo_passes(checker):
@@ -105,9 +99,7 @@ def test_monthly_repayment_derived_from_nbo_passes(checker):
     }
     result = checker.check_hallucinated_numbers(text, context)
     # $1,850 vs $2,000 = 7.5% difference → within 10% → should pass
-    assert result["passed"], (
-        f"Monthly amount $1,850 derived from $24,000 NBO should pass: {result['details']}"
-    )
+    assert result["passed"], f"Monthly amount $1,850 derived from $24,000 NBO should pass: {result['details']}"
 
 
 def test_exact_nbo_amount_always_passes(checker):
@@ -140,9 +132,7 @@ def test_no_false_positive_on_passing_nbo_email(checker):
         "nbo_amounts": [15000],
     }
     result = checker.check_hallucinated_numbers(text, context)
-    assert result["passed"], (
-        f"Legitimate NBO email with derivable amounts should pass: {result['details']}"
-    )
+    assert result["passed"], f"Legitimate NBO email with derivable amounts should pass: {result['details']}"
 
 
 def test_no_nbo_unaffected(checker):
@@ -154,6 +144,4 @@ def test_no_nbo_unaffected(checker):
         "nbo_amounts": [],
     }
     result = checker.check_hallucinated_numbers(text, context)
-    assert not result["passed"], (
-        "Unrecognised $4,999 without NBO context should remain flagged"
-    )
+    assert not result["passed"], "Unrecognised $4,999 without NBO context should remain flagged"

--- a/backend/tests/test_id_number_writeonly.py
+++ b/backend/tests/test_id_number_writeonly.py
@@ -91,9 +91,7 @@ def test_get_profile_returns_masked_variants(customer_with_ids):
     assert "secondary_id_number_masked" in data, "secondary_id_number_masked not in response"
 
     # Masked values should show only last 4 chars
-    assert data["primary_id_number_masked"] == "****5678", (
-        f"Expected ****5678, got {data['primary_id_number_masked']}"
-    )
+    assert data["primary_id_number_masked"] == "****5678", f"Expected ****5678, got {data['primary_id_number_masked']}"
     assert data["secondary_id_number_masked"] == "****4321", (
         f"Expected ****4321, got {data['secondary_id_number_masked']}"
     )

--- a/tools/file_size_allowlist.json
+++ b/tools/file_size_allowlist.json
@@ -4,10 +4,10 @@
   "packages": {
     "backend/apps/ml_engine/services": {
       "files": {
-        "data_generator.py": 1479,
+        "data_generator.py": 1485,
         "real_world_benchmarks.py": 1378,
-        "trainer.py": 1345,
-        "metrics.py": 1018,
+        "trainer.py": 1399,
+        "metrics.py": 1030,
         "underwriting_engine.py": 974,
         "property_data_service.py": 765,
         "macro_data_service.py": 579,


### PR DESCRIPTION
Greens the three **pre-existing, non-required** CI checks that were red on master (and on every PR) — all environmental, none caused by the recent deep-review PRs (they failed identically on PRs that touched no backend Python).

## Fixes
- **Dependency Audit** → `backend/requirements.txt`: bump **Django 5.2.14 → 5.2.15**, fixing 5 newly-disclosed CVEs (PYSEC-2026-197…201: signed-cookie salt derivation, `Vary`/`Cache-Control` cache leaks, SMTP STARTTLS reuse). Patch release within 5.2.x. `pip-audit` now: *No known vulnerabilities found*.
- **Backend Lint** → pin **`ruff==0.15.8`** in `requirements-dev.txt` + `lint.yml` (the unpinned `>=0.8.6` floor let CI install a newer ruff whose formatter reflowed 21 files), and run `ruff format` across the backend. CI `ruff format --check` + `ruff check` now pass. The format-only reflow is the first commit (no logic changes); the pins/bumps are the second.
- **ml_engine quality bar** → `tools/file_size_allowlist.json`: raise the caps for `data_generator.py` (1485), `metrics.py` (1030), `trainer.py` (1399) to their current cohesive sizes (the documented "raise the allowlist + note it" escape; splitting these is tracked separately).

## Verified locally
- [x] `python tools/check_file_sizes.py` → *Quality-bar check passed*
- [x] `pip-audit -r backend/requirements.txt` → *No known vulnerabilities found*
- [x] `ruff format --check .` + `ruff check .` → clean
- [ ] CI will confirm `Backend Tests` still pass on Django 5.2.15 (patch bump; expected green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)