### PR TITLE
fix(ci): green the Build workflow — compose env on dast-scan/load-test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,13 @@ jobs:
     if: >-
       github.ref == 'refs/heads/master' ||
       (github.event_name == 'pull_request' && github.base_ref == 'master')
+    # docker-compose.yml interpolates ${POSTGRES_PASSWORD:?} on EVERY `docker
+    # compose` invocation (build/up/exec/down), so ALL steps need it — not just
+    # Start. Without this, the always()-run "Stop application stack" cleanup
+    # (docker compose down) errors on the missing var and fails the whole job.
+    env:
+      POSTGRES_PASSWORD: testpass
+      REDIS_PASSWORD: testpass
     steps:
       - uses: actions/checkout@v6
 
@@ -135,6 +142,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [docker-build]
     if: github.ref == 'refs/heads/master'
+    # Same as dast-scan: the Seed and Stop steps also run `docker compose`,
+    # which needs POSTGRES_PASSWORD to interpolate the compose file.
+    env:
+      POSTGRES_PASSWORD: testpass
+      REDIS_PASSWORD: testpass
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Follow-up to #217. Greens the **Build** workflow (`build.yml`), which was failing on a pre-existing CI bug — not a security finding.

## Root cause
`docker-compose.yml` declares `POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set ...}`, so Compose **errors on the missing var for every `docker compose` invocation** (build/up/exec/**down**). Only the *"Start application stack"* step set the env inline, so:
- `dast-scan` → the always()-run *"Stop application stack"* (`docker compose down -v`) errored → job failed (the ZAP Baseline Scan itself passed).
- `load-test` → same for *"Seed test data"* (`docker compose exec`) and *"Stop application stack"*.

This was red on master already; #216 (DAST-on-PRs) just made it visible on PRs.

## Fix
Hoist `POSTGRES_PASSWORD`/`REDIS_PASSWORD` to **job-level `env:`** on both `dast-scan` and `load-test`, so all steps inherit them. No behaviour change to the scans themselves.

## Validation
- [x] `build.yml` YAML valid
- [ ] PR CI: `dast-scan` should now go green end-to-end (ZAP scan was already passing; only cleanup was failing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)