### PR TITLE
fix(docker): celery_beat uses default scheduler (stop crash loop)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,9 +207,14 @@ services:
       FIELD_ENCRYPTION_KEY: ${FIELD_ENCRYPTION_KEY:-}
     volumes:
       - ./backend:/app
+    # Use Celery's default PersistentScheduler. The beat schedule is defined in
+    # code (config/celery.py -> app.conf.beat_schedule), so the DatabaseScheduler
+    # from django-celery-beat is unnecessary — and that package is NOT a dependency
+    # (requirements ships django-celery-results, a different package), so forcing
+    # the override crash-loops beat with ModuleNotFoundError. Do not re-add it
+    # without also adding django-celery-beat to requirements + INSTALLED_APPS.
     command: >
       celery -A config beat -l info
-        --scheduler django_celery_beat.schedulers:DatabaseScheduler
         --pidfile /tmp/celerybeat.pid
     healthcheck:
       test: ["CMD-SHELL", "test -f /tmp/celerybeat.pid && kill -0 $(cat /tmp/celerybeat.pid) 2>/dev/null || exit 1"]


### PR DESCRIPTION
## Summary

`celery_beat` was crash-looping — **379 restarts in 3 hours** — with `ModuleNotFoundError: No module named 'django_celery_beat'`.

**Root cause:** the service command forced `--scheduler django_celery_beat.schedulers:DatabaseScheduler`, but that package is **not** a dependency (requirements ships `django-celery-**results**`, a different package) and isn't in `INSTALLED_APPS`. The beat schedule is defined in **code** (`config/celery.py` → `app.conf.beat_schedule`, 5 weekly jobs), which works with Celery's default `PersistentScheduler`. So the override was simply erroneous.

**Fix:** drop the `--scheduler` override (one line) so beat uses the default scheduler. Added a comment warning not to re-add it without also adding the package + app.

This has been silently broken across releases because CI never gates on beat health and the scheduled jobs (weekly crontabs) aren't exercised by tests. On-demand predictions/emails were unaffected (they run on the healthy ml/io workers).

## Test Plan
- [x] Recreated `celery_beat` on the running stack with the fix → **Up (healthy)**, `RestartCount=0` (was 379)
- [x] Logs show `scheduler -> celery.beat.PersistentScheduler`, `db -> celerybeat-schedule`, `beat: Starting...` — no import error
- [x] Single-file change (`docker-compose.yml`); CI build/dast/load-test don't start beat, smoke-e2e starts it but doesn't gate on its health