### PR TITLE
fix(fairness): exclude tiny protected groups from the disparate-impact ratio

### DIFF
--- a/backend/apps/ml_engine/services/metrics.py
+++ b/backend/apps/ml_engine/services/metrics.py
@@ -311,8 +311,18 @@ class MetricsService:
         group_labels = np.array(group_labels)
         unique_groups = np.unique(group_labels)
 
+        min_group_size = int(getattr(django_settings, "FAIRNESS_MIN_GROUP_SIZE", 30))
+
         group_metrics = {}
-        approval_rates = []
+        # Only groups with enough samples drive the disparate-impact / equalized-odds
+        # verdict. A min/max approval-rate ratio is dominated by sampling noise when a
+        # group is tiny (e.g. a state with ~10-20 test rows), so such groups are still
+        # REPORTED for transparency but excluded from the ratio. Configurable via
+        # settings.FAIRNESS_MIN_GROUP_SIZE (default 30) — consistent with the gate.
+        assessable_rates = []
+        assessable_tprs = []
+        assessable_fprs = []
+        excluded_small_groups = []
 
         for group in unique_groups:
             mask = group_labels == group
@@ -321,7 +331,6 @@ class MetricsService:
                 continue
             g_true = y_true[mask]
             g_pred = y_pred[mask]
-            y_prob[mask]
 
             approval_rate = float(g_pred.mean())
             # TPR = recall for positive class
@@ -333,27 +342,34 @@ class MetricsService:
             tn = ((g_pred == 0) & (g_true == 0)).sum()
             fpr_val = float(fp / (fp + tn)) if (fp + tn) > 0 else 0.0
 
+            assessable = count >= min_group_size
             group_metrics[str(group)] = {
                 "count": count,
                 "actual_approval_rate": round(float(g_true.mean()), 4),
                 "predicted_approval_rate": round(approval_rate, 4),
                 "tpr": round(tpr, 4),
                 "fpr": round(fpr_val, 4),
+                "included_in_fairness": assessable,
             }
-            approval_rates.append(approval_rate)
 
-        # Disparate impact ratio: min(rate) / max(rate). EEOC 80% rule: must be > 0.80
-        if len(approval_rates) >= 2 and max(approval_rates) > 0:
-            disparate_impact = min(approval_rates) / max(approval_rates)
+            if assessable:
+                assessable_rates.append(approval_rate)
+                assessable_tprs.append(tpr)
+                assessable_fprs.append(fpr_val)
+            else:
+                excluded_small_groups.append(str(group))
+
+        # Disparate impact ratio: min(rate) / max(rate) over assessable groups only.
+        # EEOC 80% rule: must be >= 0.80.
+        if len(assessable_rates) >= 2 and max(assessable_rates) > 0:
+            disparate_impact = min(assessable_rates) / max(assessable_rates)
         else:
-            disparate_impact = None  # Undefined when all groups have 0% approval
+            disparate_impact = None  # Undefined: <2 assessable groups or zero approvals
 
-        # Equalized odds difference: max gap in TPR or FPR across groups
-        tprs = [m["tpr"] for m in group_metrics.values()]
-        fprs = [m["fpr"] for m in group_metrics.values()]
+        # Equalized odds difference: max gap in TPR or FPR across assessable groups.
         eq_odds_diff = max(
-            (max(tprs) - min(tprs)) if tprs else 0.0,
-            (max(fprs) - min(fprs)) if fprs else 0.0,
+            (max(assessable_tprs) - min(assessable_tprs)) if len(assessable_tprs) >= 2 else 0.0,
+            (max(assessable_fprs) - min(assessable_fprs)) if len(assessable_fprs) >= 2 else 0.0,
         )
 
         return {
@@ -361,6 +377,8 @@ class MetricsService:
             "disparate_impact_ratio": round(disparate_impact, 4) if disparate_impact is not None else None,
             "equalized_odds_difference": round(eq_odds_diff, 4),
             "passes_80_percent_rule": disparate_impact >= 0.80 if disparate_impact is not None else None,
+            "min_group_size": min_group_size,
+            "excluded_small_groups": excluded_small_groups,
         }
 
     # ==================================================================

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -230,6 +230,11 @@ ML_MODELS_DIR = BASE_DIR / "ml_models"
 ML_EARLY_STOPPING_ROUNDS = 30
 ML_COST_FP_FN_RATIO = 5  # FP cost : FN cost ratio for threshold optimization
 ML_FAIRNESS_TARGET_DI = 0.80  # Target disparate impact ratio (EEOC 80% rule)
+# Minimum samples a protected group needs before it drives the disparate-impact
+# verdict. Smaller groups (e.g. a state with ~10-20 test rows) are still reported
+# but excluded from the min/max ratio, which is otherwise dominated by their
+# sampling noise. Shared by MetricsService.compute_fairness_metrics and the gate.
+FAIRNESS_MIN_GROUP_SIZE = 30
 ML_OVERFITTING_THRESHOLD = 0.05  # Flag if train-test AUC gap exceeds this
 # XGBoost max_bin for histogram construction. 256 is the XGBoost default and
 # is plenty for the 50k-row / 35-feature synthetic dataset; 512 doubled the

--- a/backend/tests/test_metrics_service.py
+++ b/backend/tests/test_metrics_service.py
@@ -341,9 +341,7 @@ class TestComputeFairnessMetrics:
 
     def test_reports_all_groups_and_flags_small_ones(self, svc, settings):
         settings.FAIRNESS_MIN_GROUP_SIZE = 10
-        y_true, y_pred, y_prob, labels = self._grouped(
-            [("big_a", 50, 40), ("big_b", 50, 35), ("tiny_c", 5, 0)]
-        )
+        y_true, y_pred, y_prob, labels = self._grouped([("big_a", 50, 40), ("big_b", 50, 35), ("tiny_c", 5, 0)])
         res = svc.compute_fairness_metrics(y_true, y_pred, y_prob, labels)
 
         # Every group is still reported (the chart shows them all)...
@@ -357,9 +355,7 @@ class TestComputeFairnessMetrics:
 
     def test_tiny_noisy_group_does_not_drive_the_verdict(self, svc, settings):
         settings.FAIRNESS_MIN_GROUP_SIZE = 10
-        y_true, y_pred, y_prob, labels = self._grouped(
-            [("big_a", 50, 40), ("big_b", 50, 35), ("tiny_c", 5, 0)]
-        )
+        y_true, y_pred, y_prob, labels = self._grouped([("big_a", 50, 40), ("big_b", 50, 35), ("tiny_c", 5, 0)])
         res = svc.compute_fairness_metrics(y_true, y_pred, y_prob, labels)
         # DI = 0.70 / 0.80 = 0.875 over the two large groups -> PASS.
         assert res["disparate_impact_ratio"] == pytest.approx(0.875, abs=1e-3)
@@ -369,9 +365,7 @@ class TestComputeFairnessMetrics:
         """Proof the exclusion is what fixes it: with threshold 1 the noisy group
         is included and crushes the ratio to 0 -> FAIL."""
         settings.FAIRNESS_MIN_GROUP_SIZE = 1
-        y_true, y_pred, y_prob, labels = self._grouped(
-            [("big_a", 50, 40), ("big_b", 50, 35), ("tiny_c", 5, 0)]
-        )
+        y_true, y_pred, y_prob, labels = self._grouped([("big_a", 50, 40), ("big_b", 50, 35), ("tiny_c", 5, 0)])
         res = svc.compute_fairness_metrics(y_true, y_pred, y_prob, labels)
         assert res["disparate_impact_ratio"] == 0.0
         assert res["passes_80_percent_rule"] is False
@@ -379,9 +373,7 @@ class TestComputeFairnessMetrics:
 
     def test_di_undefined_when_fewer_than_two_assessable_groups(self, svc, settings):
         settings.FAIRNESS_MIN_GROUP_SIZE = 30
-        y_true, y_pred, y_prob, labels = self._grouped(
-            [("big_a", 50, 40), ("tiny_b", 5, 1), ("tiny_c", 5, 0)]
-        )
+        y_true, y_pred, y_prob, labels = self._grouped([("big_a", 50, 40), ("tiny_b", 5, 1), ("tiny_c", 5, 0)])
         res = svc.compute_fairness_metrics(y_true, y_pred, y_prob, labels)
         assert res["disparate_impact_ratio"] is None
         assert res["passes_80_percent_rule"] is None

--- a/backend/tests/test_metrics_service.py
+++ b/backend/tests/test_metrics_service.py
@@ -317,3 +317,80 @@ class TestComputeDecileAnalysis:
         result = svc.compute_decile_analysis(y_true, y_prob)
         lifts = [d["lift"] for d in result["deciles"]]
         assert lifts[-1] == max(lifts)
+
+
+# ── compute_fairness_metrics (disparate impact + small-group stability) ──
+
+
+class TestComputeFairnessMetrics:
+    def _grouped(self, specs):
+        """Build (y_true, y_pred, y_prob, group_labels) from (name, n, n_approved) specs.
+
+        y_true is set equal to y_pred so per-group TPR/FPR are clean and the test
+        focuses on the disparate-impact (predicted approval rate) logic.
+        """
+        y_pred, labels = [], []
+        for name, n, n_approved in specs:
+            y_pred.extend([1] * n_approved + [0] * (n - n_approved))
+            labels.extend([name] * n)
+        y_pred = np.array(y_pred)
+        labels = np.array(labels)
+        y_true = y_pred.copy()
+        y_prob = y_pred.astype(float)
+        return y_true, y_pred, y_prob, labels
+
+    def test_reports_all_groups_and_flags_small_ones(self, svc, settings):
+        settings.FAIRNESS_MIN_GROUP_SIZE = 10
+        y_true, y_pred, y_prob, labels = self._grouped(
+            [("big_a", 50, 40), ("big_b", 50, 35), ("tiny_c", 5, 0)]
+        )
+        res = svc.compute_fairness_metrics(y_true, y_pred, y_prob, labels)
+
+        # Every group is still reported (the chart shows them all)...
+        assert set(res["groups"].keys()) == {"big_a", "big_b", "tiny_c"}
+        assert res["groups"]["tiny_c"]["count"] == 5
+        # ...but the small group is flagged and excluded from the ratio.
+        assert res["groups"]["big_a"]["included_in_fairness"] is True
+        assert res["groups"]["tiny_c"]["included_in_fairness"] is False
+        assert res["excluded_small_groups"] == ["tiny_c"]
+        assert res["min_group_size"] == 10
+
+    def test_tiny_noisy_group_does_not_drive_the_verdict(self, svc, settings):
+        settings.FAIRNESS_MIN_GROUP_SIZE = 10
+        y_true, y_pred, y_prob, labels = self._grouped(
+            [("big_a", 50, 40), ("big_b", 50, 35), ("tiny_c", 5, 0)]
+        )
+        res = svc.compute_fairness_metrics(y_true, y_pred, y_prob, labels)
+        # DI = 0.70 / 0.80 = 0.875 over the two large groups -> PASS.
+        assert res["disparate_impact_ratio"] == pytest.approx(0.875, abs=1e-3)
+        assert res["passes_80_percent_rule"] is True
+
+    def test_small_group_would_fail_the_rule_if_not_excluded(self, svc, settings):
+        """Proof the exclusion is what fixes it: with threshold 1 the noisy group
+        is included and crushes the ratio to 0 -> FAIL."""
+        settings.FAIRNESS_MIN_GROUP_SIZE = 1
+        y_true, y_pred, y_prob, labels = self._grouped(
+            [("big_a", 50, 40), ("big_b", 50, 35), ("tiny_c", 5, 0)]
+        )
+        res = svc.compute_fairness_metrics(y_true, y_pred, y_prob, labels)
+        assert res["disparate_impact_ratio"] == 0.0
+        assert res["passes_80_percent_rule"] is False
+        assert res["excluded_small_groups"] == []
+
+    def test_di_undefined_when_fewer_than_two_assessable_groups(self, svc, settings):
+        settings.FAIRNESS_MIN_GROUP_SIZE = 30
+        y_true, y_pred, y_prob, labels = self._grouped(
+            [("big_a", 50, 40), ("tiny_b", 5, 1), ("tiny_c", 5, 0)]
+        )
+        res = svc.compute_fairness_metrics(y_true, y_pred, y_prob, labels)
+        assert res["disparate_impact_ratio"] is None
+        assert res["passes_80_percent_rule"] is None
+        assert set(res["excluded_small_groups"]) == {"tiny_b", "tiny_c"}
+
+    def test_group_at_exactly_the_threshold_is_included(self, svc, settings):
+        settings.FAIRNESS_MIN_GROUP_SIZE = 30
+        y_true, y_pred, y_prob, labels = self._grouped([("a", 30, 24), ("b", 40, 28)])
+        res = svc.compute_fairness_metrics(y_true, y_pred, y_prob, labels)
+        assert res["groups"]["a"]["included_in_fairness"] is True
+        assert res["excluded_small_groups"] == []
+        assert res["disparate_impact_ratio"] == pytest.approx(0.875, abs=1e-3)

--- a/backend/tests/test_metrics_service.py
+++ b/backend/tests/test_metrics_service.py
@@ -339,6 +339,24 @@ class TestComputeFairnessMetrics:
         y_prob = y_pred.astype(float)
         return y_true, y_pred, y_prob, labels
 
+    def _grouped_confusion(self, specs):
+        """Build (y_true, y_pred, y_prob, group_labels) from (name, tp, fn, fp, tn) specs.
+
+        Unlike _grouped (which sets y_true == y_pred, pinning every group to TPR=1/FPR=0),
+        this lets groups genuinely disagree on TPR/FPR so the equalized-odds path is
+        exercised. tp: true=1,pred=1 · fn: true=1,pred=0 · fp: true=0,pred=1 · tn: true=0,pred=0.
+        """
+        y_true, y_pred, labels = [], [], []
+        for name, tp, fn, fp, tn in specs:
+            y_true.extend([1] * tp + [1] * fn + [0] * fp + [0] * tn)
+            y_pred.extend([1] * tp + [0] * fn + [1] * fp + [0] * tn)
+            labels.extend([name] * (tp + fn + fp + tn))
+        y_true = np.array(y_true)
+        y_pred = np.array(y_pred)
+        labels = np.array(labels)
+        y_prob = y_pred.astype(float)
+        return y_true, y_pred, y_prob, labels
+
     def test_reports_all_groups_and_flags_small_ones(self, svc, settings):
         settings.FAIRNESS_MIN_GROUP_SIZE = 10
         y_true, y_pred, y_prob, labels = self._grouped([("big_a", 50, 40), ("big_b", 50, 35), ("tiny_c", 5, 0)])
@@ -386,3 +404,33 @@ class TestComputeFairnessMetrics:
         assert res["groups"]["a"]["included_in_fairness"] is True
         assert res["excluded_small_groups"] == []
         assert res["disparate_impact_ratio"] == pytest.approx(0.875, abs=1e-3)
+
+    def test_equalized_odds_uses_only_assessable_groups(self, svc, settings):
+        """A tiny group with extreme TPR/FPR must not inflate the equalized-odds gap.
+
+        large_a: TPR 0.9 / FPR 0.1 · large_b: TPR 0.8 / FPR 0.2 · tiny_c (excluded):
+        TPR 0.0 / FPR 1.0. The gap is taken over the two large groups only —
+        max(TPR gap 0.1, FPR gap 0.1) = 0.1. If tiny_c were counted it would be ~0.9.
+        """
+        settings.FAIRNESS_MIN_GROUP_SIZE = 30
+        y_true, y_pred, y_prob, labels = self._grouped_confusion(
+            [("large_a", 27, 3, 2, 18), ("large_b", 24, 6, 4, 16), ("tiny_c", 0, 3, 3, 0)]
+        )
+        res = svc.compute_fairness_metrics(y_true, y_pred, y_prob, labels)
+
+        assert res["groups"]["large_a"]["tpr"] == pytest.approx(0.9, abs=1e-3)
+        assert res["groups"]["large_b"]["tpr"] == pytest.approx(0.8, abs=1e-3)
+        assert res["groups"]["tiny_c"]["included_in_fairness"] is False
+        # Driven by the assessable groups only — NOT inflated to ~0.9 by tiny_c.
+        assert res["equalized_odds_difference"] == pytest.approx(0.1, abs=1e-3)
+
+    def test_equalized_odds_zero_with_single_assessable_group(self, svc, settings):
+        """Fewer than two assessable groups -> no pair to compare -> gap is 0.0,
+        even when an excluded tiny group has a wildly different TPR/FPR."""
+        settings.FAIRNESS_MIN_GROUP_SIZE = 30
+        y_true, y_pred, y_prob, labels = self._grouped_confusion([("large_a", 27, 3, 2, 18), ("tiny_b", 0, 3, 3, 0)])
+        res = svc.compute_fairness_metrics(y_true, y_pred, y_prob, labels)
+
+        assert res["groups"]["large_a"]["included_in_fairness"] is True
+        assert res["groups"]["tiny_b"]["included_in_fairness"] is False
+        assert res["equalized_odds_difference"] == 0.0

--- a/tools/file_size_allowlist.json
+++ b/tools/file_size_allowlist.json
@@ -7,7 +7,7 @@
         "data_generator.py": 1485,
         "real_world_benchmarks.py": 1378,
         "trainer.py": 1399,
-        "metrics.py": 1030,
+        "metrics.py": 1050,
         "underwriting_engine.py": 974,
         "property_data_service.py": 765,
         "macro_data_service.py": 579,


### PR DESCRIPTION
## Problem
The Model Metrics **Fairness** tab was showing spurious `FAIL` badges (notably on `state`). The disparate-impact ratio `DI = min(group approval rate) / max(group approval rate)` was computed over **every** protected group regardless of size. With small cohorts — e.g. NT/TAS having only ~10-20 rows in the test split — the ratio is dominated by sampling noise and swings wildly by seed, tripping the EEOC four-fifths rule even when the model is reasonable.

## Fix
`compute_fairness_metrics` now drives the DI / equalized-odds verdict **only from groups with `>= FAIRNESS_MIN_GROUP_SIZE` samples** (new setting, default **30** — consistent with the existing fairness gate). You can't reliably measure a four-fifths ratio on an n≈12 cohort, so those groups are excluded from the *math*.

Transparency is preserved — this hides nothing:
- Every group is **still reported** in `groups` (the chart shows them all).
- Excluded groups are flagged `included_in_fairness: false` and listed in a new `excluded_small_groups` field.
- `min_group_size` is returned so the threshold is visible.

**Genuine disparities in large cohorts are unchanged** — e.g. `employment_type` (casual/self-employed approved less, which is realistic under AU responsible lending) still surfaces exactly as before. This fixes the *brittle metric*, it does not mask real bias.

## Tests
- 5 new unit tests in `test_metrics_service.py`, including a guard that proves the exclusion is load-bearing (with threshold=1 the noisy group is included and the rule correctly FAILs).
- Full fairness + metrics suites green in the backend container: **104 passed** (metrics service, fairness gate, intersectional, gate-mode, production-grade) + **37 passed** (model card, MRM dossier). Ruff clean.

## Notes / follow-ups
- The frontend `FairnessCard` ignores the new fields today; a small follow-up (on the chart-hover PR #220 or its own) can visually mark excluded groups with an "n too small" note.
- The `0.80` four-fifths threshold is still duplicated across `metrics.py`/`fairness_gate.py`/`settings`/`intersectional_fairness.py`; consolidating onto `settings.ML_FAIRNESS_TARGET_DI` is a separate cleanup, intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)