### PR TITLE
docs: fix stale portfolio numbers + CHANGELOG v1.11.1/Unreleased + surface k8s/terraform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Changelog
 
+## Unreleased — post-v1.11.1 hardening (on `master`, not yet tagged)
+
+Work landed on `master` after the `v1.11.1` tag. Not yet cut as a release.
+
+- **Model Metrics redesign + chart hover + fairness honesty.** Tabbed Model Metrics page (357→125-line page, redesign + ECE/visualisation correctness fixes) (#211). Hover detail now renders in a fixed strip *below* each of the 7 charts instead of a floating tooltip that covered the plot, with capitalised group labels (#220). Fairness disparate-impact ratio now **excludes protected groups below `FAIRNESS_MIN_GROUP_SIZE`** (default 30) so a ~10-20-sample cohort's sampling noise can't manufacture a fail; excluded groups are still shown for transparency, and an un-assessable result (fewer than two large groups) renders a neutral "Not assessable" badge instead of a false green PASS (#222 + #220).
+- **Deep 5-agent review remediation (~22 findings across #212–#219, #221).** Backend agents/ML correctness & operability (#213); backend security / guardrails / API hardening (#214); frontend null-safety, auth-redirect, payload + PII hardening (#215); k8s / compose / CI / monitoring hardening (#216); backend healthcheck moved to the open `/api/v1/health/` probe, gated `/ready/` removed (#212); CI greened — ruff pinned, Django 5.2.15, build-workflow env, smoke-e2e (#217–#219); `celery_beat` uses the default scheduler, not django-celery-beat (#221).
+- **Staff-endpoint PII trust boundary (#171).** Staff customer endpoints now filter to `role=CUSTOMER`, so an officer can no longer enumerate admin/officer accounts or auto-create a phantom `CustomerProfile` against a non-customer.
+
+## v1.11.1 — Full-codebase review remediation (2026-06-05)
+
+A 93-finding full-codebase senior review (9 Critical / 30 High / 36 Medium / 18 Low), every finding adversarially re-verified before fixing, landed across the review branch and merged to master. `APP_VERSION` bumped to `1.11.1` (#210) and tagged `v1.11.1`. Scope spanned correctness, security, reliability, and operability fixes on top of the v1.11.0 ADM/contestability baseline; no model retraining or API-surface removal.
+
 ## v1.11.0 — Decision Transparency, Contestability & Audit Remediation
 
-Adds Privacy Act automated-decision-making (ADM) transparency + a customer contestability path, then works a verified senior-audit backlog (3 HIGH / 9 MEDIUM / 21 LOW, every finding adversarially re-verified) across six phases. On branch `feat/decision-transparency-contestability` (PR #207). Backend + frontend green end-to-end; pending merge.
+Adds Privacy Act automated-decision-making (ADM) transparency + a customer contestability path, then works a verified senior-audit backlog (3 HIGH / 9 MEDIUM / 21 LOW, every finding adversarially re-verified) across six phases. Released 2026-06-03 (PR #207 merged to master, merge commit `eb21013`, tagged `v1.11.0`).
 
 ### Phase 1 — ADM transparency correctness (3 HIGH)
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Applicants can **request a human review** of a declined automated decision; an o
 | Frontend | Next.js 15, React 19, TanStack Query, Tailwind, shadcn/ui |
 | ML | scikit-learn, XGBoost, SHAP, Optuna |
 | AI | Claude API (Sonnet for generation, Opus for compliance review) |
-| Infra | Docker Compose, 7 containers, separate ML and IO Celery workers |
+| Infra (local) | Docker Compose, separate ML and IO Celery workers |
+| Infra (cloud) | Kubernetes (deployments, HPA, NetworkPolicies, PodDisruptionBudgets, Ingress) + Terraform (AWS EKS, RDS Postgres, ElastiCache Redis) |
 
 ## Run locally in 60 seconds
 
@@ -132,6 +133,8 @@ frontend/src/
 scripts/            # init_db.sh, seed_data.sh
 tools/              # standalone training + evaluation scripts
 workflows/          # markdown SOPs for each pipeline stage
+k8s/                # Kubernetes manifests — deployments, HPA, NetworkPolicies, PDBs, Ingress
+terraform/          # AWS infra-as-code — EKS, RDS Postgres, ElastiCache Redis
 ```
 
 </details>
@@ -152,7 +155,7 @@ workflows/          # markdown SOPs for each pipeline stage
 <details>
 <summary><strong>ML model details</strong> (click to expand)</summary>
 
-XGBoost trained on synthetic Australian lending data. 71 raw applicant input fields (48 numeric + categoricals) with 31 engineered interactions, Optuna Bayesian hyperparameter optimisation, isotonic probability calibration, 75 monotonic constraints (higher income -> lower risk, etc.).
+XGBoost trained on synthetic Australian lending data. 71 raw applicant input fields (48 numeric + categoricals) with 31 engineered interactions, Optuna Bayesian hyperparameter optimisation, isotonic probability calibration, 76 monotonic constraints (higher income -> lower risk, etc.).
 
 The synthetic data is calibrated against ATO, ABS, APRA, and Equifax published statistics. It includes latent variables the model can't see (documentation quality, savings patterns, employer stability), underwriter disagreement noise, and measurement error — so the model hits realistic metrics (test AUC 0.88 per the active `ModelVersion`; reproducible benchmark on a 2,000-record subset is 0.85 with default hyperparameters — see `docs/experiments/benchmark.md`) rather than the 0.99 you get with clean synthetic labels.
 

--- a/docs/interview-talking-points.md
+++ b/docs/interview-talking-points.md
@@ -37,17 +37,17 @@
 
 ## Card 4 — XGBoost with monotonic constraints
 
-**Say it:** "XGBoost over a logistic scorecard for lift, but with 21 monotonic constraints — higher income always reduces risk, lower DTI always reduces risk, etc. Monotonicity is what makes the model defensible to a regulator: I can point at the constraints and show that the model cannot produce a perverse decision where a better applicant scores worse."
+**Say it:** "XGBoost over a logistic scorecard for lift, but with 76 monotonic constraints — higher income always reduces risk, lower DTI always reduces risk, etc. Monotonicity is what makes the model defensible to a regulator: I can point at the constraints and show that the model cannot produce a perverse decision where a better applicant scores worse."
 
 **Follow-ups to expect:**
 - *How much lift?* → Measured, not assumed. Every training run fits a logistic baseline on four core features and records `baseline_auc` plus `xgb_lift_over_baseline` in training metadata. ADR 002.
-- *What else?* → IV feature selection, isotonic calibration, conformal prediction intervals for high-stakes cases, SHAP-mapped to 70 adverse-action reason codes, APRA +3% stress buffer, parcelling-based reject inference.
+- *What else?* → IV feature selection, isotonic calibration, conformal prediction intervals for high-stakes cases, SHAP-mapped to 76 adverse-action reason codes, APRA +3% stress buffer, parcelling-based reject inference.
 
 ---
 
 ## Card 5 — Emails: template-first, Claude narrowly scoped
 
-**Say it:** "Claude doesn't write denial letters from scratch. It would be expensive, slow, inconsistent, and regulatorially dangerous. Every email starts from an audited template. Claude is invoked only to personalise the reason-code section. Then 15 deterministic guardrails run before send — prohibited language, hallucinated dollar amounts, overly formal phrasing, apology language, word count, required AFCA reference, and so on."
+**Say it:** "Claude doesn't write denial letters from scratch. It would be expensive, slow, inconsistent, and regulatorially dangerous. Every email starts from an audited template. Claude is invoked only to personalise the reason-code section. Then 18 deterministic guardrails run before send (19 for marketing emails) — prohibited language, hallucinated dollar amounts, overly formal phrasing, apology language, word count, required AFCA reference, and so on."
 
 **Follow-ups to expect:**
 - *Why is apology language banned?* → Australian banking guidance interprets it as admission of wrongdoing. There's an explicit guardrail, a test, and a persistent note in the project so it can't come back.
@@ -131,16 +131,16 @@
 
 **Numbers worth remembering:**
 - Test AUC 0.87–0.88 Optuna-tuned, 0.84–0.85 default hyperparameters (synthetic), ~0.82 real-world estimate (TSTR).
-- 71 input fields, 21 monotonic constraints, 31 engineered interactions.
-- 15 deterministic email guardrails. Three regeneration attempts then human review.
-- 70 SHAP-mapped adverse-action reason codes.
+- 71 input fields, 76 monotonic constraints, 31 engineered interactions.
+- 18 deterministic email guardrails on a decision email (19 on a marketing email). Up to three regeneration attempts, then the email is withheld and flagged to operations — the human-review queue is reserved for bias escalations only.
+- 76 SHAP-mapped adverse-action reason codes.
 - <$5/day Claude API cap.
 - 30s watchdog poll, 5-minute stuck threshold.
-- 60% backend test coverage floor, ~1000 tests across 66 files.
+- 63% backend test coverage floor, 1,932 backend tests across 158 files, plus 341 frontend tests.
 
 **Things you shouldn't oversell:**
 - No production users. No licensed compliance sign-off. Synthetic data only.
 - No paging. No multi-region. No Vault — secrets are in `.env`.
 - Model card is honest, not audited.
 
-*Last updated: 2026-04-17.*
+*Last updated: 2026-06-08.*


### PR DESCRIPTION
## Why
On an "honest metrics" portfolio project, `docs/interview-talking-points.md` (last touched 2026-04-17) had drifted on **every** numeric claim, and `CHANGELOG.md` had no `v1.11.1` entry despite `APP_VERSION = "1.11.1"` (and still framed v1.11.0 as "pending merge"). All numbers below were **derived from source** (counted in-code), not copied from the README.

## interview-talking-points.md
| Claim | Was | Now (source) |
|---|---|---|
| Email guardrails | 15 | **18** decision / **19** marketing (`guardrails/engine.py` run_all_checks) |
| Guardrail-failure path | "then human review" | **withheld + ops-flagged** (human-review queue is bias-only) |
| Monotonic constraints | 21 | **76** (`monotone_constraints.py`) |
| SHAP reason codes | 70 | **76** (`reason_codes.py`) |
| Coverage floor | 60% | **63%** (`test.yml` `--cov-fail-under=63`) |
| Test count | ~1000 / 66 files | **1,932 backend / 158 files** (+341 frontend) |
| Last updated | 2026-04-17 | 2026-06-08 |

## CHANGELOG.md
- Added the missing **v1.11.1** entry (93-finding full-codebase review, tagged 2026-06-05).
- Added an honest **Unreleased** section for the 13 post-v1.11.1 commits (#211 metrics redesign; #212–#219/#221 deep-review remediation; #171/#222/#220).
- Corrected the v1.11.0 lead-in from "pending merge" → "released 2026-06-03".

## README.md
- 75 → **76** monotonic constraints (off-by-one).
- Surfaced the previously-invisible **k8s/** (18 manifests — deployments, HPA, NetworkPolicies, PDBs, Ingress) and **terraform/** (AWS EKS + RDS + ElastiCache) infra in the Stack table + project layout.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)