### PR TITLE
feat(ml_engine): validation sign-off gate (warn|block|off) — recut of #174

### DIFF
--- a/backend/apps/ml_engine/services/validation_gate_mode.py
+++ b/backend/apps/ml_engine/services/validation_gate_mode.py
@@ -1,0 +1,197 @@
+"""Mode dispatcher for the pre-activation validation sign-off gate (SR 11-7).
+
+Codex adversarial review (v1.10.7) flagged that the existing fairness gate
+(PR #163) and champion-challenger promotion gate (PRs #164–#165) check
+*performance metrics* but never enforce the governance artefact:
+``ModelValidationReport`` is created by the ``validate_model`` management
+command but neither the training task nor manual activation consults it.
+
+This dispatcher closes that gap. It mirrors the warn|block|off pattern of
+``fairness_gate_mode`` and ``promotion_gate_mode`` so operators learn one
+mode pattern that applies across all three gates.
+
+Behaviour by mode:
+
+  - ``warn`` (default): gate runs, decision is returned, activation proceeds
+    even if no approved sign-off exists. Useful for the initial roll-out
+    phase where validation reports haven't been seeded yet — operators get
+    visibility without breaking the existing demo flow.
+  - ``block``: the dispatcher raises ``ValidationSignoffBlocked`` when no
+    approved/signed-off report exists for the candidate. Callers (tasks.py
+    and ``ModelActivateView``) interpret this depending on their context —
+    tasks.py demotes the freshly-created candidate to ``is_active=False``
+    rather than raising past the activation transaction; the view returns
+    HTTP 409 unless the request carries an audited ``force=true`` flag.
+  - ``off``: the gate is skipped entirely. Use only when validation reports
+    are out of band (e.g. a private offline workflow).
+
+The dispatcher is pure-functional. Settings access (``ML_VALIDATION_SIGNOFF_GATE_MODE``)
+lives in the callers so the dispatcher is unit-testable without Django ORM boot.
+
+See ``docs/superpowers/specs/2026-05-07-codex-adversarial-response-v1-10-7-design.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from apps.ml_engine.models import ModelValidationReport, ModelVersion
+
+logger = logging.getLogger(__name__)
+
+
+VALID_MODES = ("warn", "block", "off")
+DEFAULT_MODE = "warn"
+
+
+class ValidationSignoffBlocked(RuntimeError):
+    """Raised by the dispatcher in ``block`` mode when no approved
+    ModelValidationReport exists for the candidate. Carries a structured
+    payload so callers can return it to API clients.
+    """
+
+    def __init__(self, message: str, payload: dict):
+        super().__init__(message)
+        self.payload = payload
+
+
+@dataclass
+class ValidationDecision:
+    """Pure-data result of the gate check. Independent of caller context."""
+
+    result: str  # "passed" | "blocked" | "skipped"
+    reason: str  # "approved" | "no_report" | "report_not_approved" | "gate_off" | "bypass"
+    candidate_id: str | None
+    report_id: str | None
+    report_outcome: str | None
+    signed_off: bool | None
+
+    def to_dict(self) -> dict:
+        return {
+            "result": self.result,
+            "reason": self.reason,
+            "candidate_id": self.candidate_id,
+            "report_id": self.report_id,
+            "report_outcome": self.report_outcome,
+            "signed_off": self.signed_off,
+        }
+
+
+def normalize_mode(mode: str | None) -> str:
+    """Coerce arbitrary input to a valid mode; unknown values collapse to warn.
+
+    Mirrors the pattern in ``promotion_gate_mode.normalize_mode`` — a
+    misconfigured deployment never silently disables the gate.
+    """
+    if mode in VALID_MODES:
+        return mode
+    if mode is not None:
+        logger.warning(
+            "Unknown ML_VALIDATION_SIGNOFF_GATE_MODE=%r — defaulting to %r",
+            mode,
+            DEFAULT_MODE,
+        )
+    return DEFAULT_MODE
+
+
+def _check_signoff(candidate: ModelVersion) -> ValidationDecision:
+    """Return the raw gate decision for a candidate ModelVersion.
+
+    The candidate must have a saved primary key. Training-path callers that
+    haven't yet persisted the candidate should use ``check_pre_activation``
+    instead, which handles the no-PK case explicitly.
+    """
+    candidate_id = str(candidate.pk) if getattr(candidate, "pk", None) else None
+    report = (
+        ModelValidationReport.objects.filter(model_version_id=candidate.pk).order_by("-validation_date", "-id").first()
+    )
+    if report is None:
+        return ValidationDecision(
+            result="blocked",
+            reason="no_report",
+            candidate_id=candidate_id,
+            report_id=None,
+            report_outcome=None,
+            signed_off=None,
+        )
+    if not report.signed_off or report.outcome != ModelValidationReport.Outcome.APPROVED:
+        return ValidationDecision(
+            result="blocked",
+            reason="report_not_approved",
+            candidate_id=candidate_id,
+            report_id=str(report.id),
+            report_outcome=report.outcome,
+            signed_off=report.signed_off,
+        )
+    return ValidationDecision(
+        result="passed",
+        reason="approved",
+        candidate_id=candidate_id,
+        report_id=str(report.id),
+        report_outcome=report.outcome,
+        signed_off=True,
+    )
+
+
+def evaluate_validation_signoff_gate(
+    candidate: ModelVersion,
+    mode: str,
+    *,
+    bypass: bool = False,
+) -> dict:
+    """Decide whether activation should proceed given the candidate + mode.
+
+    Args:
+        candidate: The ``ModelVersion`` about to be promoted. Must already
+            have a saved primary key (training-path callers persist the row
+            before invoking this dispatcher).
+        mode: One of "warn" | "block" | "off". Unknown values are coerced
+            to "warn" via :func:`normalize_mode`.
+        bypass: Audited break-glass override (e.g. ``?force=true`` on the
+            manual activation endpoint). When true the gate is treated as
+            ``off`` for this single call and the bypass is recorded in the
+            decision payload.
+
+    Returns:
+        {
+            "action": "activate" | "skip_check",
+            "decision": ValidationDecision | None,
+            "mode": str,
+        }
+
+    Raises:
+        ValidationSignoffBlocked: in ``block`` mode when no approved
+            sign-off exists. Callers must ensure this raise happens
+            *before* the activation transaction so prior-active models
+            keep serving.
+    """
+    mode = normalize_mode(mode)
+
+    if mode == "off" or bypass:
+        decision = ValidationDecision(
+            result="skipped",
+            reason="bypass" if bypass else "gate_off",
+            candidate_id=str(candidate.pk) if getattr(candidate, "pk", None) else None,
+            report_id=None,
+            report_outcome=None,
+            signed_off=None,
+        )
+        return {
+            "action": "skip_check",
+            "decision": decision,
+            "mode": mode,
+            "bypass": bypass,
+        }
+
+    decision = _check_signoff(candidate)
+
+    if mode == "block" and decision.result == "blocked":
+        raise ValidationSignoffBlocked(
+            f"Activation blocked (mode=block): {decision.reason}. "
+            "Create or sign off a ModelValidationReport for this candidate, "
+            "or set ML_VALIDATION_SIGNOFF_GATE_MODE=warn after manual review.",
+            payload=decision.to_dict(),
+        )
+
+    return {"action": "activate", "decision": decision, "mode": mode, "bypass": False}

--- a/backend/apps/ml_engine/tasks.py
+++ b/backend/apps/ml_engine/tasks.py
@@ -66,6 +66,10 @@ def _do_train(task, algorithm, data_path, lock, *, segment=None):
     )
     from apps.ml_engine.services.segmentation import SEGMENT_UNIFIED
     from apps.ml_engine.services.trainer import ModelTrainer
+    from apps.ml_engine.services.validation_gate_mode import (
+        ValidationSignoffBlocked,
+        evaluate_validation_signoff_gate,
+    )
 
     if data_path is None:
         data_path = str(settings.BASE_DIR / ".tmp" / "synthetic_loans.csv")
@@ -163,6 +167,34 @@ def _do_train(task, algorithm, data_path, lock, *, segment=None):
             next_review_date=(timezone.now() + timedelta(days=90)).date(),
         )
 
+    # Validation sign-off gate (Codex v1.10.7 finding 2). The candidate now
+    # has a real PK so the gate can query ModelValidationReport. In `block`
+    # mode the gate raises — at training time there is by construction no
+    # approved sign-off (the row was just created), so block mode demotes
+    # the candidate to is_active=False rather than re-raising past the
+    # already-completed activation transaction. Operators then create +
+    # sign off a report and manually activate via ModelActivateView.
+    validation_mode = getattr(settings, "ML_VALIDATION_SIGNOFF_GATE_MODE", "warn")
+    validation_blocked_demoted = False
+    try:
+        validation_gate_decision = evaluate_validation_signoff_gate(mv, validation_mode)
+    except ValidationSignoffBlocked as exc:
+        logger.warning(
+            "Model %s training-path activation blocked by validation gate: %s. "
+            "Candidate retained as is_active=False; manual activation required after sign-off.",
+            mv.id,
+            exc,
+        )
+        ModelVersion.objects.filter(pk=mv.pk).update(is_active=False, traffic_percentage=0)
+        mv.refresh_from_db()
+        validation_gate_decision = {
+            "action": "blocked_demoted",
+            "decision": exc.payload,
+            "mode": "block",
+            "bypass": False,
+        }
+        validation_blocked_demoted = True
+
     # Record the gate decisions (mode + result) on the activated mv so the
     # MRM dossier §1 banner has the audit trail for both gates. In `warn`
     # mode a failed gate is logged + flagged; activation already happened.
@@ -170,7 +202,17 @@ def _do_train(task, algorithm, data_path, lock, *, segment=None):
         **(mv.training_metadata or {}),
         "fairness_gate_mode": gate_decision["mode"],
         "promotion_gate_mode": promotion_gate_decision["mode"],
+        "validation_gate_mode": validation_gate_decision["mode"],
     }
+    validation_decision_payload = validation_gate_decision.get("decision")
+    if validation_decision_payload is not None:
+        gate_meta["validation_gate"] = (
+            validation_decision_payload.to_dict()
+            if hasattr(validation_decision_payload, "to_dict")
+            else validation_decision_payload
+        )
+    if validation_blocked_demoted:
+        gate_meta["validation_gate_blocked_demoted"] = True
     gate_result = gate_decision["gate_result"]
     if gate_result is not None:
         gate_meta["fairness_gate"] = gate_result

--- a/backend/apps/ml_engine/tests/test_validation_gate_mode.py
+++ b/backend/apps/ml_engine/tests/test_validation_gate_mode.py
@@ -1,0 +1,212 @@
+"""Tests for the validation sign-off gate dispatcher (Codex v1.10.7 finding 2).
+
+Covers:
+  - Mode-matrix dispatch (warn / block / off, plus unknown collapses to warn)
+  - Decision against a real ModelVersion + ModelValidationReport pair
+  - Force bypass on the dispatcher
+  - End-to-end behaviour through ModelActivateView (?force=true and 409 on block)
+
+See docs/superpowers/specs/2026-05-07-codex-adversarial-response-v1-10-7-design.md
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from apps.accounts.models import CustomUser
+from apps.loans.models import AuditLog
+from apps.ml_engine.models import ModelValidationReport, ModelVersion
+from apps.ml_engine.services.validation_gate_mode import (
+    DEFAULT_MODE,
+    VALID_MODES,
+    ValidationDecision,
+    ValidationSignoffBlocked,
+    evaluate_validation_signoff_gate,
+    normalize_mode,
+)
+
+# ---------------------------------------------------------------------------
+# Pure-function tests for normalize_mode (no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeMode:
+    def test_passes_valid_modes_through(self):
+        for mode in VALID_MODES:
+            assert normalize_mode(mode) == mode
+
+    def test_collapses_unknown_to_warn(self, caplog):
+        with caplog.at_level("WARNING"):
+            assert normalize_mode("strict") == DEFAULT_MODE
+        assert "Unknown ML_VALIDATION_SIGNOFF_GATE_MODE" in caplog.text
+
+    def test_handles_none(self):
+        assert normalize_mode(None) == DEFAULT_MODE
+
+
+# ---------------------------------------------------------------------------
+# DB-bound dispatcher tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def models_dir(tmp_path, settings):
+    settings.ML_MODELS_DIR = str(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def model_version(db, models_dir):
+    file_path = models_dir / "v_signoff_test.joblib"
+    file_path.write_bytes(b"\0" * 64)
+    return ModelVersion.objects.create(
+        algorithm="xgb",
+        version="v_signoff_test",
+        file_path=str(file_path),
+        file_hash="b" * 64,
+        is_active=False,
+        segment=ModelVersion.SEGMENT_UNIFIED,
+        traffic_percentage=0,
+    )
+
+
+def _make_report(model_version, *, signed_off: bool, outcome: str):
+    return ModelValidationReport.objects.create(
+        model_version=model_version,
+        validator_name="Indep. Auditor",
+        validator_role="Risk Manager",
+        validation_date=dt.date.today(),
+        outcome=outcome,
+        methodology="Holdout test + AUC retention vs champion",
+        signed_off=signed_off,
+    )
+
+
+@pytest.mark.django_db
+class TestValidationGateDispatcher:
+    def test_off_mode_skips_check(self, model_version):
+        result = evaluate_validation_signoff_gate(model_version, mode="off")
+        assert result["action"] == "skip_check"
+        assert result["mode"] == "off"
+        assert isinstance(result["decision"], ValidationDecision)
+        assert result["decision"].result == "skipped"
+        assert result["decision"].reason == "gate_off"
+
+    def test_bypass_skips_check_and_records_bypass_reason(self, model_version):
+        result = evaluate_validation_signoff_gate(model_version, mode="block", bypass=True)
+        assert result["action"] == "skip_check"
+        assert result["bypass"] is True
+        assert result["decision"].reason == "bypass"
+
+    def test_no_report_blocks_in_block_mode(self, model_version):
+        with pytest.raises(ValidationSignoffBlocked) as exc_info:
+            evaluate_validation_signoff_gate(model_version, mode="block")
+        payload = exc_info.value.payload
+        assert payload["result"] == "blocked"
+        assert payload["reason"] == "no_report"
+
+    def test_no_report_warns_but_proceeds_in_warn_mode(self, model_version):
+        result = evaluate_validation_signoff_gate(model_version, mode="warn")
+        assert result["action"] == "activate"
+        assert result["decision"].result == "blocked"
+        assert result["decision"].reason == "no_report"
+
+    def test_unapproved_report_blocks_in_block_mode(self, model_version):
+        _make_report(model_version, signed_off=True, outcome=ModelValidationReport.Outcome.CONDITIONAL)
+        with pytest.raises(ValidationSignoffBlocked) as exc_info:
+            evaluate_validation_signoff_gate(model_version, mode="block")
+        assert exc_info.value.payload["reason"] == "report_not_approved"
+
+    def test_unsigned_report_blocks_in_block_mode(self, model_version):
+        _make_report(model_version, signed_off=False, outcome=ModelValidationReport.Outcome.APPROVED)
+        with pytest.raises(ValidationSignoffBlocked) as exc_info:
+            evaluate_validation_signoff_gate(model_version, mode="block")
+        assert exc_info.value.payload["reason"] == "report_not_approved"
+
+    def test_approved_signed_report_passes(self, model_version):
+        report = _make_report(model_version, signed_off=True, outcome=ModelValidationReport.Outcome.APPROVED)
+        result = evaluate_validation_signoff_gate(model_version, mode="block")
+        assert result["action"] == "activate"
+        assert result["decision"].result == "passed"
+        assert result["decision"].report_id == str(report.id)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through ModelActivateView
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def admin_user(db):
+    return CustomUser.objects.create_user(
+        username="admin_signoff",
+        email="admin_signoff@test.com",
+        password="x",
+        role="admin",
+        is_staff=True,
+    )
+
+
+@pytest.fixture
+def authed_admin_client(admin_user):
+    client = APIClient()
+    client.force_authenticate(user=admin_user)
+    return client
+
+
+@pytest.mark.django_db
+class TestModelActivateValidationGate:
+    def test_block_mode_returns_409_without_report(self, authed_admin_client, model_version):
+        with override_settings(ML_VALIDATION_SIGNOFF_GATE_MODE="block"):
+            url = reverse("model-activate", kwargs={"pk": model_version.id})
+            response = authed_admin_client.post(url)
+        assert response.status_code == 409
+        body = response.json()
+        assert body["error"] == "validation_signoff_required"
+        assert body["details"]["reason"] == "no_report"
+
+        # Verify the row was NOT activated.
+        model_version.refresh_from_db()
+        assert model_version.is_active is False
+
+    def test_force_bypass_activates_and_audits(self, authed_admin_client, model_version, admin_user):
+        with override_settings(ML_VALIDATION_SIGNOFF_GATE_MODE="block"):
+            url = reverse("model-activate", kwargs={"pk": model_version.id})
+            response = authed_admin_client.post(url + "?force=true")
+        assert response.status_code == 200, response.content
+
+        model_version.refresh_from_db()
+        assert model_version.is_active is True
+
+        log = AuditLog.objects.filter(
+            user=admin_user,
+            action="model_activate_force",
+            resource_id=str(model_version.id),
+        ).first()
+        assert log is not None
+        assert log.details["force_bypass"] is True
+        assert log.details["validation_gate_decision"]["reason"] == "bypass"
+
+    def test_warn_mode_allows_activation_without_report(self, authed_admin_client, model_version):
+        with override_settings(ML_VALIDATION_SIGNOFF_GATE_MODE="warn"):
+            url = reverse("model-activate", kwargs={"pk": model_version.id})
+            response = authed_admin_client.post(url)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["validation_gate"] == "warn"
+        model_version.refresh_from_db()
+        assert model_version.is_active is True
+
+    def test_approved_report_passes_block_mode(self, authed_admin_client, model_version):
+        _make_report(model_version, signed_off=True, outcome=ModelValidationReport.Outcome.APPROVED)
+        with override_settings(ML_VALIDATION_SIGNOFF_GATE_MODE="block"):
+            url = reverse("model-activate", kwargs={"pk": model_version.id})
+            response = authed_admin_client.post(url)
+        assert response.status_code == 200
+        model_version.refresh_from_db()
+        assert model_version.is_active is True

--- a/backend/apps/ml_engine/views.py
+++ b/backend/apps/ml_engine/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings as django_settings
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from rest_framework import status
@@ -10,6 +11,10 @@ from apps.accounts.permissions import IsAdmin, IsAdminOrOfficer
 from apps.loans.models import AuditLog
 from apps.loans.permissions import check_loan_access
 from apps.ml_engine.models import DriftReport, ModelVersion, PredictionLog
+from apps.ml_engine.services.validation_gate_mode import (
+    ValidationSignoffBlocked,
+    evaluate_validation_signoff_gate,
+)
 from apps.ml_engine.tasks import run_prediction_task, train_model_task
 
 
@@ -267,6 +272,40 @@ class ModelActivateView(APIView):
         except ModelVersion.DoesNotExist:
             return Response({"error": "Model not found"}, status=status.HTTP_404_NOT_FOUND)
 
+        # Codex v1.10.7 finding 2: validation sign-off gate. In `block` mode
+        # we refuse activation when no approved ModelValidationReport exists
+        # for this candidate, unless the caller passes ?force=true (audited
+        # break-glass). `warn` mode (default) records the decision but lets
+        # activation proceed.
+        force = request.query_params.get("force", "").lower() == "true"
+        validation_mode = getattr(django_settings, "ML_VALIDATION_SIGNOFF_GATE_MODE", "warn")
+        try:
+            validation_decision = evaluate_validation_signoff_gate(version, validation_mode, bypass=force)
+        except ValidationSignoffBlocked as exc:
+            return Response(
+                {
+                    "error": "validation_signoff_required",
+                    "details": exc.payload,
+                    "hint": (
+                        "Create + sign off a ModelValidationReport for this "
+                        "candidate, or pass ?force=true (audited override)."
+                    ),
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        # Codex adversarial review (v1.10.7) finding 1: this used to clear
+        # is_active across ALL segments before re-activating one — silently
+        # breaking scoring for every other segment until an operator repaired
+        # traffic. The training path in tasks.py:save_model already filters
+        # deactivation by segment; manual activation now mirrors that
+        # invariant. The segment-scoped filter alone preserves coverage by
+        # construction (we only deactivate models that share this segment).
+        target_segment = version.segment
+        previous_active_segments = sorted(
+            ModelVersion.objects.filter(is_active=True).values_list("segment", flat=True).distinct()
+        )
+
         with transaction.atomic():
             # Scope deactivation to THIS model's segment, matching the trainer
             # (tasks.py) and ModelVersion.clean(). A blanket deactivation would
@@ -280,10 +319,31 @@ class ModelActivateView(APIView):
             version.traffic_percentage = 100
             version.save()
 
+            audit_decision = validation_decision.get("decision")
+            audit_payload = audit_decision.to_dict() if hasattr(audit_decision, "to_dict") else audit_decision
+            AuditLog.objects.create(
+                user=request.user,
+                action="model_activate_force" if force else "model_activate",
+                resource_type="ModelVersion",
+                resource_id=str(version.id),
+                details={
+                    "version": version.version,
+                    "segment": target_segment,
+                    "previous_active_segments": previous_active_segments,
+                    "validation_gate_mode": validation_decision.get("mode"),
+                    "validation_gate_decision": audit_payload,
+                    "force_bypass": force,
+                },
+                ip_address=request.META.get("REMOTE_ADDR"),
+            )
+
         return Response(
             {
                 "message": f"Model {version.version} activated as champion (100% traffic)",
                 "model_id": str(version.id),
+                "segment": target_segment,
+                "validation_gate": validation_decision.get("mode"),
+                "force": force,
             }
         )
 

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -277,6 +277,17 @@ ML_FAIRNESS_GATE_MODE = os.environ.get("ML_FAIRNESS_GATE_MODE", "warn")
 # in scope. See docs/superpowers/specs/2026-05-07-ml-promotion-gate-mode-design.md.
 ML_PROMOTION_GATE_MODE = os.environ.get("ML_PROMOTION_GATE_MODE", "warn")
 
+# Pre-activation validation sign-off gate mode (Codex v1.10.7). Mirrors the
+# fairness/promotion gate pattern: "warn" (default — gate runs, decision is
+# recorded, activation proceeds even with no approved ModelValidationReport),
+# "block" (training-path candidates are demoted to is_active=False without
+# an approved sign-off; manual ModelActivateView returns 409 unless ?force=true
+# is provided), "off" (skip the check entirely). Defaults to "warn" so the
+# PR ships zero behaviour change for any deployment that doesn't set the env
+# var; flip to "block" once operators have established a sign-off cadence.
+# See docs/superpowers/specs/2026-05-07-codex-adversarial-response-v1-10-7-design.md.
+ML_VALIDATION_SIGNOFF_GATE_MODE = os.environ.get("ML_VALIDATION_SIGNOFF_GATE_MODE", "warn")
+
 # D7 — MRM dossier auto-generation on ModelVersion post_save.
 # Enabled by default; disable in unit tests that create throwaway models.
 MRM_DOSSIER_AUTO_GENERATE = os.environ.get("MRM_DOSSIER_AUTO_GENERATE", "true").lower() == "true"


### PR DESCRIPTION
Recut of #174 (validation sign-off gate), which was stacked on the closed/superseded #173 and carried 271 files of stale-base noise. Cherry-picked the single real commit onto fresh master and resolved the `views.py` `activate()` conflict (master's segment-safe deactivation is preserved; the gate logic is added around it).

**What it does:** mirrors the existing fairness/promotion gate pattern. On model activation, `ML_VALIDATION_SIGNOFF_GATE_MODE` (default **`warn`** — non-blocking) controls whether a candidate without an approved `ModelValidationReport` can be activated:
- `warn` (default): records the decision, activation proceeds (no behaviour change).
- `block`: returns **409** unless `?force=true` (audited break-glass).
- `off`: gate disabled.

`validation_gate_mode.py` (new, mirrors `fairness_gate_mode`/`promotion_gate_mode`), wired into the activate view + tasks; the activate `AuditLog` now records the gate mode/decision/force-bypass.

Tests: 14 gate-logic tests + 13 champion-challenger (activate endpoint) green; ruff + file-size clean. Note: #174's original edits to `test_model_activate.py` were dropped (that file was deleted on master during the segment-safe consolidation); gate logic is covered by `test_validation_gate_mode.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)