### PR TITLE
ci: finish gh-actions version sweep (upload-artifact v7, setup-python v6)

### DIFF
--- a/.github/workflows/email-parity.yml
+++ b/.github/workflows/email-parity.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - uses: actions/setup-node@v6

--- a/.github/workflows/email-preview-e2e.yml
+++ b/.github/workflows/email-preview-e2e.yml
@@ -33,14 +33,14 @@ jobs:
           npx playwright test email-preview
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: frontend/playwright-report/
           retention-days: 7
       - name: Upload Playwright results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-results
           path: frontend/test-results/

--- a/.github/workflows/smoke-e2e.yml
+++ b/.github/workflows/smoke-e2e.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload smoke result
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: smoke-result
           path: .tmp/smoke_result.json


### PR DESCRIPTION
## Summary

Master already runs `actions/upload-artifact@v7` and `actions/setup-python@v6` in the build / test / lint / security workflows. Three workflows were stragglers still on the old majors:

- `smoke-e2e.yml` — upload-artifact `v4` → `v7`
- `email-preview-e2e.yml` — upload-artifact `v4` → `v7` (×2)
- `email-parity.yml` — setup-python `v5` → `v6`

Bumping them brings every workflow to the same pinned majors that are already running green elsewhere in CI, and lets the stale dependabot PRs **#148** (setup-python 5→6) and **#149** (upload-artifact 4→7) close as superseded.

## Risk

CI-config only, no application code. The target majors are already exercised by the build/test/lint/security workflows on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)