### PR TITLE
chore(deps-dev): bump dev-dep floors to match installed/CI versions

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -6,9 +6,9 @@ pytest==9.0.3
 pytest-django==4.12.0
 pytest-cov>=5.0
 hypothesis>=6.155.2
-schemathesis>=3.36
-pre-commit>=4.0
+schemathesis>=4.21.1
+pre-commit>=4.6.0
 ruff==0.15.8  # pinned: CI runs `ruff format --check`; an unpinned floor let CI drift to a newer ruff whose formatter reflowed files, reddening Backend Lint
-pip-audit>=2.7
+pip-audit>=2.10.0
 vulture>=2.13
 mypy>=1.13


### PR DESCRIPTION
## Summary

Three dependabot dev-dependency floor bumps, consolidated into one PR. The container and CI already resolve and test against these exact versions (full backend suite green), so raising the declared floors is a no-op that just aligns `requirements-dev.txt` with reality:

| package | old floor | new floor | installed |
|---|---|---|---|
| schemathesis | `>=3.36` | `>=4.21.1` | 4.21.1 |
| pre-commit | `>=4.0` | `>=4.6.0` | 4.6.0 |
| pip-audit | `>=2.7` | `>=2.10.0` | 2.10.0 |

Supersedes **#225**, **#160**, **#156** (which will be closed once this lands).

## Risk

Dev-only dependencies; floors already satisfied by the installed/tested versions. schemathesis 4.x is a major but is already what CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)