### PR TITLE
fix: Train Model self-heal + dashboard/model-metrics polish

### DIFF
--- a/backend/apps/ml_engine/management/commands/train_model.py
+++ b/backend/apps/ml_engine/management/commands/train_model.py
@@ -33,6 +33,13 @@ class Command(BaseCommand):
 
         self.stdout.write(f"Training {algorithm.upper()} model with data from {data_path}...")
 
+        # Self-heal: parity with the Celery "Train Model" path so a fresh clone
+        # (no .tmp/synthetic_loans.csv) doesn't die with a cryptic FileNotFoundError.
+        from apps.ml_engine.tasks import _ensure_training_data
+
+        if _ensure_training_data(data_path):
+            self.stdout.write(self.style.WARNING(f"No training data at {data_path} — generated a synthetic dataset."))
+
         trainer = ModelTrainer()
         model, metrics = trainer.train(data_path, algorithm=algorithm)
 

--- a/backend/apps/ml_engine/tasks.py
+++ b/backend/apps/ml_engine/tasks.py
@@ -52,6 +52,46 @@ def train_model_task(self, algorithm="xgb", data_path=None, segment=None):
         raise
 
 
+def _ensure_training_data(data_path, num_records=None):
+    """Generate a synthetic training CSV at ``data_path`` if it is missing.
+
+    "Train Model" reads the disposable .tmp/synthetic_loans.csv, which is
+    gitignored and absent on a fresh clone or after .tmp is cleared. Rather than
+    letting the trainer die with a cryptic FileNotFoundError, self-heal by
+    generating a synthetic dataset on demand. Synthetic only — no live data or
+    network calls. Callers hold the training lock, so there is no generation
+    race. Returns True if a dataset was generated, False if one already existed.
+
+    A 0-byte file is treated as missing: a torn/interrupted write would otherwise
+    be trusted by an existence-only check and break every future run. The write
+    itself is atomic (temp file + os.replace) so a partial CSV is never visible.
+    """
+    import os
+
+    data_path = os.path.abspath(data_path)
+    if os.path.exists(data_path) and os.path.getsize(data_path) > 0:
+        return False
+
+    from apps.ml_engine.services.datagen.data_generator import DataGenerator
+
+    rows = num_records if num_records is not None else getattr(settings, "ML_AUTO_SEED_ROWS", 20000)
+    logger.warning(
+        "Training data %s not found — auto-generating %d synthetic rows (self-heal)",
+        data_path,
+        rows,
+    )
+    generator = DataGenerator()
+    df = generator.generate(num_records=rows)
+    # Atomic publish: write to a temp file in the same directory, then replace,
+    # so an interrupted write never leaves a partial CSV the existence check
+    # above would wrongly trust on the next run.
+    tmp_path = f"{data_path}.tmp.{os.getpid()}"
+    generator.save_to_csv(df, tmp_path)
+    os.replace(tmp_path, data_path)
+    logger.info("Auto-generated training dataset: %d rows -> %s", len(df), data_path)
+    return True
+
+
 def _do_train(task, algorithm, data_path, lock, *, segment=None):
     """Inner training logic — called with lock held."""
     from types import SimpleNamespace
@@ -73,6 +113,10 @@ def _do_train(task, algorithm, data_path, lock, *, segment=None):
 
     if data_path is None:
         data_path = str(settings.BASE_DIR / ".tmp" / "synthetic_loans.csv")
+
+    # Self-heal: a fresh clone or cleared .tmp has no training CSV. Generate one
+    # rather than failing the run with a cryptic FileNotFoundError.
+    _ensure_training_data(data_path)
 
     segment = segment or SEGMENT_UNIFIED
     trainer = ModelTrainer()

--- a/backend/apps/ml_engine/tests/test_train_data_autoseed.py
+++ b/backend/apps/ml_engine/tests/test_train_data_autoseed.py
@@ -1,0 +1,116 @@
+"""Tests for the training-data self-heal guard in ml_engine.tasks.
+
+"Train Model" reads the disposable .tmp/synthetic_loans.csv. That file is
+gitignored and absent on a fresh clone or after .tmp is cleared, which used to
+make training die with a cryptic FileNotFoundError deep in the trainer. The
+guard auto-generates a synthetic dataset on demand instead.
+
+The sync `train_model` management command also self-heals; the segment training
+path shares `_do_train`, so the wiring test pins that the guard runs before the
+trainer regardless of caller.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+import apps.ml_engine.tasks as tasks_mod
+from apps.ml_engine.tasks import _ensure_training_data
+
+_FAKE_DF = pd.DataFrame({"approved": [0, 1] * 10})
+
+
+def test_generates_synthetic_csv_when_missing(tmp_path):
+    target = tmp_path / "seed" / "synthetic_loans.csv"
+    assert not target.exists()
+
+    generated = _ensure_training_data(str(target), num_records=200)
+
+    assert generated is True
+    assert target.exists()
+    df = pd.read_csv(target)
+    # Must be a TRAINABLE dataset, not just a non-empty file: the trainer needs
+    # >=20 rows and >=5 samples in each class of the `approved` label.
+    assert len(df) == 200
+    assert "approved" in df.columns
+    assert df["approved"].nunique() == 2
+    assert df["approved"].value_counts().min() >= 5
+
+
+def test_noop_when_csv_already_present(tmp_path):
+    target = tmp_path / "synthetic_loans.csv"
+    target.write_text("sentinel,row\n1,2\n")
+
+    generated = _ensure_training_data(str(target), num_records=100)
+
+    assert generated is False
+    # Existing data must never be overwritten.
+    assert target.read_text() == "sentinel,row\n1,2\n"
+
+
+def test_zero_byte_csv_is_treated_as_missing(tmp_path, monkeypatch):
+    # A torn/interrupted write can leave a 0-byte file. os.path.exists() returns
+    # True for it, so an existence-only check would trust it forever and break
+    # every future run. The guard must regenerate instead.
+    target = tmp_path / "synthetic_loans.csv"
+    target.write_bytes(b"")
+    monkeypatch.setattr(
+        "apps.ml_engine.services.datagen.data_generator.DataGenerator.generate",
+        lambda self, num_records=50000, **k: _FAKE_DF.copy(),
+    )
+
+    generated = _ensure_training_data(str(target), num_records=20)
+
+    assert generated is True
+    df = pd.read_csv(target)
+    assert len(df) > 0
+
+
+def test_uses_setting_default_when_num_records_omitted(tmp_path, settings, monkeypatch):
+    # The wired path calls _ensure_training_data(data_path) with no num_records,
+    # so ML_AUTO_SEED_ROWS must flow through to the generator.
+    settings.ML_AUTO_SEED_ROWS = 7
+    captured = {}
+
+    def fake_generate(self, num_records=50000, **kwargs):
+        captured["n"] = num_records
+        return _FAKE_DF.copy()
+
+    monkeypatch.setattr(
+        "apps.ml_engine.services.datagen.data_generator.DataGenerator.generate",
+        fake_generate,
+    )
+
+    _ensure_training_data(str(tmp_path / "synthetic_loans.csv"))
+
+    assert captured["n"] == 7
+
+
+def test_do_train_self_heals_before_training(settings, monkeypatch):
+    # Regression guard for the core contract: _do_train must call the self-heal
+    # with the default BASE_DIR path BEFORE invoking the trainer. A refactor that
+    # drops or reorders the guard must turn this test red.
+    calls = []
+    monkeypatch.setattr(
+        tasks_mod, "_ensure_training_data", lambda p, *a, **k: calls.append(("ensure", p)) or False
+    )
+
+    class _Boom(Exception):
+        pass
+
+    def _boom_train(self, *a, **k):
+        calls.append(("train",))
+        raise _Boom()
+
+    monkeypatch.setattr(
+        "apps.ml_engine.services.training.trainer.ModelTrainer.train", _boom_train
+    )
+
+    with pytest.raises(_Boom):
+        tasks_mod._do_train(None, "xgb", None, MagicMock())
+
+    assert calls[0] == ("ensure", str(settings.BASE_DIR / ".tmp" / "synthetic_loans.csv"))
+    assert calls[1] == ("train",)

--- a/backend/apps/ml_engine/tests/test_train_data_autoseed.py
+++ b/backend/apps/ml_engine/tests/test_train_data_autoseed.py
@@ -94,9 +94,7 @@ def test_do_train_self_heals_before_training(settings, monkeypatch):
     # with the default BASE_DIR path BEFORE invoking the trainer. A refactor that
     # drops or reorders the guard must turn this test red.
     calls = []
-    monkeypatch.setattr(
-        tasks_mod, "_ensure_training_data", lambda p, *a, **k: calls.append(("ensure", p)) or False
-    )
+    monkeypatch.setattr(tasks_mod, "_ensure_training_data", lambda p, *a, **k: calls.append(("ensure", p)) or False)
 
     class _Boom(Exception):
         pass
@@ -105,9 +103,7 @@ def test_do_train_self_heals_before_training(settings, monkeypatch):
         calls.append(("train",))
         raise _Boom()
 
-    monkeypatch.setattr(
-        "apps.ml_engine.services.training.trainer.ModelTrainer.train", _boom_train
-    )
+    monkeypatch.setattr("apps.ml_engine.services.training.trainer.ModelTrainer.train", _boom_train)
 
     with pytest.raises(_Boom):
         tasks_mod._do_train(None, "xgb", None, MagicMock())

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -245,6 +245,10 @@ ML_MAX_BIN = 256
 ML_OPTUNA_TRIALS = 30
 # Threads per XGBoost training. Matches the celery_worker_ml CPU quota.
 ML_XGB_N_JOBS = 2
+# Rows the training task auto-generates when .tmp/synthetic_loans.csv is missing
+# (fresh clone / cleared .tmp). Smaller than the 50k canonical seed so the
+# self-heal stays fast while still producing a usable model. Env-overridable.
+ML_AUTO_SEED_ROWS = int(os.environ.get("ML_AUTO_SEED_ROWS", "20000"))
 
 # Hard credit policy overlay (D3). Modes: "off" (not applied), "shadow"
 # (evaluated + logged, model verdict stands), "enforce" (hard-fails override

--- a/backend/tests/test_celery_integration.py
+++ b/backend/tests/test_celery_integration.py
@@ -96,16 +96,31 @@ class TestCeleryTaskExecution:
 
     def test_train_model_task_serializes_kwargs(self):
         """Verify train_model_task kwargs (algorithm, data_path) serialize."""
+        from unittest.mock import MagicMock, patch
+
         from apps.ml_engine.tasks import train_model_task
 
-        # apply() exercises full serialization; the task will fail inside
-        # trainer logic (missing csv) — we're testing the transport layer.
-        result = train_model_task.apply(
-            kwargs={
-                "algorithm": "xgb",
-                "data_path": "/tmp/nonexistent.csv",
-            }
-        )
+        # apply() exercises full serialization; the task will fail inside trainer
+        # logic (missing csv) — we're testing the transport layer. Make the body
+        # deterministic regardless of environment:
+        #  - mock the Redis train lock so a real concurrent training run can't
+        #    short-circuit the task to "skipped" (lock contention),
+        #  - no-op the self-heal guard so the missing path stays missing and the
+        #    trainer raises on read instead of generating 20k rows + a real train.
+        fake_lock = MagicMock()
+        fake_lock.acquire.return_value = True
+        fake_redis = MagicMock()
+        fake_redis.lock.return_value = fake_lock
+        with (
+            patch("redis.from_url", return_value=fake_redis),
+            patch("apps.ml_engine.tasks._ensure_training_data", return_value=False),
+        ):
+            result = train_model_task.apply(
+                kwargs={
+                    "algorithm": "xgb",
+                    "data_path": "/tmp/nonexistent.csv",
+                }
+            )
 
         assert result.failed(), "Task must actually execute (not just be constructed)"
         assert isinstance(result.result, Exception), (

--- a/frontend/src/__tests__/components/RecentApplications.test.tsx
+++ b/frontend/src/__tests__/components/RecentApplications.test.tsx
@@ -33,11 +33,12 @@ describe('RecentApplications', () => {
     expect(screen.getByText(/Bob/)).toBeInTheDocument()
   })
 
-  it('makes each row navigate to the application detail page', () => {
+  it('no longer renders an Open link to the application detail page', () => {
     render(<RecentApplications applications={[mockApp('a1', 'Alice')]} />)
-    // The row should expose a link to /dashboard/applications/{id}
-    const rowLink = screen.getByRole('link', { name: /open application a1/i })
-    expect(rowLink).toHaveAttribute('href', '/dashboard/applications/a1')
+    // The "Open →" link was removed; no row should link to the detail route.
+    expect(screen.queryByRole('link', { name: /open application/i })).not.toBeInTheDocument()
+    const links = screen.getAllByRole('link')
+    expect(links.every((l) => !l.getAttribute('href')?.startsWith('/dashboard/applications/'))).toBe(true)
   })
 
   it('still links applicant name to customer profile (existing behaviour)', () => {

--- a/frontend/src/__tests__/components/metrics/FairnessCard.test.tsx
+++ b/frontend/src/__tests__/components/metrics/FairnessCard.test.tsx
@@ -24,10 +24,17 @@ const metricsWithSmallGroup = {
 }
 
 describe('FairnessCard', () => {
-  it('renders the per-attribute card with a PASS badge', () => {
+  it('renders the per-attribute card with its Equalized Odds figure', () => {
     render(<FairnessCard fairnessMetrics={metricsWithSmallGroup} />)
     expect(screen.getByText('Fairness: State')).toBeInTheDocument()
-    expect(screen.getByText(/DI: 0\.970 PASS/)).toBeInTheDocument()
+    expect(screen.getByText(/Equalized Odds Diff: 0\.0200/)).toBeInTheDocument()
+  })
+
+  it('does not render a PASS/FAIL disparate-impact badge', () => {
+    render(<FairnessCard fairnessMetrics={metricsWithSmallGroup} />)
+    expect(screen.queryByText(/\bPASS\b/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/\bFAIL\b/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/DI:/)).not.toBeInTheDocument()
   })
 
   it('notes small groups excluded from the ratio, with the threshold', () => {
@@ -52,7 +59,7 @@ describe('FairnessCard', () => {
     expect(screen.queryByText(/excluded from the/i)).not.toBeInTheDocument()
   })
 
-  it('shows "Not assessable" instead of a green PASS when the ratio is null', () => {
+  it('hides the Equalized Odds figure (shows "—") when the ratio is null', () => {
     // Backend emits null DI / null pass when fewer than two groups are assessable.
     const notAssessable = {
       state: {
@@ -68,10 +75,9 @@ describe('FairnessCard', () => {
       },
     }
     render(<FairnessCard fairnessMetrics={notAssessable} />)
-    expect(screen.getByText(/Not assessable/i)).toBeInTheDocument()
-    // Must NOT coerce an un-measurable result into a clean pass.
-    expect(screen.queryByText(/PASS/)).not.toBeInTheDocument()
-    expect(screen.queryByText(/DI: 1\.000/)).not.toBeInTheDocument()
+    // Must NOT coerce an un-measurable result into a clean 0.0000.
+    expect(screen.getByText(/Equalized Odds Diff: —/)).toBeInTheDocument()
+    expect(screen.queryByText(/\bPASS\b/)).not.toBeInTheDocument()
   })
 
   it('renders nothing when there are no fairness metrics', () => {

--- a/frontend/src/components/dashboard/RecentApplications.tsx
+++ b/frontend/src/components/dashboard/RecentApplications.tsx
@@ -25,7 +25,6 @@ export function RecentApplications({ applications }: RecentApplicationsProps) {
               <TableHead>Amount</TableHead>
               <TableHead>Status</TableHead>
               <TableHead>Date</TableHead>
-              <TableHead className="sr-only">Open</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -46,21 +45,12 @@ export function RecentApplications({ applications }: RecentApplicationsProps) {
                     <Badge className={s.color} variant="outline">{s.label}</Badge>
                   </TableCell>
                   <TableCell className="text-muted-foreground">{formatDate(app.created_at)}</TableCell>
-                  <TableCell className="text-right">
-                    <Link
-                      href={`/dashboard/applications/${app.id}`}
-                      aria-label={`Open application ${app.id}`}
-                      className="text-xs text-blue-600 hover:underline"
-                    >
-                      Open →
-                    </Link>
-                  </TableCell>
                 </TableRow>
               )
             })}
             {applications.length === 0 && (
               <TableRow>
-                <TableCell colSpan={5} className="text-center text-muted-foreground">
+                <TableCell colSpan={4} className="text-center text-muted-foreground">
                   No applications yet
                 </TableCell>
               </TableRow>

--- a/frontend/src/components/metrics/FairnessCard.tsx
+++ b/frontend/src/components/metrics/FairnessCard.tsx
@@ -2,7 +2,6 @@
 
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend, Label } from 'recharts'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
 import { useChartHover, ChartHoverPanel, renderEmptyTooltip } from './ChartHoverPanel'
 
 interface FairnessCardProps {
@@ -29,13 +28,11 @@ function FairnessAttributeCard({ attribute, data }: { attribute: string; data: a
   const groups = data.groups as Record<string, GroupStats>
   // The backend emits disparate_impact_ratio / passes_80_percent_rule as null when
   // fewer than two groups are large enough to assess (or there are no approvals at
-  // all). Surface that as "Not assessable" rather than coercing it to a green
-  // DI 1.000 PASS — an un-measurable fairness result must never read as a clean pass
-  // on a regulated lending dashboard.
+  // all). When that's the case we hide the Equalized Odds figure rather than show a
+  // coerced 0.0000 — an un-measurable fairness result must never read as a clean
+  // pass on a regulated lending dashboard.
   const assessable: boolean =
     typeof data.disparate_impact_ratio === 'number' && typeof data.passes_80_percent_rule === 'boolean'
-  const disparateImpact: number | null = assessable ? data.disparate_impact_ratio : null
-  const passes80: boolean = data.passes_80_percent_rule === true
   const eqOddsDiff: number | null =
     assessable && typeof data.equalized_odds_difference === 'number' ? data.equalized_odds_difference : null
   const minGroupSize: number = data.min_group_size ?? 30
@@ -55,25 +52,10 @@ function FairnessAttributeCard({ attribute, data }: { attribute: string; data: a
   return (
     <Card>
       <CardHeader className="pb-4">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <CardTitle className="text-base">Fairness: {label}</CardTitle>
-            <CardDescription className="mt-1.5">
-              Equalized Odds Diff: {eqOddsDiff !== null ? eqOddsDiff.toFixed(4) : '—'}
-            </CardDescription>
-          </div>
-          <Badge
-            className={`shrink-0 ${!assessable
-              ? 'bg-gray-100 text-gray-700 border-gray-200'
-              : passes80
-                ? 'bg-green-100 text-green-800 border-green-200'
-                : 'bg-red-100 text-red-800 border-red-200'
-            }`}
-            variant="outline"
-          >
-            {assessable ? `DI: ${disparateImpact!.toFixed(3)} ${passes80 ? 'PASS' : 'FAIL'}` : 'DI: — Not assessable'}
-          </Badge>
-        </div>
+        <CardTitle className="text-base">Fairness: {label}</CardTitle>
+        <CardDescription className="mt-1.5">
+          Equalized Odds Diff: {eqOddsDiff !== null ? eqOddsDiff.toFixed(4) : '—'}
+        </CardDescription>
       </CardHeader>
       <CardContent>
         <ResponsiveContainer width="100%" height={320}>


### PR DESCRIPTION
Three independent, atomic fixes from one session.

## 1. `fix(ml_engine)` — Train Model self-heal (main fix)
"Train Model" read the disposable `.tmp/synthetic_loans.csv` and died with a cryptic `FileNotFoundError` when it was absent (fresh clone / cleared `.tmp`).

- New `_ensure_training_data()` generates a synthetic dataset on demand (`ML_AUTO_SEED_ROWS`, env-overridable, default 20000).
- **Atomic write** (temp file + `os.replace`) and a 0-byte-treated-as-missing check, so an interrupted write can't leave a poison file that breaks every future run.
- Wired into `_do_train` (Celery/button path) **and** the `train_model` management command (the most likely fresh-clone failure point).

> Note: the original production failure was operational — the celery worker fleet was running pre-`governance/`-decomp (#198) code in memory and threw `ModuleNotFoundError`. That was fixed by restarting the workers (no code change). This PR adds the durable guard so the button is robust to a missing dataset going forward.

## 2. `fix(model-metrics)` — remove DI PASS/FAIL badge
Drops the top-right disparate-impact PASS/FAIL/Not-assessable badge on each fairness chart. The `assessable` check still gates the Equalized Odds figure (shows `—`, never a coerced `0.0000` when unmeasurable).

## 3. `fix(dashboard)` — remove redundant Open link
The applicant name already links to the customer profile; the separate `Open →` column was redundant. Removed (header, cell, empty-state colspan).

## Verification
- Full backend suite: **2061 passed, 33 skipped**.
- Affected frontend tests: **10 passed** (RecentApplications + FairnessCard, both updated).
- New `test_train_data_autoseed.py` (5 tests incl. 0-byte + `_do_train` wiring guard); fixed `test_celery_integration` whose "missing csv ⇒ fail" premise no longer holds under the guard (mocks the redis lock + guard for determinism).
- Live integration: deleted the CSV, triggered a real train — logged `self-heal → auto-generating 20000 rows`, trained successfully (AUC 0.8637).
- An adversarial multi-lens review caught two issues before merge: a CI-breaking test and the non-atomic poison-file trap — both fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)