### PR TITLE
fix(ml_engine): collapse three mismatched decision thresholds into one operating point (review #1/#4)

### DIFF
--- a/backend/apps/ml_engine/management/commands/train_model.py
+++ b/backend/apps/ml_engine/management/commands/train_model.py
@@ -74,7 +74,10 @@ class Command(BaseCommand):
             ks_statistic=metrics.get("ks_statistic"),
             log_loss_value=metrics.get("log_loss"),
             ece=metrics.get("calibration_data", {}).get("ece"),
-            optimal_threshold=metrics.get("threshold_analysis", {}).get("youden_j_threshold"),
+            # Persist the SAME operating threshold the per-group fairness search
+            # is anchored to (cost-optimal), so the disparate-impact guarantee
+            # holds at serving and the reported metrics match deployment.
+            optimal_threshold=metrics.get("optimal_threshold"),
             confusion_matrix=metrics["confusion_matrix"],
             feature_importances=metrics["feature_importances"],
             roc_curve_data=metrics["roc_curve"],
@@ -101,7 +104,7 @@ class Command(BaseCommand):
                 f"  KS Stat:   {metrics.get('ks_statistic', 'N/A')}\n"
                 f"  Brier:     {metrics.get('brier_score', 'N/A')}\n"
                 f"  ECE:       {metrics.get('calibration_data', {}).get('ece', 'N/A')}\n"
-                f"  Threshold: {metrics.get('threshold_analysis', {}).get('youden_j_threshold', 'N/A')}\n"
+                f"  Threshold: {metrics.get('optimal_threshold', 'N/A')}\n"
                 f"  Saved to:  {model_path}"
             )
         )

--- a/backend/apps/ml_engine/services/training/trainer.py
+++ b/backend/apps/ml_engine/services/training/trainer.py
@@ -940,12 +940,17 @@ class ModelTrainer:
         y_val_prob = model.predict_proba(X_val)[:, 1]
         self._conformal_scores = np.sort(np.abs(y_val_prob - y_val.values))
 
-        # Evaluate on test set only (val was used for calibration and early stopping)
-        y_pred = model.predict(X_test)
+        # Evaluate on the test set at the OPERATING threshold the system deploys
+        # (the cost-optimal threshold the per-group fairness search is anchored
+        # to), NOT the model's 0.5 cutoff — which would describe a classifier the
+        # serving path never runs. AUC/Gini/KS/Brier/ECE are threshold-independent.
         y_prob = model.predict_proba(X_test)[:, 1]
+        y_pred = (y_prob >= optimal_threshold).astype(int)
 
         metrics = self.metrics_service.compute_metrics(y_test, y_pred, y_prob)
         metrics["confusion_matrix"] = self.metrics_service.confusion_matrix_data(y_test, y_pred)
+        # Tag the threshold these metrics were computed at (honest dashboard label).
+        metrics["classification_threshold"] = round(float(optimal_threshold), 4)
         metrics["roc_curve"] = self.metrics_service.roc_curve_data(y_test, y_prob)
         metrics["feature_importances"] = self.metrics_service.feature_importance_data(model, feature_cols)
         metrics["training_params"] = best_params

--- a/backend/apps/ml_engine/tasks.py
+++ b/backend/apps/ml_engine/tasks.py
@@ -190,7 +190,10 @@ def _do_train(task, algorithm, data_path, lock, *, segment=None):
             ks_statistic=metrics.get("ks_statistic"),
             log_loss_value=metrics.get("log_loss"),
             ece=metrics.get("calibration_data", {}).get("ece"),
-            optimal_threshold=metrics.get("threshold_analysis", {}).get("youden_j_threshold"),
+            # Persist the SAME operating threshold the per-group fairness search
+            # is anchored to (cost-optimal), so the disparate-impact guarantee
+            # holds at serving and the reported metrics match deployment.
+            optimal_threshold=metrics.get("optimal_threshold"),
             confusion_matrix=metrics["confusion_matrix"],
             feature_importances=metrics["feature_importances"],
             roc_curve_data=metrics["roc_curve"],

--- a/backend/apps/ml_engine/tests/test_threshold_coherence.py
+++ b/backend/apps/ml_engine/tests/test_threshold_coherence.py
@@ -1,0 +1,109 @@
+"""Regression guards for the operating-threshold coherence fix (review finding #1/#4).
+
+Three different operating thresholds used to be in play:
+  1. The per-group fairness thresholds were anchored to the *cost-optimal*
+     threshold (validation set) — trainer.py group-threshold search.
+  2. The value persisted as ``ModelVersion.optimal_threshold`` was the
+     *Youden's J* threshold (test set) — train_model.py / tasks.py.
+  3. The reported confusion matrix / precision / recall / F1 / fairness DI were
+     computed at the model's internal *0.5* cutoff (``model.predict``).
+
+At serving the base threshold was Youden's J but per-group decisions used the
+cost-optimal-anchored group thresholds, so the disparate-impact guarantee the
+trainer computed did NOT hold at inference, and the displayed metrics described
+a classifier the system never runs.
+
+The fix collapses these to ONE operating point: the cost-optimal threshold the
+group search is anchored to (``metrics["optimal_threshold"]``). It is persisted
+as the base, and the headline classification + fairness metrics are reported at
+it. These tests pin that coherence on both persistence paths (sync management
+command and Celery task) and the reporting contract.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+from django.core.management import call_command
+
+from apps.ml_engine.models import ModelVersion
+from apps.ml_engine.services.datagen.data_generator import DataGenerator
+
+
+@pytest.fixture
+def small_csv(tmp_path):
+    """A small but trainable synthetic dataset written to a temp CSV."""
+    gen = DataGenerator()
+    df = gen.generate(num_records=500, random_seed=99)
+    path = tmp_path / "loans.csv"
+    df.to_csv(path, index=False)
+    return str(path)
+
+
+def _assert_threshold_coherent(mv: ModelVersion) -> None:
+    """The persisted base threshold must equal the cost-optimal anchor the
+    per-group fairness search used, and every group threshold must be that
+    anchor or a downward adjustment from it."""
+    assert mv.optimal_threshold is not None, "optimal_threshold must be persisted"
+    anchor = mv.training_metadata["optimal_threshold"]
+    assert mv.optimal_threshold == anchor, (
+        f"persisted optimal_threshold ({mv.optimal_threshold}) must equal the "
+        f"group-threshold anchor ({anchor}); a mismatch means the disparate-impact "
+        f"guarantee does not hold at serving time"
+    )
+    group_thresholds = mv.training_metadata.get("group_thresholds", {})
+    for group, threshold in group_thresholds.items():
+        assert threshold <= mv.optimal_threshold + 1e-9, (
+            f"group '{group}' threshold {threshold} exceeds the base anchor "
+            f"{mv.optimal_threshold} — the fairness search only walks the "
+            f"threshold DOWN from the anchor, never up"
+        )
+
+
+@pytest.mark.django_db
+def test_command_persists_threshold_anchored_to_group_search(small_csv):
+    call_command("train_model", algorithm="rf", data_path=small_csv)
+    mv = ModelVersion.objects.filter(is_active=True).order_by("-id").first()
+    assert mv is not None
+    try:
+        _assert_threshold_coherent(mv)
+    finally:
+        if mv.file_path and os.path.exists(mv.file_path):
+            os.unlink(mv.file_path)
+
+
+@pytest.mark.django_db
+def test_celery_task_persists_threshold_anchored_to_group_search(small_csv):
+    from apps.ml_engine.tasks import _do_train
+
+    # _do_train takes (task, algorithm, data_path, lock, *, segment); the task
+    # and lock are only touched by the outer wrapper, so plain mocks suffice and
+    # we avoid standing up redis. Fairness/promotion gates default to "warn"
+    # (non-blocking), so a small rf model trains and activates cleanly.
+    _do_train(MagicMock(), "rf", small_csv, MagicMock())
+    mv = ModelVersion.objects.filter(is_active=True).order_by("-id").first()
+    assert mv is not None
+    try:
+        _assert_threshold_coherent(mv)
+    finally:
+        if mv.file_path and os.path.exists(mv.file_path):
+            os.unlink(mv.file_path)
+
+
+@pytest.mark.django_db
+def test_reported_metrics_declare_their_operating_threshold(small_csv):
+    """#4: the confusion matrix / precision / recall / F1 must be computed at
+    the operating threshold the system deploys, not the model's 0.5 cutoff. The
+    trainer tags the reported metrics with ``classification_threshold`` so the
+    dashboard can label them honestly; it must equal the operating threshold."""
+    from apps.ml_engine.services.training.trainer import ModelTrainer
+
+    _model, metrics = ModelTrainer().train(small_csv, algorithm="rf", use_reject_inference=False)
+    assert "classification_threshold" in metrics, (
+        "reported classification metrics must declare the threshold they were computed at"
+    )
+    assert metrics["classification_threshold"] == metrics["optimal_threshold"], (
+        "confusion matrix / P / R / F1 must be reported at the operating threshold, not 0.5"
+    )

--- a/frontend/src/__tests__/components/metrics/ConfusionMatrix.test.tsx
+++ b/frontend/src/__tests__/components/metrics/ConfusionMatrix.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { ConfusionMatrix } from '@/components/metrics/ConfusionMatrix'
+
+describe('ConfusionMatrix', () => {
+  const matrix = { tp: 80, fp: 20, tn: 850, fn: 50 }
+
+  it('renders the four cell counts and the sample total', () => {
+    render(<ConfusionMatrix matrix={matrix} />)
+    expect(screen.getByText('80')).toBeInTheDocument()
+    expect(screen.getByText(/Total: 1000 samples/)).toBeInTheDocument()
+  })
+
+  it('labels the operating threshold the counts were computed at', () => {
+    // Honesty: a confusion matrix with no threshold reads as a 0.5 classifier.
+    render(<ConfusionMatrix matrix={matrix} threshold={0.55} />)
+    expect(screen.getByText(/at operating threshold 0\.55/)).toBeInTheDocument()
+  })
+
+  it('omits the threshold label when none is provided', () => {
+    render(<ConfusionMatrix matrix={matrix} />)
+    expect(screen.queryByText(/operating threshold/)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/metrics/ConfusionMatrix.tsx
+++ b/frontend/src/components/metrics/ConfusionMatrix.tsx
@@ -7,9 +7,12 @@ interface ConfusionMatrixProps {
     tp?: number; fp?: number; tn?: number; fn?: number;
     true_positives?: number; false_positives?: number; true_negatives?: number; false_negatives?: number;
   }
+  /** The operating threshold these counts were computed at. Surfaced so the
+   *  matrix is never mistaken for a 0.5-cutoff classifier the system never runs. */
+  threshold?: number | null
 }
 
-export function ConfusionMatrix({ matrix: raw }: ConfusionMatrixProps) {
+export function ConfusionMatrix({ matrix: raw, threshold }: ConfusionMatrixProps) {
   const matrix = {
     tp: raw.tp ?? raw.true_positives ?? 0,
     fp: raw.fp ?? raw.false_positives ?? 0,
@@ -74,6 +77,9 @@ export function ConfusionMatrix({ matrix: raw }: ConfusionMatrixProps) {
           </div>
           <p className="text-center text-xs text-muted-foreground mt-2">
             Total: {total} samples
+            {typeof threshold === 'number' && (
+              <> · at operating threshold {threshold.toFixed(2)}</>
+            )}
           </p>
         </div>
       </CardContent>

--- a/frontend/src/components/metrics/tabs/PerformanceTab.tsx
+++ b/frontend/src/components/metrics/tabs/PerformanceTab.tsx
@@ -14,7 +14,7 @@ export function PerformanceTab({ metrics }: { metrics: ModelMetrics }) {
   return (
     <div className="space-y-6">
       <div className="grid gap-6 md:grid-cols-2">
-        {hasConfusion && <ConfusionMatrix matrix={metrics.confusion_matrix} />}
+        {hasConfusion && <ConfusionMatrix matrix={metrics.confusion_matrix} threshold={metrics.optimal_threshold} />}
         {hasRoc && <ROCCurve fpr={metrics.roc_curve_data.fpr!} tpr={metrics.roc_curve_data.tpr!} auc={metrics.auc_roc ?? 0} />}
       </div>
       {hasFeatures && <FeatureImportance features={features} />}

--- a/tools/file_size_allowlist.json
+++ b/tools/file_size_allowlist.json
@@ -6,7 +6,7 @@
       "files": {
         "datagen/data_generator.py": 1490,
         "datagen/underwriting_engine.py": 974,
-        "training/trainer.py": 1399,
+        "training/trainer.py": 1405,
         "governance/calibration_validator.py": 536,
         "metrics/compute.py": 1050,
         "metrics/real_world_benchmarks.py": 1378,


### PR DESCRIPTION
**PR 1 of 3** from the multi-dimension codebase review (metric-honesty batch).

## Problem (review finding #1 HIGH + #4 MED)
Three different operating thresholds were in play and mismatched:
1. **Per-group fairness thresholds** were anchored to the **cost-optimal** threshold (val set) — `trainer.py` group-threshold search (the EEOC 80%-rule enforcement).
2. The value **persisted** as `ModelVersion.optimal_threshold` was the **Youden's-J** threshold (test set) — `train_model.py` / `tasks.py`.
3. The reported **confusion matrix / precision / recall / F1 / fairness DI** were computed at the model's internal **0.5** cutoff (`model.predict`).

At serving (`decision_assembly.py`) the base was Youden's-J but per-group decisions used the cost-optimal-anchored group thresholds — so **the disparate-impact guarantee the trainer computed did not hold at inference**, and the displayed classification metrics described a classifier the system never runs. (Verified numerically: persisted `0.44` vs group anchor `0.55` on a fresh train.)

## Fix
- Persist the **same** operating threshold the group search is anchored to (`metrics["optimal_threshold"]`, the cost-optimal point) in **both** the management command and the Celery task.
- Evaluate test-set predictions at that operating threshold instead of 0.5 — this also corrects the displayed **fairness DI**, which used the same `y_pred`.
- Tag the reported metrics with `classification_threshold` and surface it as an honest **"at operating threshold X"** label on the `ConfusionMatrix`.
- `AUC / Gini / KS / Brier / ECE` are threshold-independent and unchanged.

## Behavioural impact
- Coherent at serving: base threshold == group-threshold anchor == reported-metrics threshold.
- Confusion matrix / P / R / F1 / approval-rate numbers will differ from the old 0.5 figures (now honest to deployment). **Takes effect on the next retrain** — existing `ModelVersion` rows keep their stored values until retrained.

## Tests
- New `test_threshold_coherence.py`: pins persisted base == group anchor on **both** the command and Celery-task paths, every per-group threshold ≤ the anchor, and that reported metrics declare their operating threshold. RED before this change, GREEN after.
- `ConfusionMatrix.test.tsx`: covers the new label.
- Full ml_engine + trainer/predictor/contract blast radius: **505 passed**. Affected frontend: **11 passed**. ruff + file-size + tsc + eslint clean.
- `trainer.py` file-size cap 1399→1405 for the honesty instrumentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)