### PR TITLE
fix: correctness + safety batch from codebase review (#2/#3/#6 + 2 gaps)

### DIFF
--- a/backend/apps/accounts/serializers.py
+++ b/backend/apps/accounts/serializers.py
@@ -89,6 +89,17 @@ class RegisterSerializer(NameValidationMixin, serializers.ModelSerializer):
             raise serializers.ValidationError({"password": "Password must contain at least one digit."})
         return data
 
+    def validate_email(self, value):
+        # Email is a login identifier (LoginSerializer resolves an "@"-style
+        # login to a username via CustomUser.objects.get(email=...)). CustomUser
+        # inherits AbstractUser's non-unique email, so without this check a second
+        # registration could reuse a victim's email and break their email login
+        # with an unhandled MultipleObjectsReturned (500 / account DoS). Enforce
+        # case-insensitive uniqueness for non-empty emails.
+        if value and CustomUser.objects.filter(email__iexact=value).exists():
+            raise serializers.ValidationError("An account with this email already exists.")
+        return value
+
     def create(self, validated_data):
         validated_data.pop("password2")
         password = validated_data.pop("password")
@@ -111,6 +122,13 @@ class LoginSerializer(serializers.Serializer):
                 username_or_email = user_obj.username
             except CustomUser.DoesNotExist as err:
                 raise serializers.ValidationError("Invalid credentials.") from err
+            except CustomUser.MultipleObjectsReturned:
+                # Legacy duplicate emails (predating the registration-time
+                # uniqueness check) must never 500. Resolve to the ORIGINAL owner
+                # (oldest account) so the victim can still log in by email; a
+                # wrong password still fails authenticate() below.
+                user_obj = CustomUser.objects.filter(email=username_or_email).order_by("id").first()
+                username_or_email = user_obj.username
         user = authenticate(username=username_or_email, password=data["password"])
         if not user:
             raise serializers.ValidationError("Invalid credentials.")

--- a/backend/apps/accounts/tests/test_auth_hardening.py
+++ b/backend/apps/accounts/tests/test_auth_hardening.py
@@ -1,0 +1,71 @@
+"""Auth hardening regression guards (review #6 + gap G1).
+
+#6 — CustomUser.email is not unique. Registering a second account with a
+victim's email used to break their email login with an unhandled
+MultipleObjectsReturned (500 / account DoS). Registration now rejects duplicate
+emails (case-insensitive) and the email-login path resolves any legacy
+duplicates to the original account instead of 500ing.
+
+G1 — the login / register / refresh throttles subclassed AnonRateThrottle but
+only overrode `rate`, not `scope`, so all three shared the single "anon" per-IP
+cache key and interfered with each other's limits. Each now owns a scope.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.accounts.models import CustomUser
+from apps.accounts.serializers import LoginSerializer, RegisterSerializer
+from apps.accounts.views import LoginRateThrottle, RefreshRateThrottle, RegisterRateThrottle
+
+_PW = "Xx123456789!"  # 13 chars, satisfies length + upper/lower/digit rules
+
+
+# --- G1: throttle scope isolation ---
+
+
+def test_auth_throttles_have_distinct_non_anon_scopes():
+    scopes = [LoginRateThrottle().scope, RegisterRateThrottle().scope, RefreshRateThrottle().scope]
+    assert len(set(scopes)) == 3, f"throttle scopes must be distinct, got {scopes}"
+    assert "anon" not in scopes, "auth throttles must not share AnonRateThrottle's 'anon' bucket"
+
+
+def test_auth_throttle_rates_unchanged():
+    assert LoginRateThrottle().rate == "5/min"
+    assert RegisterRateThrottle().rate == "3/min"
+    assert RefreshRateThrottle().rate == "30/min"
+
+
+# --- #6: duplicate-email registration + login resolution ---
+
+
+@pytest.mark.django_db
+def test_register_rejects_duplicate_email_case_insensitively():
+    CustomUser.objects.create_user(username="victim", email="dup@example.com", password=_PW)
+    serializer = RegisterSerializer(
+        data={
+            "username": "attacker",
+            "email": "DUP@example.com",  # case-insensitive collision with the victim
+            "password": _PW,
+            "password2": _PW,
+            "first_name": "Ann",
+            "last_name": "Other",
+        }
+    )
+    assert not serializer.is_valid()
+    assert "email" in serializer.errors
+
+
+@pytest.mark.django_db
+def test_email_login_with_legacy_duplicate_emails_does_not_500():
+    # Two accounts sharing an email, as could exist before the uniqueness check.
+    original = CustomUser.objects.create_user(username="orig", email="dup2@example.com", password=_PW)
+    CustomUser.objects.create_user(username="second", email="dup2@example.com", password="Yy123456789!")
+
+    serializer = LoginSerializer(data={"username": "dup2@example.com", "password": _PW})
+
+    # Must NOT raise MultipleObjectsReturned; resolves to the original (oldest)
+    # account so the victim can still log in by email.
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["user"].id == original.id

--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -74,6 +74,10 @@ def _clear_jwt_cookies(response):
 
 
 class RefreshRateThrottle(AnonRateThrottle):
+    # Distinct scope so this limit doesn't share AnonRateThrottle's "anon" cache
+    # key with the login/register throttles — without it all three count against
+    # the same per-IP bucket and interfere with each other's limits.
+    scope = "token_refresh"
     rate = "30/min"
 
 
@@ -140,10 +144,14 @@ class CookieTokenRefreshView(generics.GenericAPIView):
 
 
 class LoginRateThrottle(AnonRateThrottle):
+    # Distinct scope (see RefreshRateThrottle) — login, register and refresh must
+    # each own their per-IP bucket rather than sharing AnonRateThrottle's "anon".
+    scope = "login"
     rate = "5/min"
 
 
 class RegisterRateThrottle(AnonRateThrottle):
+    scope = "register"
     rate = "3/min"
 
 

--- a/backend/apps/agents/services/marketing_pipeline.py
+++ b/backend/apps/agents/services/marketing_pipeline.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 
 from apps.agents.exceptions import LLMServiceError
 from apps.agents.models import BiasReport, MarketingEmail, NextBestOffer
@@ -19,6 +20,22 @@ class MarketingPipelineService:
 
     def __init__(self, step_tracker: StepTracker):
         self.tracker = step_tracker
+
+    @staticmethod
+    def _has_marketing_consent(application) -> bool:
+        """True only if the applicant's profile exists AND granted marketing
+        consent. The reverse accessor is ``.profile`` — CustomerProfile.user sets
+        ``related_name="profile"``, so ``.customerprofile`` does not exist and
+        raised AttributeError on every call, which the old bare ``except
+        Exception`` swallowed → consent always read as absent → every marketing
+        email was silently blocked as "no_marketing_consent". Catch only a
+        genuinely missing profile so a future typo surfaces loudly instead.
+        """
+        try:
+            profile = application.applicant.profile
+        except ObjectDoesNotExist:
+            return False
+        return bool(profile and profile.marketing_consent)
 
     def run(self, application, agent_run, steps, denial_reasons, profile_context):
         """Run the full NBO + marketing email pipeline. Returns updated steps list."""
@@ -184,13 +201,8 @@ class MarketingPipelineService:
                     try:
                         from apps.email_engine.services.sender import send_decision_email
 
-                        # Check marketing consent before sending
-                        try:
-                            profile = application.applicant.customerprofile
-                        except Exception:
-                            profile = None
-
-                        if not profile or not profile.marketing_consent:
+                        # Gate on marketing consent before sending.
+                        if not self._has_marketing_consent(application):
                             logger.info(
                                 "Marketing email blocked: customer %s has not given marketing consent",
                                 application.applicant_id,

--- a/backend/apps/agents/services/recommendation_engine.py
+++ b/backend/apps/agents/services/recommendation_engine.py
@@ -539,6 +539,8 @@ class RecommendationEngine:
 
         rate = _get_rate_for_tier(catalog["rate_tiers"], s.credit_score)
 
+        # Initial sizing at the longest term (60mo) to find the upper bound,
+        # also capped by 90% of pledged savings and the catalog ceiling.
         max_amount = min(
             s.savings_balance * 0.90,
             _max_serviceable_amount(s.monthly_surplus, rate, 60),
@@ -549,16 +551,33 @@ class RecommendationEngine:
         if max_amount < 2000:
             return None
 
-        # Pick term to keep repayments under 15% of monthly income
+        # Choose the SHORTEST term whose repayment fits the cap. The cap is the
+        # customer's demonstrated serviceable surplus (the SAME basis that sized
+        # max_amount), not just 15% of gross — quoting a shorter term whose
+        # repayment exceeds their surplus is an NCCP serviceability smell.
+        # 15%-of-gross is kept as an additional ceiling. Mirrors unsecured (M19).
         monthly_income = s.annual_income / 12
-        target_repayment = monthly_income * 0.15
+        target_repayment = min(monthly_income * 0.15, s.monthly_surplus)
 
-        term = 60  # default
-        for t in catalog["terms"]:
-            rep = _monthly_repayment(max_amount, rate, t)
-            if rep <= target_repayment:
+        terms = catalog["terms"]  # secured: [12, 24, 36, 60, 84]
+        term = max(terms)  # longest = most affordable fallback
+        for t in sorted(terms):
+            if _monthly_repayment(max_amount, rate, t) <= target_repayment:
                 term = t
                 break
+
+        # Re-size max_amount at the ACTUAL selected term (M19). The secured path
+        # previously sized for 60mo but quoted the repayment at the chosen
+        # shorter term, so the quote could exceed the surplus the sizing assumed.
+        max_amount = min(
+            s.savings_balance * 0.90,
+            _max_serviceable_amount(s.monthly_surplus, rate, term),
+            catalog["max_amount"],
+        )
+        max_amount = math.floor(max_amount / 1000) * 1000
+
+        if max_amount < 2000:
+            return None
 
         repayment = _monthly_repayment(max_amount, rate, term)
         fortnightly = repayment / 2

--- a/backend/apps/agents/tests/test_marketing_consent.py
+++ b/backend/apps/agents/tests/test_marketing_consent.py
@@ -1,0 +1,49 @@
+"""Regression guard for the marketing-consent reverse-accessor bug (review #2).
+
+The consent gate read `application.applicant.customerprofile`, but the reverse
+accessor is `.profile` (CustomerProfile.user has related_name="profile"). The
+wrong name raised AttributeError that a bare `except Exception` swallowed, so
+consent always read as absent and EVERY marketing email was silently blocked —
+even for customers who had explicitly granted consent. The check now lives in
+the testable `_has_marketing_consent` helper.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from django.core.exceptions import ObjectDoesNotExist
+
+from apps.agents.services.marketing_pipeline import MarketingPipelineService
+
+
+class _Profile:
+    def __init__(self, consent: bool):
+        self.marketing_consent = consent
+
+
+class _ApplicantWithoutProfile:
+    """Accessing `.profile` raises, like a missing reverse OneToOne relation."""
+
+    @property
+    def profile(self):
+        raise ObjectDoesNotExist("no profile")
+
+
+def _application(applicant):
+    return SimpleNamespace(applicant=applicant)
+
+
+def test_consent_granted_returns_true():
+    app = _application(SimpleNamespace(profile=_Profile(True)))
+    assert MarketingPipelineService._has_marketing_consent(app) is True
+
+
+def test_consent_declined_returns_false():
+    app = _application(SimpleNamespace(profile=_Profile(False)))
+    assert MarketingPipelineService._has_marketing_consent(app) is False
+
+
+def test_missing_profile_returns_false_without_raising():
+    app = _application(_ApplicantWithoutProfile())
+    assert MarketingPipelineService._has_marketing_consent(app) is False

--- a/backend/apps/agents/tests/test_recommendation_engine.py
+++ b/backend/apps/agents/tests/test_recommendation_engine.py
@@ -69,3 +69,42 @@ class TestUnsecuredPersonalTermSelection:
         rec = eng._evaluate_unsecured_personal(s)
         if rec is not None:
             assert rec.term_months == 60
+
+
+class TestSecuredPersonalServiceability:
+    """Guards the M19-parity fix for secured personal loans (review #3). The
+    secured offer used to size max_amount for a 60-month horizon but quote the
+    repayment at the chosen (possibly shorter) term, so the quote could exceed
+    the customer's demonstrated serviceable surplus. After the fix max_amount is
+    re-sized at the selected term, so repayment <= surplus in every case."""
+
+    def test_repayment_never_exceeds_serviceable_surplus(self):
+        eng = RecommendationEngine()
+        # High income (a short term fits the 15%-of-gross ceiling) + ample
+        # savings (the savings cap doesn't bind) — the exact shape that made the
+        # old code quote a short-term repayment above the demonstrated surplus.
+        s = _snapshot(
+            annual_income=240000.0,
+            monthly_expenses=2000.0,
+            savings_balance=120000.0,
+            credit_score=780,
+        )
+        rec = eng._evaluate_secured_personal(s)
+        assert rec is not None
+        assert rec.monthly_repayment <= s.monthly_surplus + 0.01, (
+            f"quoted ${rec.monthly_repayment:,.0f}/mo exceeds serviceable surplus ${s.monthly_surplus:,.0f}/mo"
+        )
+
+    def test_quoted_repayment_is_internally_consistent_with_amount_and_term(self):
+        eng = RecommendationEngine()
+        s = _snapshot(
+            annual_income=300000.0,
+            monthly_expenses=2000.0,
+            savings_balance=200000.0,
+            credit_score=800,
+        )
+        rec = eng._evaluate_secured_personal(s)
+        assert rec is not None
+        recomputed = _monthly_repayment(rec.amount, rec.estimated_rate, rec.term_months)
+        assert abs(recomputed - rec.monthly_repayment) < 0.01
+        assert rec.monthly_repayment <= s.monthly_surplus + 0.01

--- a/backend/apps/ml_engine/services/scoring/decision_assembly.py
+++ b/backend/apps/ml_engine/services/scoring/decision_assembly.py
@@ -92,8 +92,15 @@ def assemble_decision(
             )
             prediction_label = "denied"
     except Exception:
-        logger.warning("Pricing tier computation failed", exc_info=True)
-        pricing_payload = {"tier": "unavailable", "approved": True}
+        # Fail-safe: the pricing tier is a hard risk gate that can DECLINE a
+        # model-approved application (PD above the bank's writeable cutoff). A
+        # transient failure must NOT read as a clean approve — flag the decision
+        # for human review and never report the gate as approved. (Routing here
+        # mirrors how requires_human_review already handles drift/borderline; it
+        # is not the bias-detection queue.)
+        logger.warning("Pricing tier computation failed — flagging for human review (fail-safe)", exc_info=True)
+        pricing_payload = {"tier": "unavailable", "approved": False}
+        requires_human_review = True
 
     return {
         "probability": probability,

--- a/backend/apps/ml_engine/tests/test_decision_assembly.py
+++ b/backend/apps/ml_engine/tests/test_decision_assembly.py
@@ -172,7 +172,7 @@ class TestAssembleDecision:
 
         assert result["prediction_label"] == "denied"
 
-    def test_pricing_failure_returns_unavailable_payload_without_crashing(self):
+    def test_pricing_failure_is_failsafe_and_flags_review(self):
         mv = _mk_version(optimal_threshold=0.5)
         with patch(
             "apps.ml_engine.services.scoring.decision_assembly.get_tier",
@@ -187,9 +187,13 @@ class TestAssembleDecision:
                 segment="personal",
             )
 
-        # Model approves; pricing failed fail-open so label stays approved.
+        # Fail-SAFE (review G2): the pricing tier is a hard risk gate that can
+        # decline a model approval, so a transient failure must NOT read as a
+        # clean approve. The model's own label is preserved, but the gate is
+        # reported not-approved and the decision is flagged for human review.
         assert result["prediction_label"] == "approved"
-        assert result["pricing_payload"] == {"tier": "unavailable", "approved": True}
+        assert result["pricing_payload"] == {"tier": "unavailable", "approved": False}
+        assert result["requires_human_review"] is True
 
     def test_probability_rounded_to_four_places(self):
         mv = _mk_version(optimal_threshold=0.5)


### PR DESCRIPTION
**PR 2 of 3** from the multi-dimension codebase review (correctness/safety batch). Five independent fixes, each with a regression test.

### #2 (MED) — Marketing emails were silently 100% blocked
The consent gate read `application.applicant.customerprofile`, but the reverse accessor is `.profile` (`CustomerProfile.user` sets `related_name="profile"`). The wrong name raised `AttributeError`, which a bare `except Exception` swallowed → consent always read as absent → **every** marketing follow-up was blocked as `no_marketing_consent` since 2026-06-05. Extracted a testable `_has_marketing_consent` helper using the correct accessor + narrowed the except to `ObjectDoesNotExist`.

### #3 (MED) — Secured loan could quote a repayment above serviceable surplus
`_evaluate_secured_personal` sized `max_amount` for a 60-month horizon but quoted the repayment at the chosen (possibly shorter) term, so the quote could exceed the applicant's demonstrated surplus. Mirrored the unsecured **M19** fix: cap `target_repayment` by the surplus and re-size `max_amount` at the selected term ⇒ `repayment ≤ surplus` always.

### #6 (MED) — Duplicate-email registration → email-login DoS
`CustomUser.email` isn't unique, so registering a second account with a victim's email broke their email login with an unhandled `MultipleObjectsReturned` (500). `RegisterSerializer` now rejects duplicate emails (case-insensitive); `LoginSerializer` resolves any legacy duplicate to the **original (oldest)** account instead of 500ing. *App-level fix — a DB `unique=True` constraint is noted as a follow-up (naive uniqueness collides on blank emails and needs a dedupe migration).*

### G2 (gap) — Pricing risk-gate failed OPEN
`decision_assembly` returned `{"approved": True}` when the pricing gate threw, so a transient failure read as a clean approve. Now **fail-safe**: gate reported not-approved + decision flagged for human review (same mechanism that already handles drift/borderline — not the bias queue), model label preserved.

### G1 (gap) — Auth throttles shared one cache bucket
login (5/min) / register (3/min) / refresh (30/min) subclassed `AnonRateThrottle` but only overrode `rate`, not `scope`, so all three shared the `throttle_anon_<ip>` key and interfered. Each now has a distinct `scope`; rates unchanged.

## Tests
- New `test_marketing_consent.py`, `test_auth_hardening.py`; new `TestSecuredPersonalServiceability`; updated the decision_assembly pricing-failure test (it **encoded** the fail-open bug) to assert fail-safe.
- Non-DB subset (21 tests) verified green on host. The 2 DB-backed #6 tests + full-suite regression run execute here in CI (the worktree isolation from a concurrent branch meant the local container couldn't mount this tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)