### PR TITLE
fix(logging): harden PII masking — AU phone formats + structured extras (review #5/#19)

### DIFF
--- a/backend/config/logging_filters.py
+++ b/backend/config/logging_filters.py
@@ -13,19 +13,27 @@ class PiiMaskingFilter(logging.Filter):
     """Redact PII patterns from log record messages and args."""
 
     _PATTERNS: list[tuple[re.Pattern, str]] = [
+        # Phone numbers FIRST: a spaced/dashed phone tail otherwise gets stolen
+        # and mislabelled by the generic 9-digit TFN/Medicare matchers below.
+        # Australian mobile (04XX XXX XXX), landline ((0X) XXXX XXXX) and +61
+        # forms, tolerant of spaces/dashes between groups — CustomerProfile.phone
+        # is a free-text CharField, so real values are rarely an unbroken run.
+        (re.compile(r"(?:\+?61[\s-]?|\(?0)[2-478]\)?(?:[\s-]?\d){8}"), "[PHONE_REDACTED]"),
         # Australian Tax File Number (XXX XXX XXX)
         (re.compile(r"\b\d{3}\s?\d{3}\s?\d{3}\b"), "[TFN_REDACTED]"),
         # Medicare number (XXXX XXXXX X)
         (re.compile(r"\b\d{4}\s?\d{5}\s?\d\b"), "[MEDICARE_REDACTED]"),
         # Email addresses
         (re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"), "[EMAIL_REDACTED]"),
-        # Phone numbers (Australian: 04XX XXX XXX, 1300/1800, +61)
-        (re.compile(r"(?:\+61|0)[2-478]\d{8}"), "[PHONE_REDACTED]"),
         # Dollar amounts following sensitive keywords
         (re.compile(r'(?:income|salary|wage|earning)[=:\s"\']+\$?[\d,.]+', re.IGNORECASE), "[INCOME_REDACTED]"),
         # Generic ID number patterns after identity keywords
         (re.compile(r'(?:passport|licence|license|driver)[=:\s"\']+[A-Z0-9]{6,12}', re.IGNORECASE), "[ID_REDACTED]"),
     ]
+
+    # Standard LogRecord attributes — anything NOT here was attached via the
+    # logging `extra={...}` kwarg and may carry PII, so it must be scrubbed too.
+    _STD_ATTRS = frozenset(vars(logging.makeLogRecord({}))) | {"message", "asctime"}
 
     def filter(self, record: logging.LogRecord) -> bool:
         record.msg = self._redact(str(record.msg))
@@ -34,6 +42,11 @@ class PiiMaskingFilter(logging.Filter):
                 record.args = {k: self._redact(str(v)) for k, v in record.args.items()}
             elif isinstance(record.args, tuple):
                 record.args = tuple(self._redact(str(a)) for a in record.args)
+        # Structured-logging extras land as custom record attributes; redact any
+        # string-valued ones without disturbing the standard LogRecord fields.
+        for key, value in list(record.__dict__.items()):
+            if key not in self._STD_ATTRS and isinstance(value, str):
+                record.__dict__[key] = self._redact(value)
         return True
 
     def _redact(self, text: str) -> str:

--- a/backend/tests/test_pii_logging_filter.py
+++ b/backend/tests/test_pii_logging_filter.py
@@ -1,0 +1,70 @@
+"""Tests for config.logging_filters.PiiMaskingFilter (review #5 + #19).
+
+#5: the phone pattern only matched an unbroken digit run, so the common AU
+spaced/dashed forms (the way CustomerProfile.phone actually stores numbers)
+leaked into logs unredacted, and an unbroken number was mislabelled MEDICARE.
+#19: the filter scrubbed record.msg/args but not structured-logging `extra={}`
+fields, so any future extra carrying PII bypassed redaction.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from config.logging_filters import PiiMaskingFilter
+
+
+def _redact(text: str) -> str:
+    return PiiMaskingFilter()._redact(text)
+
+
+class TestPhoneRedaction:
+    def test_spaced_mobile_is_redacted(self):
+        out = _redact("call 0412 345 678 today")
+        assert "[PHONE_REDACTED]" in out
+        assert "0412 345 678" not in out
+
+    def test_dashed_mobile_is_redacted(self):
+        out = _redact("ph 0412-345-678")
+        assert "[PHONE_REDACTED]" in out
+        assert "0412-345-678" not in out
+
+    def test_parenthesised_landline_is_redacted(self):
+        out = _redact("office (02) 9876 5432")
+        assert "[PHONE_REDACTED]" in out
+
+    def test_plus61_international_is_redacted(self):
+        assert "[PHONE_REDACTED]" in _redact("intl +61 412 345 678")
+
+    def test_unbroken_mobile_is_phone_not_medicare(self):
+        # Phone runs before the generic Medicare matcher, so an unbroken mobile
+        # is labelled PHONE rather than mislabelled MEDICARE.
+        out = _redact("mobile 0412345678")
+        assert "[PHONE_REDACTED]" in out
+        assert "0412345678" not in out
+        assert "MEDICARE" not in out
+
+    def test_real_tfn_not_stolen_by_phone(self):
+        # A 9-digit TFN does not start with 0/+61, so phone leaves it for the TFN
+        # matcher rather than swallowing it.
+        out = _redact("tfn 123 456 789")
+        assert "[TFN_REDACTED]" in out
+
+
+class TestExtrasRedaction:
+    def test_string_extra_field_is_redacted(self):
+        record = logging.LogRecord("svc", logging.INFO, "/p", 1, "decision logged", None, None)
+        record.applicant_phone = "0412 345 678"  # simulates extra={"applicant_phone": ...}
+        PiiMaskingFilter().filter(record)
+        assert record.applicant_phone == _redact("0412 345 678")
+        assert "[PHONE_REDACTED]" in record.applicant_phone
+
+    def test_standard_attributes_are_not_touched(self):
+        record = logging.LogRecord("mymod", logging.INFO, "/p", 1, "hello", None, None)
+        PiiMaskingFilter().filter(record)
+        assert record.name == "mymod"
+        assert record.levelname == "INFO"
+
+
+def test_email_still_redacted():
+    assert "[EMAIL_REDACTED]" in _redact("contact applicant@example.com")


### PR DESCRIPTION
**PR 3 of 3** from the codebase review — focused on the **security-relevant** hygiene (PII log redaction). The remaining cosmetic LOW findings are catalogued at the bottom for a separate follow-up rather than diluted into this PR.

### #5 (MED→) — AU phone numbers leaked into logs
The phone pattern `(?:\+61|0)[2-478]\d{8}` only matched an **unbroken** digit run, so the common Australian spaced/dashed forms that `CustomerProfile.phone` (a free-text CharField) actually stores leaked unredacted — verified against the live regex: `0412 345 678`, `0412-345-678`, `(02) 9876 5432`, `+61 412 345 678` all passed through, and an unbroken mobile was mislabelled `MEDICARE`. New separator-tolerant pattern, ordered **before** the generic 9-digit TFN/Medicare matchers so a phone tail is no longer stolen/mislabelled. A real 9-digit TFN (no `0`/`+61` prefix) is still left for the TFN matcher.

### #19 — structured-logging extras bypassed redaction
The filter scrubbed `record.msg`/`record.args` but not `extra={...}` fields. It now also redacts string-valued custom record attributes (everything outside the standard `LogRecord` attribute set), leaving standard fields untouched.

## Tests
New `test_pii_logging_filter.py` (9 cases: spaced/dashed/parenthesised/+61 phones, phone-before-Medicare ordering, TFN-not-stolen, extras redaction, standard-attr safety). **25 green on host** including the existing `pii_masking` suite.

## Deferred (catalogued, not in this PR)
Lower-priority/cosmetic LOW findings, grouped for a quick follow-up batch once greenlit:
- **Docs accuracy** #9/#10/#11 — reason-code count (76→70), frontend test count (327/341→actual), backend test/file count drift. (Fragile exact counts — will set to consistent approximate figures.)
- **Ops** #16 (CORS missing→localhost, no startup check), #17 (unguarded `lock.release()` masks real error), #18 (numeric env-var parse crashes at import).
- **a11y** #12 (FairnessCard has no screen-reader text alternative).
- **Test quality** #20/#21 (celery "serializes" tests use `.apply()` which bypasses the JSON round-trip — genuine serialization testing needs care).
- **ML honesty notes** #13 (IV leakage detector effectively disabled but reports an excluded count), #14 (PSI per-bin epsilon scheme differs from the headline PSI).
- **Minor** #7 (fraud docstring contradicts its threshold), #8 (temporal-CV silently skipped under reject-inference).
- **#15** (PII filter wired only in production logging; dev/Docker uses Django defaults) — needs a base-logging config addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)