### PR TITLE
fix: cosmetic hygiene from review (docs accuracy #9-11, a11y #12, ops #16/#17, docstring #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ A separate `watchdog` service runs in the core stack at all times. It polls ever
 
 ## Testing
 
-1,750+ backend tests and 327 frontend tests. 63% backend coverage floor enforced in CI. CI pipeline runs Ruff, Bandit SAST, gitleaks, npm audit, OWASP ZAP DAST, k6 load test, and Trivy container scanning.
+1,900+ backend tests and 370+ frontend tests. 63% backend coverage floor enforced in CI. CI pipeline runs Ruff, Bandit SAST, gitleaks, npm audit, OWASP ZAP DAST, k6 load test, and Trivy container scanning.
 
 <details>
 <summary><strong>Verifying the build</strong> (click to expand)</summary>

--- a/backend/apps/loans/services/fraud_detection.py
+++ b/backend/apps/loans/services/fraud_detection.py
@@ -106,10 +106,12 @@ class FraudDetectionService:
         }
 
     def _check_velocity(self, application):
-        """Flag if the applicant submitted more than 3 applications in 7 days.
+        """Flag if the applicant has 10 or more in-pipeline applications in 7 days.
 
         Only counts applications still in the intake pipeline (pending/processing)
-        — already-decided applications are legitimate prior submissions.
+        — already-decided applications are legitimate prior submissions. The
+        threshold is `recent_count >= 10` (the +1 in messages includes the
+        current application).
         """
         from apps.loans.models import LoanApplication
 

--- a/backend/apps/ml_engine/tasks.py
+++ b/backend/apps/ml_engine/tasks.py
@@ -48,7 +48,13 @@ def train_model_task(self, algorithm="xgb", data_path=None, segment=None):
             algorithm,
             self.request.id,
         )
-        lock.release()
+        # Guard the release: after a long train the 30-min lock may already have
+        # expired, and releasing an expired/unowned redis lock raises — which
+        # would mask the real training error this except block is re-raising.
+        try:
+            lock.release()
+        except Exception:
+            logger.warning("train_model lock release failed (likely expired); ignoring")
         raise
 
 

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -176,6 +176,18 @@ CORS_ALLOWED_ORIGINS = [
 ]
 CORS_ALLOW_CREDENTIALS = True
 
+# A missing CORS_ALLOWED_ORIGINS in production silently falls back to localhost,
+# which blocks the real deployed frontend with no obvious error. Surface it loudly
+# at startup rather than letting it manifest as opaque CORS failures in the browser.
+if not DEBUG and not os.environ.get("CORS_ALLOWED_ORIGINS"):
+    import warnings
+
+    warnings.warn(
+        "CORS_ALLOWED_ORIGINS is not set with DEBUG=False — defaulting to localhost; "
+        "the deployed frontend's requests will be blocked until it is configured.",
+        stacklevel=2,
+    )
+
 # Content Security Policy (django-csp 4.0+)
 # Uses CONTENT_SECURITY_POLICY dict format.
 # Start in report-only mode to avoid breaking existing functionality.

--- a/backend/tests/test_celery_integration.py
+++ b/backend/tests/test_celery_integration.py
@@ -151,6 +151,37 @@ class TestCeleryTaskExecution:
         )
 
 
+@pytest.mark.django_db
+def test_train_lock_release_failure_does_not_mask_training_error():
+    """If training raises AND the (possibly expired) redis lock's release() also
+    raises, the ORIGINAL training error must propagate — the release failure must
+    not mask it (review #17). Fully mocks redis, so it needs no broker."""
+    from unittest.mock import MagicMock
+
+    from apps.ml_engine.tasks import train_model_task
+
+    fake_lock = MagicMock()
+    fake_lock.acquire.return_value = True
+    fake_lock.release.side_effect = RuntimeError("lock already expired")
+    fake_redis = MagicMock()
+    fake_redis.lock.return_value = fake_lock
+
+    class _TrainBoom(Exception):
+        pass
+
+    with (
+        patch("redis.from_url", return_value=fake_redis),
+        patch("apps.ml_engine.tasks._do_train", side_effect=_TrainBoom("training failed")),
+    ):
+        result = train_model_task.apply(kwargs={"algorithm": "xgb"})
+
+    assert result.failed()
+    assert isinstance(result.result, _TrainBoom), (
+        f"the original training error must propagate, not the lock-release error; "
+        f"got {type(result.result).__name__}: {result.result}"
+    )
+
+
 @skip_without_redis
 class TestCeleryBrokerHealth:
     """Verify the Redis broker connection is healthy."""

--- a/docs/interview-talking-points.md
+++ b/docs/interview-talking-points.md
@@ -41,7 +41,7 @@
 
 **Follow-ups to expect:**
 - *How much lift?* → Measured, not assumed. Every training run fits a logistic baseline on four core features and records `baseline_auc` plus `xgb_lift_over_baseline` in training metadata. ADR 002.
-- *What else?* → IV feature selection, isotonic calibration, conformal prediction intervals for high-stakes cases, SHAP-mapped to 76 adverse-action reason codes, APRA +3% stress buffer, parcelling-based reject inference.
+- *What else?* → IV feature selection, isotonic calibration, conformal prediction intervals for high-stakes cases, SHAP-mapped to 70 adverse-action reason codes, APRA +3% stress buffer, parcelling-based reject inference.
 
 ---
 
@@ -144,10 +144,10 @@
 - Test AUC 0.87–0.88 Optuna-tuned, 0.84–0.85 default hyperparameters (synthetic), ~0.82 real-world estimate (TSTR).
 - 71 input fields, 76 monotonic constraints, 31 engineered interactions.
 - 18 deterministic email guardrails on a decision email (19 on a marketing email). Up to three regeneration attempts, then the email is withheld and flagged to operations — the human-review queue is reserved for bias escalations only.
-- 76 SHAP-mapped adverse-action reason codes.
+- 70 SHAP-mapped adverse-action reason codes.
 - <$5/day LLM API cap (Claude by default; optional free Groq backend, selectable via `EMAIL_LLM_BACKEND`, chosen because its free tier doesn't train on prompts).
 - 30s watchdog poll, 5-minute stuck threshold.
-- 63% backend test coverage floor, 1,932 backend tests across 158 files, plus 341 frontend tests.
+- 63% backend test coverage floor, 1,900+ backend tests across 180+ files, plus 370+ frontend tests.
 
 **Things you shouldn't oversell:**
 - No production users. No licensed compliance sign-off. Synthetic data only.

--- a/frontend/src/__tests__/components/metrics/FairnessCard.test.tsx
+++ b/frontend/src/__tests__/components/metrics/FairnessCard.test.tsx
@@ -30,6 +30,16 @@ describe('FairnessCard', () => {
     expect(screen.getByText(/Equalized Odds Diff: 0\.0200/)).toBeInTheDocument()
   })
 
+  it('exposes a screen-reader text alternative listing each group (review #12)', () => {
+    render(<FairnessCard fairnessMetrics={metricsWithSmallGroup} />)
+    // The BarChart is otherwise inaccessible; an sr-only list carries the data.
+    expect(
+      screen.getByText(
+        /actual approval 60%, predicted approval 62%, true positive rate 80%, false positive rate 20%/,
+      ),
+    ).toBeInTheDocument()
+  })
+
   it('does not render a PASS/FAIL disparate-impact badge', () => {
     render(<FairnessCard fairnessMetrics={metricsWithSmallGroup} />)
     expect(screen.queryByText(/\bPASS\b/)).not.toBeInTheDocument()

--- a/frontend/src/components/metrics/FairnessCard.tsx
+++ b/frontend/src/components/metrics/FairnessCard.tsx
@@ -58,6 +58,15 @@ function FairnessAttributeCard({ attribute, data }: { attribute: string; data: a
         </CardDescription>
       </CardHeader>
       <CardContent>
+        {/* Text alternative for screen readers — the BarChart is otherwise
+            inaccessible (consistent with the sibling metrics charts). */}
+        <ul className="sr-only">
+          {chartData.map((d) => (
+            <li key={d.group}>
+              {`${d.group}: actual approval ${d['Actual Approval']}%, predicted approval ${d['Predicted Approval']}%, true positive rate ${d.TPR}%, false positive rate ${d.FPR}%`}
+            </li>
+          ))}
+        </ul>
         <ResponsiveContainer width="100%" height={320}>
           <BarChart data={chartData} margin={{ top: 10, right: 20, bottom: 30, left: 10 }} {...hoverProps}>
             <CartesianGrid strokeDasharray="3 3" opacity={0.4} />


### PR DESCRIPTION
**PR 4** of the codebase-review follow-up — the cheap, safe, high-credibility hygiene. (PRs #235/#236/#237 landed the HIGH/MED findings.)

### Docs accuracy (#9, #10, #11) — credibility on an "honest metrics" repo
- **Reason codes:** interview-talking-points claimed **76**; there are **70** distinct codes (76 is the feature→code *map-entry* count; `reason_codes.py` has 70 distinct `Rnn`). README already said 70 — fixed the two talking-points mentions.
- **Test counts:** README (`1,750+`/`327`) and talking-points (`1,932`/`158 files`/`341`) disagreed and were stale. Reconciled to consistent current figures — **1,900+ backend tests across 180+ files, 370+ frontend tests** (conservative, drift-tolerant).

### a11y (#12)
`FairnessCard`'s chart had no screen-reader alternative (its sibling charts do). Added an `sr-only` per-group list (actual/predicted approval, TPR, FPR).

### Ops (#16, #17)
- **#16:** a missing `CORS_ALLOWED_ORIGINS` in production silently defaults to localhost and blocks the real frontend with no error — now warns at startup when `DEBUG=False` and it's unset.
- **#17:** the `train_model_task` except block called `lock.release()` unguarded; after a long train the 30-min lock can expire and `release()` then raises, **masking the real training error** — now guarded so the original error propagates.

### Docstring (#7)
`_check_velocity` said "more than 3 applications" but the threshold is `>= 10` — corrected.

## Tests
`+test_train_lock_release_failure_does_not_mask_training_error` (mocks redis), `+FairnessCard` sr-only assertion. Backend ruff + Django settings-load verified on host; frontend + the DB-backed test run here in CI.

## Deferred → PR 5 (catalogued)
`#18` env-int parse guard, `#20`/`#21` celery serialization-test honesty, `#15` PII-filter dev-logging wiring, `#13`/`#14` IV-detector/PSI-bin honesty, `#8` temporal-CV-under-reject-inference — grouped because they touch settings/ML internals (incl. the freshly-changed trainer/metrics) and warrant their own careful pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)