### PR TITLE
fix(email_engine): degrade to template on provider errors, not just budget

### DIFF
--- a/backend/apps/email_engine/services/email_generator.py
+++ b/backend/apps/email_engine/services/email_generator.py
@@ -8,6 +8,7 @@ import httpx
 from utils.sanitization import sanitize_prompt_input as _sanitize_prompt_input
 
 from .documentation import build_documentation_checklist
+from .exceptions import EmailBackendError
 from .guardrails import GuardrailChecker
 from .pricing import calculate_loan_pricing
 from .prompts import APPROVAL_EMAIL_PROMPT, DENIAL_EMAIL_PROMPT
@@ -442,6 +443,17 @@ class EmailGenerator:
             from .exceptions import RateLimited
 
             raise RateLimited(retry_after=30) from exc
+        except (anthropic.APIError, EmailBackendError) as exc:
+            # A provider error (timeout, connection drop, 4xx/5xx — e.g. a free
+            # tier returning 413 "request too large") must NOT leave a customer
+            # without a compliant email. Degrade to the deterministic template,
+            # exactly like the budget-exhausted path. 429 is handled above as
+            # RateLimited (Celery backoff); programming bugs are not APIError /
+            # EmailBackendError, so they still surface.
+            logging.getLogger("email_engine.generator").warning(
+                "email LLM backend error (%s) — falling back to template", type(exc).__name__
+            )
+            return self._generate_fallback(application, decision, context, start_time)
         # Failure accounting (record_failure, circuit-breaker tripping) happens
         # inside guarded_api_call. Any other exception here propagates to the caller.
 

--- a/backend/apps/email_engine/services/exceptions.py
+++ b/backend/apps/email_engine/services/exceptions.py
@@ -9,3 +9,17 @@ class RateLimited(Exception):
     def __init__(self, retry_after=30):
         self.retry_after = retry_after
         super().__init__(f"Claude API rate limited; retry after {retry_after}s")
+
+
+class EmailBackendError(Exception):
+    """Raised by an OpenAI-compatible email backend adapter when the provider
+    fails in a way that should DEGRADE TO THE DETERMINISTIC TEMPLATE rather than
+    crash: a non-retryable HTTP error (e.g. 413 request-too-large, 4xx, 5xx) or
+    a transport failure.
+
+    EmailGenerator catches this (alongside ``anthropic.APIError``) and returns
+    the template fallback, so a provider hiccup never leaves a customer without a
+    compliant email. A 429 is handled separately as ``RateLimited`` (Celery
+    retry); programming errors (AttributeError, KeyError, ...) are NOT wrapped in
+    this, so they still surface as real bugs.
+    """

--- a/backend/apps/email_engine/services/llm_client.py
+++ b/backend/apps/email_engine/services/llm_client.py
@@ -35,6 +35,8 @@ import logging
 import anthropic
 import httpx
 
+from .exceptions import EmailBackendError
+
 logger = logging.getLogger("email_engine.llm_client")
 
 DEFAULT_GROQ_BASE_URL = "https://api.groq.com/openai/v1"
@@ -139,14 +141,16 @@ class GroqLLMClient:
                 json=payload,
             )
         except httpx.HTTPError as exc:
-            # Transport-level failure — surface so guarded_api_call records the
-            # failure, releases the reservation, and the caller falls back.
-            raise RuntimeError(f"Groq request failed: {exc}") from exc
+            # Transport-level failure — surface as a backend error so the caller
+            # degrades to the deterministic template instead of crashing.
+            raise EmailBackendError(f"Groq request failed: {exc}") from exc
 
         if resp.status_code == 429:
             raise self._rate_limit_error(resp)
         if resp.status_code >= 400:
-            raise RuntimeError(f"Groq API error {resp.status_code}: {resp.text[:300]}")
+            # 4xx (e.g. 413 request-too-large on a small free tier) / 5xx →
+            # degrade to the template rather than hard-error.
+            raise EmailBackendError(f"Groq API error {resp.status_code}: {resp.text[:300]}")
 
         return self._normalise(resp.json())
 

--- a/backend/tests/test_email_generator.py
+++ b/backend/tests/test_email_generator.py
@@ -420,3 +420,51 @@ class TestEmailBackendSelection:
         lowered = result["body"].lower()
         for banned in ("sorry", "apologis", "disappoint"):
             assert banned not in lowered
+
+    @patch.dict(os.environ, {"EMAIL_LLM_BACKEND": "groq", "GROQ_API_KEY": "gsk-test"}, clear=True)
+    @patch("apps.email_engine.services.llm_client.GroqLLMClient")
+    @patch("apps.agents.services.api_budget.ApiBudgetGuard")
+    def test_backend_error_falls_back_to_template(self, mock_budget_cls, mock_groq_cls):
+        """A provider error (e.g. a free-tier 413 surfacing as EmailBackendError)
+        must degrade to the deterministic template, not crash email generation."""
+        from apps.email_engine.services.exceptions import EmailBackendError
+
+        mock_client = MagicMock()
+        mock_client.provider = "groq"
+        mock_groq_cls.return_value = mock_client
+        mock_client.messages.create.side_effect = EmailBackendError("Groq API error 413: request too large")
+        mock_budget_cls.return_value = MagicMock()
+
+        from apps.email_engine.services.email_generator import EmailGenerator
+
+        gen = EmailGenerator()
+        app = _make_mock_application(decision="approved")
+        result = gen.generate(app, "approved", confidence=0.92)
+        assert result["template_fallback"] is True
+        assert result["passed_guardrails"] is True
+        assert result["body"]
+
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key-123"}, clear=True)
+    @patch("apps.email_engine.services.email_generator.anthropic.Anthropic")
+    @patch("apps.agents.services.api_budget.ApiBudgetGuard")
+    def test_anthropic_api_error_falls_back_to_template(self, mock_budget_cls, mock_anthropic_cls):
+        """The same graceful degradation applies to the default Claude backend:
+        a connection/5xx error falls back to the template instead of propagating."""
+        import anthropic
+        import httpx
+
+        mock_client = MagicMock()
+        mock_anthropic_cls.return_value = mock_client
+        req = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+        mock_client.messages.create.side_effect = anthropic.APIConnectionError(request=req)
+        mock_budget_cls.return_value = MagicMock()
+
+        from apps.email_engine.services.email_generator import EmailGenerator
+
+        gen = EmailGenerator()
+        app = _make_mock_application(decision="denied", loan_amount=20000)
+        app.applicant.first_name = "Jane"
+        app.applicant.last_name = "Doe"
+        result = gen.generate(app, "denied", confidence=0.35)
+        assert result["template_fallback"] is True
+        assert result["passed_guardrails"] is True

--- a/backend/tests/test_groq_llm_client.py
+++ b/backend/tests/test_groq_llm_client.py
@@ -13,6 +13,7 @@ import httpx
 import pytest
 
 from apps.email_engine.services.email_generator import EMAIL_SUBMIT_TOOL
+from apps.email_engine.services.exceptions import EmailBackendError
 from apps.email_engine.services.llm_client import (
     GroqLLMClient,
     _map_finish_reason,
@@ -144,16 +145,24 @@ class TestGroqErrorHandling:
         with pytest.raises(anthropic.RateLimitError):
             c.messages.create(messages=[{"role": "user", "content": "x"}])
 
-    def test_500_raises_runtime_error(self):
+    def test_413_request_too_large_raises_email_backend_error(self):
+        # Free-tier TPM/context ceiling → must be a backend error so the caller
+        # degrades to the deterministic template, not a hard crash.
         c = _client()
-        c._http.post.return_value = _http_response(status_code=500, text_body="upstream boom")
-        with pytest.raises(RuntimeError):
+        c._http.post.return_value = _http_response(status_code=413, payload={"error": {"message": "Request too large"}})
+        with pytest.raises(EmailBackendError):
             c.messages.create(messages=[{"role": "user", "content": "x"}])
 
-    def test_transport_error_raises_runtime_error(self):
+    def test_500_raises_email_backend_error(self):
+        c = _client()
+        c._http.post.return_value = _http_response(status_code=500, text_body="upstream boom")
+        with pytest.raises(EmailBackendError):
+            c.messages.create(messages=[{"role": "user", "content": "x"}])
+
+    def test_transport_error_raises_email_backend_error(self):
         c = _client()
         c._http.post.side_effect = httpx.ConnectError("no route")
-        with pytest.raises(RuntimeError):
+        with pytest.raises(EmailBackendError):
             c.messages.create(messages=[{"role": "user", "content": "x"}])
 
     def test_provider_attribute_is_groq(self):


### PR DESCRIPTION
## Summary

A provider error during email generation — a timeout, a dropped connection, or a 4xx/5xx (notably a **free Groq tier returning HTTP 413 \"request too large\"** for our ~9k-token compliance prompts) — previously **propagated and crashed email generation**. The deterministic template fallback only triggered on a missing key or budget exhaustion, not on a live provider failure.

This makes any provider failure **degrade to the deterministic template**, consistent with the "emails always deliver" principle (ADR 006). Found via real end-to-end testing of the Groq backend (#234): both approval and denial emails 413'd on Groq's 6k-TPM free tier and hard-errored instead of falling back.

## What changed

- **New `EmailBackendError`** (`email_engine/services/exceptions.py`). The OpenAI-compatible adapter raises it on 413 / 4xx / 5xx and transport failures (previously a bare `RuntimeError` that nothing caught).
- **`EmailGenerator` catches `(anthropic.APIError, EmailBackendError)`** → returns the template fallback. This covers **both** backends (Claude API errors and the OpenAI-compatible adapter).
- A **429** still maps to `RateLimited` (Celery backoff), handled before the new clause. **Programming bugs** (`AttributeError`, `KeyError`, …) are *not* `APIError`/`EmailBackendError`, so they still surface as real failures — the fallback is precise, not a blanket `except Exception`.

## Test plan

- Adapter: 413 / 500 / transport-error → `EmailBackendError` (was `RuntimeError`); 429 → `anthropic.RateLimitError`.
- `EmailGenerator.generate()`: falls back to the template (and still passes guardrails) on `EmailBackendError` (Groq path) and `anthropic.APIConnectionError` (Claude path).
- **Full backend suite: 2100 passed, 33 skipped.** Ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)