### PR TITLE
fix: review tail — ML-internal honesty + ops/test hygiene (#8/#13/#14/#15/#18/#20/#21)

### DIFF
--- a/backend/apps/ml_engine/services/metrics/compute.py
+++ b/backend/apps/ml_engine/services/metrics/compute.py
@@ -249,18 +249,22 @@ class MetricsService:
         expected_counts = np.histogram(expected, bins=bin_edges)[0]
         actual_counts = np.histogram(actual, bins=bin_edges)[0]
 
-        # Convert to proportions; epsilon smoothing to avoid log(0)
-        eps = 1e-4
-        expected_pct = (expected_counts + eps) / (len(expected) + eps * len(expected_counts))
-        actual_pct = (actual_counts + eps) / (len(actual) + eps * len(actual_counts))
-        # Re-normalize so proportions sum to 1
-        expected_pct = expected_pct / expected_pct.sum()
-        actual_pct = actual_pct / actual_pct.sum()
+        # Convert to proportions using the SAME scheme as the canonical
+        # drift_monitor.compute_psi: epsilon REPLACES zeros only, with NO
+        # re-normalisation. The previous 1e-4 + re-normalise scheme made the
+        # per-bin breakdown fail to sum to the headline psi_value (#14); the
+        # bins share the identical edges with drift_monitor, so matching the
+        # smoothing makes sum(psi_components) reconcile to psi_value.
+        eps = 1e-8
+        expected_pct = expected_counts / len(expected)
+        actual_pct = actual_counts / len(actual)
+        expected_pct = np.where(expected_pct == 0, eps, expected_pct)
+        actual_pct = np.where(actual_pct == 0, eps, actual_pct)
 
-        # PSI = sum((actual% - expected%) * ln(actual% / expected%))
-        # Route the scalar through the canonical primitive so every PSI
-        # consumer reports the same number (single source of truth, M1).
-        # The per-bin breakdown below is presentation-only.
+        # PSI = sum((actual% - expected%) * ln(actual% / expected%)). The scalar
+        # routes through the canonical primitive (single source of truth, M1);
+        # the per-bin components now use identical bins + smoothing so they SUM
+        # to it (a presentation breakdown that reconciles to the headline).
         psi_components = (actual_pct - expected_pct) * np.log(actual_pct / expected_pct)
         psi_value = drift_monitor.compute_psi(expected, actual, bins=n_bins)
 

--- a/backend/apps/ml_engine/services/training/feature_selection.py
+++ b/backend/apps/ml_engine/services/training/feature_selection.py
@@ -63,7 +63,7 @@ def compute_woe_iv(df, feature, target, bins=10):
     return {"feature": feature, "iv": round(iv, 4), "woe_table": grouped}
 
 
-def select_features_by_iv(df, features, target, iv_min=0.02, iv_max=0.5, bins=10):
+def select_features_by_iv(df, features, target, iv_min=0.02, iv_max=0.5, bins=10, leakage_warn_threshold=0.5):
     """Select features based on Information Value thresholds.
 
     Args:
@@ -94,6 +94,15 @@ def select_features_by_iv(df, features, target, iv_min=0.02, iv_max=0.5, bins=10
     excluded_weak = iv_table[iv_table["iv"] < iv_min]["feature"].tolist()
     excluded_leakage = iv_table[iv_table["iv"] > iv_max]["feature"].tolist()
 
+    # Honest leakage signal at the INDUSTRY-STANDARD threshold (0.5), separate
+    # from the (deliberately higher) iv_max used for actual exclusion. These
+    # features are KEPT but flagged: IV above the standard "suspiciously strong /
+    # possible leakage" line yet at/below iv_max. On synthetic data this is
+    # expected for core credit features the generator uses directly — surfacing
+    # it keeps the leakage picture honest, rather than letting a rarely-triggered
+    # excluded_leakage count imply leakage was screened at 0.5 when iv_max is 1.5.
+    elevated_iv = iv_table[(iv_table["iv"] > leakage_warn_threshold) & (iv_table["iv"] <= iv_max)]["feature"].tolist()
+
     if excluded_weak:
         logger.info("Excluded %d weak features (IV < %.2f): %s", len(excluded_weak), iv_min, excluded_weak[:5])
     if excluded_leakage:
@@ -104,11 +113,20 @@ def select_features_by_iv(df, features, target, iv_min=0.02, iv_max=0.5, bins=10
             excluded_leakage,
         )
 
+    if elevated_iv:
+        logger.info(
+            "Elevated-IV features KEPT but flagged (IV in (%.2f, %.2f]): %s",
+            leakage_warn_threshold,
+            iv_max,
+            elevated_iv,
+        )
+
     logger.info("IV feature selection: %d/%d features selected", len(selected), len(features))
 
     return {
         "selected_features": selected,
         "excluded_weak": excluded_weak,
         "excluded_leakage": excluded_leakage,
+        "elevated_iv": elevated_iv,
         "iv_table": iv_table,
     }

--- a/backend/apps/ml_engine/services/training/trainer.py
+++ b/backend/apps/ml_engine/services/training/trainer.py
@@ -767,11 +767,16 @@ class ModelTrainer:
                 {g: round(w, 3) for g, w in weight_map.items()},
             )
 
-        # Snapshot y_train length BEFORE reject-inference augmentation so the
-        # temporal CV alignment check (below) can compare against the pre-augmented
-        # size. After augmentation len(y_train) grows, which would cause the check
-        # to always fail and silently skip temporal CV.
+        # Snapshot the length AND the pre-augmentation X_train/y_train BEFORE
+        # reject-inference augmentation. RI (below) REASSIGNS X_train/y_train to a
+        # larger concatenated set; the temporal CV further down aligns row-for-row
+        # with train_quarters_snapshot (the original split), so it must run on
+        # these pre-RI copies. Running it on the augmented set misaligns against
+        # the snapshot and the diagnostic gets silently skipped/failed whenever
+        # reject inference runs (#8).
         _y_train_pre_ri_len = len(y_train)
+        _X_train_pre_ri = X_train
+        _y_train_pre_ri = y_train
 
         # ------------------------------------------------------------------
         # Reject-inference-aware training: include denied applications at
@@ -887,14 +892,16 @@ class ModelTrainer:
         temporal_cv_auc_mean = None
         temporal_cv_folds_used = 0
         cv_drift_signal = None
-        # Align the quarter snapshot to the current X_train rows. Reject-inference
-        # augmentation (below) happens AFTER this block for the XGB path, so we
-        # run the temporal CV on pre-augmented indices; but X_train may still
-        # have been trimmed by preprocessing earlier, so guard on length.
+        # Align the quarter snapshot to the PRE-reject-inference split. RI
+        # augmentation above reassigned X_train/y_train to a larger set, but the
+        # snapshot is row-aligned only to the original split — so temporal CV runs
+        # on the pre-RI copies (#8: previously it used the augmented X_train and
+        # was silently skipped/failed whenever RI ran). Guard on length in case
+        # preprocessing trimmed rows before the snapshot.
         if train_quarters_snapshot is not None and len(train_quarters_snapshot) == _y_train_pre_ri_len:
             try:
                 temporal_cv_auc_mean, temporal_cv_folds_used = self._compute_temporal_cv_auc(
-                    X_train, y_train, train_quarters_snapshot
+                    _X_train_pre_ri, _y_train_pre_ri, train_quarters_snapshot
                 )
                 if temporal_cv_auc_mean is not None:
                     cv_drift_signal = round(cv_mean - temporal_cv_auc_mean, 4)
@@ -1041,6 +1048,9 @@ class ModelTrainer:
             "iv_features_selected": len(getattr(self, "_iv_result", {}).get("selected_features", [])),
             "iv_features_excluded_weak": len(getattr(self, "_iv_result", {}).get("excluded_weak", [])),
             "iv_features_excluded_leakage": len(getattr(self, "_iv_result", {}).get("excluded_leakage", [])),
+            # Kept-but-flagged: IV above the standard 0.5 leakage line but <= the
+            # (higher) iv_max used for exclusion — the honest leakage signal (#13).
+            "iv_features_elevated": len(getattr(self, "_iv_result", {}).get("elevated_iv", [])),
             # Per-feature PSI (test vs train) — consumed by model_selector._max_psi,
             # the MRM dossier, and mrm_compliance._compliance_status via training_metadata.
             "psi_by_feature": metrics.get("psi_by_feature", {}),

--- a/backend/apps/ml_engine/tests/test_psi_iv_honesty.py
+++ b/backend/apps/ml_engine/tests/test_psi_iv_honesty.py
@@ -1,0 +1,53 @@
+"""Honesty/diagnostic guards for review #14 (PSI bin reconciliation) and
+#13 (elevated-IV leakage signal). Pure unit tests — no DB."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from apps.ml_engine.services.metrics import MetricsService
+from apps.ml_engine.services.training.feature_selection import select_features_by_iv
+
+
+def test_psi_bin_components_reconcile_to_headline():
+    """#14: the per-bin PSI breakdown must SUM to the headline PSI. Previously
+    the bins used a 1e-4 + re-normalise scheme while the headline used the
+    canonical drift_monitor primitive (1e-8, no re-normalise), so they diverged."""
+    rng = np.random.default_rng(7)
+    expected = rng.normal(0.0, 1.0, 2000)
+    actual = rng.normal(0.6, 1.3, 2000)  # shifted + wider → non-trivial PSI
+
+    result = MetricsService().compute_psi(expected, actual, n_bins=10)
+
+    assert result["bins"], "expected a per-bin breakdown"
+    component_sum = sum(b["psi_component"] for b in result["bins"])
+    assert abs(component_sum - result["psi"]) < 1e-3, (
+        f"per-bin components ({component_sum:.6f}) must reconcile to the headline PSI ({result['psi']:.6f})"
+    )
+
+
+def test_elevated_iv_features_are_flagged_but_kept():
+    """#13: features with IV above the standard 0.5 leakage line but at/below the
+    (higher) iv_max are KEPT, and reported in `elevated_iv` as an honest leakage
+    signal — never silently dropped, never conflated with the rare excluded set."""
+    rng = np.random.default_rng(42)
+    n = 600
+    target = np.array([0, 1] * (n // 2))
+    df = pd.DataFrame(
+        {
+            "approved": target,
+            "predictive": target * 2.0 + rng.normal(0, 1.0, n),
+            "noise": rng.normal(0, 1, n),
+        }
+    )
+
+    result = select_features_by_iv(df, ["predictive", "noise"], target="approved", iv_min=0.02, iv_max=1.5)
+
+    assert "elevated_iv" in result, "the elevated-IV honest leakage signal must be reported"
+    # Whatever lands in elevated_iv is KEPT (flagged, not excluded).
+    for feat in result["elevated_iv"]:
+        assert feat in result["selected_features"], f"{feat} flagged elevated but not kept"
+        assert feat not in result["excluded_leakage"], f"{feat} both elevated and excluded"
+    # And elevated is strictly the (0.5, iv_max] band — disjoint from the weak set.
+    assert set(result["elevated_iv"]).isdisjoint(result["excluded_weak"])

--- a/backend/config/logging_filters.py
+++ b/backend/config/logging_filters.py
@@ -38,10 +38,13 @@ class PiiMaskingFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         record.msg = self._redact(str(record.msg))
         if record.args:
+            # Redact ONLY string args — coercing numbers to str (the old
+            # behaviour) corrupted them so a "%d"/"%f" format string then raised
+            # TypeError at emit time. PII only ever appears in string args.
             if isinstance(record.args, dict):
-                record.args = {k: self._redact(str(v)) for k, v in record.args.items()}
+                record.args = {k: (self._redact(v) if isinstance(v, str) else v) for k, v in record.args.items()}
             elif isinstance(record.args, tuple):
-                record.args = tuple(self._redact(str(a)) for a in record.args)
+                record.args = tuple(self._redact(a) if isinstance(a, str) else a for a in record.args)
         # Structured-logging extras land as custom record attributes; redact any
         # string-valued ones without disturbing the standard LogRecord fields.
         for key, value in list(record.__dict__.items()):

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -15,6 +15,36 @@ APP_VERSION = "1.11.1"
 
 DEBUG = os.environ.get("DJANGO_DEBUG", "False").lower() in ("true", "1", "yes")
 
+
+def _env_int(name: str, default: int) -> int:
+    """Read an int env var, tolerant of a malformed value (warn + fall back)
+    rather than crashing every process with a ValueError at import time."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        import warnings
+
+        warnings.warn(f"Invalid integer for {name}={raw!r}; using default {default}.", stacklevel=2)
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    """float counterpart of _env_int — tolerant of malformed values."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        import warnings
+
+        warnings.warn(f"Invalid float for {name}={raw!r}; using default {default}.", stacklevel=2)
+        return default
+
+
 _secret_key = os.environ.get("DJANGO_SECRET_KEY", "")
 if not _secret_key and not DEBUG:
     raise ValueError(
@@ -260,7 +290,7 @@ ML_XGB_N_JOBS = 2
 # Rows the training task auto-generates when .tmp/synthetic_loans.csv is missing
 # (fresh clone / cleared .tmp). Smaller than the 50k canonical seed so the
 # self-heal stays fast while still producing a usable model. Env-overridable.
-ML_AUTO_SEED_ROWS = int(os.environ.get("ML_AUTO_SEED_ROWS", "20000"))
+ML_AUTO_SEED_ROWS = _env_int("ML_AUTO_SEED_ROWS", 20000)
 
 # Hard credit policy overlay (D3). Modes: "off" (not applied), "shadow"
 # (evaluated + logged, model verdict stands), "enforce" (hard-fails override
@@ -319,7 +349,7 @@ DECISION_REVIEW_ENABLED = os.environ.get("DECISION_REVIEW_ENABLED", "true").lowe
 # "second_approver" blocks such overturns at the API pending dual approval.
 # Unknown values collapse to "off" (see overturn_policy.normalize_overturn_mode).
 DECISION_OVERTURN_GATE_MODE = os.environ.get("DECISION_OVERTURN_GATE_MODE", "off")
-DECISION_OVERTURN_THRESHOLD = float(os.environ.get("DECISION_OVERTURN_THRESHOLD", "100000"))
+DECISION_OVERTURN_THRESHOLD = _env_float("DECISION_OVERTURN_THRESHOLD", 100000)
 
 # Standalone single-application prediction endpoint (/ml/predict/<id>/).
 # The agent orchestrator is the production decision path; the standalone task
@@ -388,7 +418,7 @@ if not FIELD_ENCRYPTION_KEY and not DEBUG:
 # See docs/superpowers/specs/2026-05-25-security-gap-closure-design.md.
 KMS_BACKEND = os.environ.get("KMS_BACKEND", "env").lower()
 AWS_KMS_KEY_ID = os.environ.get("AWS_KMS_KEY_ID", "")
-KMS_DEK_TTL = int(os.environ.get("KMS_DEK_TTL", "3600"))
+KMS_DEK_TTL = _env_int("KMS_DEK_TTL", 3600)
 
 # Email — use Gmail SMTP when credentials are set, otherwise log to console
 EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")
@@ -398,13 +428,13 @@ if EMAIL_HOST_USER and EMAIL_HOST_PASSWORD:
 else:
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 EMAIL_HOST = os.environ.get("EMAIL_HOST", "smtp.gmail.com")
-EMAIL_PORT = int(os.environ.get("EMAIL_PORT", 587))
+EMAIL_PORT = _env_int("EMAIL_PORT", 587)
 EMAIL_USE_TLS = True
 DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "aussieloanai@gmail.com")
 
 # AI Budget Controls
-AI_DAILY_CALL_LIMIT = int(os.environ.get("AI_DAILY_CALL_LIMIT", "500"))
-AI_DAILY_BUDGET_LIMIT_USD = float(os.environ.get("AI_DAILY_BUDGET_LIMIT_USD", "5.0"))
+AI_DAILY_CALL_LIMIT = _env_int("AI_DAILY_CALL_LIMIT", 500)
+AI_DAILY_BUDGET_LIMIT_USD = _env_float("AI_DAILY_BUDGET_LIMIT_USD", 5.0)
 AI_CIRCUIT_BREAKER_THRESHOLD = 3  # consecutive failures before circuit opens
 AI_CIRCUIT_BREAKER_COOLDOWN = 600  # seconds to keep circuit open (10 min)
 
@@ -422,7 +452,7 @@ AI_TEMPERATURE_MARKETING = 0.2  # Marketing/retention content (slight variance f
 # these from the environment directly; declared here for documentation + audit.
 EMAIL_LLM_BACKEND = os.environ.get("EMAIL_LLM_BACKEND", "anthropic")
 EMAIL_LLM_MODEL = os.environ.get("EMAIL_LLM_MODEL", "")  # blank -> backend default
-EMAIL_LLM_SEED = int(os.environ.get("EMAIL_LLM_SEED", "0"))  # reproducibility (Groq best-effort)
+EMAIL_LLM_SEED = _env_int("EMAIL_LLM_SEED", 0)  # reproducibility (Groq best-effort)
 GROQ_API_KEY = os.environ.get("GROQ_API_KEY", "")
 GROQ_BASE_URL = os.environ.get("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 
@@ -488,6 +518,33 @@ if _sentry_dsn:
         send_default_pii=False,
         environment=os.environ.get("SENTRY_ENVIRONMENT", "development"),
     )
+
+# Logging — wire the PII masking filter on the console in BASE settings so
+# development and Docker (which inherit these) also redact PII from logs, not
+# just production. production.py overrides LOGGING with its JSON/correlation-id
+# variant (which also installs mask_pii). disable_existing_loggers=False keeps
+# third-party + pytest log capture intact.
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "standard": {"format": "{levelname} {asctime} {name} {message}", "style": "{"},
+    },
+    "filters": {
+        "mask_pii": {"()": "config.logging_filters.PiiMaskingFilter"},
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "standard",
+            "filters": ["mask_pii"],
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": os.environ.get("LOG_LEVEL", "INFO"),
+    },
+}
 
 # Validate environment variables on startup (fail fast if required vars are missing).
 # Skipped during tests and when SKIP_ENV_VALIDATION=1.

--- a/backend/tests/test_celery_integration.py
+++ b/backend/tests/test_celery_integration.py
@@ -14,6 +14,22 @@ import pytest
 from tests.conftest import skip_without_redis
 
 
+def _assert_payload_json_serializable(args=(), kwargs=None):
+    """Genuinely exercise the broker serialization that ``.apply()`` SKIPS.
+
+    ``.apply()`` runs a task eagerly and hands it the live Python objects
+    in-process — it does NOT serialise, so on its own it never proves the
+    payload would survive a real broker hop. Round-trip the (args, kwargs)
+    through Celery's configured JSON serializer to prove that explicitly.
+    """
+    from kombu.serialization import dumps, loads
+
+    kwargs = kwargs or {}
+    content_type, content_encoding, data = dumps([list(args), kwargs], serializer="json")
+    restored = loads(data, content_type, content_encoding)
+    assert restored == [list(args), kwargs], "task payload is not JSON-serialisable for the broker"
+
+
 @skip_without_redis
 @pytest.mark.django_db(transaction=True)
 class TestCeleryTaskExecution:
@@ -35,8 +51,9 @@ class TestCeleryTaskExecution:
                 "processing_time_ms": 100,
                 "model_version": "test-v1",
             }
-            # Use .apply() to execute synchronously but still go through
-            # the full serialization path (args must be JSON-serializable).
+            # Prove the payload is broker-serialisable (the part .apply() skips),
+            # then .apply() to exercise the eager execution path past the DB lookup.
+            _assert_payload_json_serializable(args=[999])
             result = run_prediction_task.apply(args=[999])
 
         # Task must have actually executed past serialisation and hit the DB.
@@ -52,7 +69,8 @@ class TestCeleryTaskExecution:
         from apps.email_engine.tasks import generate_email_task
         from apps.loans.models import LoanApplication
 
-        # apply() runs synchronously but exercises serialization.
+        # .apply() runs eagerly (no serialisation); prove serialisability explicitly.
+        _assert_payload_json_serializable(args=[999, "approved"])
         result = generate_email_task.apply(args=[999, "approved"])
 
         assert result.failed(), "Task must actually execute (not just be constructed)"
@@ -66,8 +84,9 @@ class TestCeleryTaskExecution:
         from apps.agents.tasks import orchestrate_pipeline_task
         from apps.loans.models import LoanApplication
 
-        # apply() runs synchronously and exercises serialization. The task
-        # itself will fail inside on DB lookup (app_id=999 doesn't exist).
+        # .apply() runs eagerly (no serialisation); prove serialisability explicitly.
+        # The task then fails inside on the DB lookup (app_id=999 doesn't exist).
+        _assert_payload_json_serializable(args=[999])
         result = orchestrate_pipeline_task.apply(args=[999])
 
         assert result.failed(), "Task must actually execute (not just be constructed)"
@@ -100,9 +119,12 @@ class TestCeleryTaskExecution:
 
         from apps.ml_engine.tasks import train_model_task
 
-        # apply() exercises full serialization; the task will fail inside trainer
-        # logic (missing csv) — we're testing the transport layer. Make the body
-        # deterministic regardless of environment:
+        # Prove the kwargs survive the broker's JSON serializer — .apply() below
+        # runs eagerly and does NOT serialise, so this is the real transport check.
+        _assert_payload_json_serializable(kwargs={"algorithm": "xgb", "data_path": "/tmp/nonexistent.csv"})
+
+        # .apply() then exercises eager execution; the task fails inside the trainer
+        # (missing csv). Make the body deterministic regardless of environment:
         #  - mock the Redis train lock so a real concurrent training run can't
         #    short-circuit the task to "skipped" (lock contention),
         #  - no-op the self-heal guard so the missing path stays missing and the
@@ -133,6 +155,9 @@ class TestCeleryTaskExecution:
         from apps.agents.models import AgentRun
         from apps.agents.tasks import resume_pipeline_task
 
+        _assert_payload_json_serializable(
+            args=[999], kwargs={"reviewer": "test-officer", "note": "Approved after manual review"}
+        )
         result = resume_pipeline_task.apply(
             args=[999],
             kwargs={

--- a/backend/tests/test_pii_logging_filter.py
+++ b/backend/tests/test_pii_logging_filter.py
@@ -68,3 +68,18 @@ class TestExtrasRedaction:
 
 def test_email_still_redacted():
     assert "[EMAIL_REDACTED]" in _redact("contact applicant@example.com")
+
+
+def test_numeric_log_args_are_not_corrupted():
+    # The filter must NOT coerce numeric args to strings — doing so makes a
+    # "%d"/"%f" format string raise TypeError at emit time. (Regression guard for
+    # the dev-logging wiring that surfaced this; PII only appears in string args.)
+    record = logging.LogRecord("svc", logging.INFO, "/p", 1, "Excluded %d weak features (IV < %.2f)", (19, 0.02), None)
+    PiiMaskingFilter().filter(record)
+    assert record.getMessage() == "Excluded 19 weak features (IV < 0.02)"
+
+
+def test_string_args_are_still_redacted():
+    record = logging.LogRecord("svc", logging.INFO, "/p", 1, "applicant %s", ("0412 345 678",), None)
+    PiiMaskingFilter().filter(record)
+    assert "[PHONE_REDACTED]" in record.getMessage()

--- a/backend/tests/test_trainer_pipeline.py
+++ b/backend/tests/test_trainer_pipeline.py
@@ -193,6 +193,40 @@ class TestTrainerPipeline:
         finally:
             os.unlink(tmp.name)
 
+    def test_temporal_cv_runs_under_reject_inference(self, small_dataset):
+        """#8: temporal CV must run on the PRE-reject-inference split. RI
+        augmentation grows X_train past the quarter-snapshot length; before the
+        fix the alignment check failed and temporal CV was silently skipped
+        whenever RI ran. When RI actually augments here, temporal CV must still
+        produce a real AUC (this dataset uses a temporal split)."""
+        df, reject_labels = small_dataset
+        if reject_labels is None or reject_labels.dropna().empty:
+            pytest.skip("No reject inference labels available for this dataset")
+
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False, newline="")
+        df.to_csv(tmp.name, index=False)
+        tmp.close()
+        try:
+            trainer = ModelTrainer()
+            try:
+                _model, metrics = trainer.train(
+                    tmp.name,
+                    algorithm="rf",
+                    use_reject_inference=True,
+                    reject_inference_labels=reject_labels,
+                )
+            except KeyError:
+                pytest.skip("RI transform KeyError: categorical columns already encoded")
+
+            meta = metrics.get("training_metadata", {})
+            assert "temporal_cv_auc_mean" in meta
+            assert meta["temporal_cv_auc_mean"] is not None, (
+                "temporal CV was skipped under reject inference — the pre-RI alignment fix (#8) regressed"
+            )
+            assert 0.0 < meta["temporal_cv_auc_mean"] <= 1.0
+        finally:
+            os.unlink(tmp.name)
+
     def test_monotonic_constraints_defined_for_all_features(self):
         """If the trainer defines monotonic constraints, they should cover all features."""
         trainer = ModelTrainer()

--- a/tools/file_size_allowlist.json
+++ b/tools/file_size_allowlist.json
@@ -6,9 +6,9 @@
       "files": {
         "datagen/data_generator.py": 1490,
         "datagen/underwriting_engine.py": 974,
-        "training/trainer.py": 1405,
+        "training/trainer.py": 1415,
         "governance/calibration_validator.py": 536,
-        "metrics/compute.py": 1050,
+        "metrics/compute.py": 1053,
         "metrics/real_world_benchmarks.py": 1378,
         "external/property_data.py": 765,
         "external/macro_data.py": 579,


### PR DESCRIPTION
**PR 5 (final)** of the codebase-review campaign — the remaining LOW findings. All are **honesty/diagnostic/hardening** changes; none alters the model's decisions or gate behaviour.

### Ops / config
- **#18** — malformed numeric env vars (`ML_AUTO_SEED_ROWS`, `KMS_DEK_TTL`, `EMAIL_PORT`, `AI_DAILY_*`, `DECISION_OVERTURN_THRESHOLD`, `EMAIL_LLM_SEED`) crashed every process at import. New `_env_int`/`_env_float` helpers warn + fall back.
- **#15** — `PiiMaskingFilter` was wired only in production logging; dev/Docker logged PII unmasked. Added a base `LOGGING` config (inherited by dev) that installs `mask_pii`; production keeps its JSON override.
  - **Latent bug fixed (exposed by #15):** the filter coerced *numeric* log args to `str`, so a `%d`/`%f` format string raised `TypeError` at emit time (silently swallowed in prod, surfaced once wired into tests). Now redacts only string args.

### ML-internal honesty (reporting/diagnostics only — model unchanged)
- **#14** — the PSI per-bin breakdown used a different epsilon/normalisation than the canonical headline PSI, so the bins didn't sum to it. Aligned to `drift_monitor`'s scheme → the breakdown reconciles.
- **#13** — the IV leakage detector runs at a deliberately high `iv_max=1.5` (core synthetic features legitimately exceed 0.5), so the reported `excluded_leakage` count rarely fired and misleadingly implied screening at 0.5. Now also reports `elevated_iv` — features in `(0.5, iv_max]` that are **kept but flagged** — an honest standard-threshold leakage signal. Selection is unchanged.
- **#8** — temporal CV (a diagnostic) was silently skipped whenever reject inference ran (RI augmentation grew `X_train` past the quarter snapshot). Now runs on pre-RI copies.

### Test honesty
- **#20/#21** — the celery "serializes" tests used `.apply()` (eager, no serialisation) yet claimed to test the transport layer. Added a genuine kombu JSON round-trip assertion to each + corrected the comments.

## Tests
New `test_psi_iv_honesty.py` (PSI reconciliation, elevated-IV); `test_temporal_cv_runs_under_reject_inference`; numeric-arg + string-redaction filter guards; round-trip assertions on the 5 serialisation tests. **Host-verified:** PSI/IV/temporal-CV/filter + a 39-test non-DB sanity run, all green. Celery DB tests + full suite run in CI. trainer.py cap 1405→1415, compute.py 1050→1053 (honesty instrumentation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)