### PR TITLE
feat(email_engine): add free local Ollama email backend (OpenAI-compatible)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,16 +26,26 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 
 # Email LLM backend — who writes the approval/denial emails.
 #   anthropic (default) = paid Claude API.
-#   groq                = FREE, OpenAI-compatible Groq. Chosen because its free
-#                         tier does not train on prompts (see ADR 010).
-# The lending decision is deterministic ML either way; a missing key degrades
-# cleanly to the deterministic template fallback. Get a free key at
-# https://console.groq.com/keys
+#   groq                = FREE, OpenAI-compatible Groq (hosted). Free tier does
+#                         not train on prompts, but its 6k tokens/min cap is too
+#                         small for the ~9k-token compliance emails (see ADR 010).
+#   ollama              = FREE, LOCAL Ollama — no per-minute cap (fits the big
+#                         emails), runs offline, nothing leaves the host. Needs
+#                         the `ollama` compose service (docker compose up ollama
+#                         ollama-init). Slow on CPU (~20-60s/email).
+# The lending decision is deterministic ML either way; a missing key / unreachable
+# backend degrades cleanly to the deterministic template fallback.
+# Groq free key: https://console.groq.com/keys
 EMAIL_LLM_BACKEND=anthropic
 EMAIL_LLM_MODEL=
 EMAIL_LLM_SEED=0
 GROQ_API_KEY=gsk-your-key-here
 GROQ_BASE_URL=https://api.groq.com/openai/v1
+# Local Ollama (only used when EMAIL_LLM_BACKEND=ollama). Defaults work with the
+# compose `ollama` service; OLLAMA_API_KEY is a dummy (Ollama ignores auth).
+OLLAMA_BASE_URL=http://ollama:11434/v1
+OLLAMA_MODEL=
+OLLAMA_API_KEY=ollama
 
 # Security
 FIELD_ENCRYPTION_KEY=change-me-generate-with-python-c-from-cryptography.fernet-import-Fernet-print-Fernet.generate_key

--- a/backend/apps/agents/services/api_budget.py
+++ b/backend/apps/agents/services/api_budget.py
@@ -44,10 +44,23 @@ MODEL_PRICING = {
     # reserves the per-call floor and counts the call against the daily call
     # limit, but no dollar spend accrues.
     "llama-3.1-8b-instant": {"input": 0.00, "output": 0.00},
+    # Free LOCAL Ollama backend — $0/token (runs on-prem, no API billing).
+    # "loan-email" is our 16k-context Modelfile build; the rest are common
+    # Ollama tags. Add a row here if you deploy a different OLLAMA_MODEL, else it
+    # falls back to Sonnet pricing and would wrongly accrue spend.
+    "loan-email": {"input": 0.00, "output": 0.00},
+    "qwen2.5:7b": {"input": 0.00, "output": 0.00},
+    "llama3.2:3b": {"input": 0.00, "output": 0.00},
+    "llama3.1:8b": {"input": 0.00, "output": 0.00},
 }
 
 # Fallback: assume Sonnet pricing for unknown models
 _DEFAULT_PRICING = {"input": 3.00, "output": 15.00}
+
+# Where each provider physically processes the prompt — drives the APICallLog
+# cross-border (Privacy Act APP 8) record. Local Ollama runs on-prem in
+# Australia, so it is NOT a cross-border disclosure; hosted providers are US.
+_PROVIDER_DESTINATION = {"anthropic": "US", "groq": "US", "ollama": "AU"}
 
 
 def estimate_cost_usd(input_tokens, output_tokens, model=""):
@@ -494,17 +507,18 @@ def guarded_api_call(client, **kwargs):
         from apps.agents.models import APICallLog
 
         prompt_text = _extract_prompt_text(kwargs)
+        provider = getattr(client, "provider", "anthropic")
         APICallLog.objects.create(
             loan_application_id=loan_application_id,
             agent_run_id=agent_run_id,
             service=service,
-            provider=getattr(client, "provider", "anthropic"),
+            provider=provider,
             model_used=model,
             pii_categories=_detect_pii_categories(prompt_text),
             prompt_hash=hashlib.sha256(prompt_text.encode()).hexdigest(),
             input_tokens=input_tokens,
             output_tokens=output_tokens,
-            destination_country="US",
+            destination_country=_PROVIDER_DESTINATION.get(provider, "US"),
         )
     except Exception as e:
         logger.warning("Failed to create APICallLog: %s", e)

--- a/backend/apps/email_engine/services/email_generator.py
+++ b/backend/apps/email_engine/services/email_generator.py
@@ -105,6 +105,33 @@ class EmailGenerator:
             )
             return client, "groq", model
 
+        if backend == "ollama":
+            from .llm_client import DEFAULT_OLLAMA_BASE_URL, DEFAULT_OLLAMA_MODEL, OpenAICompatibleLLMClient
+
+            model = configured_model or DEFAULT_OLLAMA_MODEL
+            # Ollama's /v1 ignores the bearer header, so a dummy default key means
+            # the client is always built (local inference needs no secret). An
+            # unreachable local server is handled at RUNTIME — httpx.ConnectError
+            # -> EmailBackendError -> deterministic template fallback — not by
+            # nulling the client here.
+            api_key = os.environ.get("OLLAMA_API_KEY", "ollama")
+            try:
+                seed = int(os.environ.get("EMAIL_LLM_SEED", "0") or "0")
+            except ValueError:
+                seed = 0
+            client = OpenAICompatibleLLMClient(
+                api_key=api_key,
+                base_url=os.environ.get("OLLAMA_BASE_URL", DEFAULT_OLLAMA_BASE_URL),
+                model=model,
+                seed=seed,
+                # Local CPU inference of a ~9k-token prompt can take tens of
+                # seconds; allow a long read timeout so a slow (not failed)
+                # generation isn't mistaken for an outage and bounced to template.
+                timeout=httpx.Timeout(180.0, connect=10.0),
+                provider="ollama",
+            )
+            return client, "ollama", model
+
         # Default: Anthropic Claude (unchanged behaviour).
         model = configured_model or "claude-sonnet-4-6"
         api_key = os.environ.get("ANTHROPIC_API_KEY", "")

--- a/backend/apps/email_engine/services/llm_client.py
+++ b/backend/apps/email_engine/services/llm_client.py
@@ -1,12 +1,18 @@
-"""Provider adapter for a free, OpenAI-compatible LLM email backend (Groq).
+"""Provider adapter for OpenAI-compatible LLM email backends (Groq, Ollama).
 
 Why this exists
 ---------------
 Decision emails are written by an LLM, but the lending *decision* itself is
 deterministic ML — so the email writer is a low-stakes, swappable component.
-This adapter lets the email path run on a **free** Groq model instead of the
-paid Claude API, without touching the budget guard, the guardrail battery, or
-the deterministic template fallback.
+This adapter lets the email path run on any OpenAI-/chat-completions-compatible
+endpoint instead of the paid Claude API:
+
+  * **Groq** — a free hosted tier (no per-token cost), or
+  * **Ollama** — a free, *local/on-prem* model (no per-minute token cap, and no
+    data leaves the host — see ADR 010),
+
+without touching the budget guard, the guardrail battery, or the deterministic
+template fallback.
 
 It deliberately duck-types ``anthropic.Anthropic`` so the single call site in
 ``api_budget.guarded_api_call`` (``client.messages.create(**kwargs)``) and the
@@ -21,12 +27,20 @@ structural change. The adapter:
     caller reads (``.content[].type/.input/.text``, ``.usage.input_tokens/
     output_tokens``, ``.stop_reason``),
   * raises ``anthropic.RateLimitError`` on HTTP 429 so the existing retry seam
-    in ``EmailGenerator`` is reused unchanged.
+    in ``EmailGenerator`` is reused unchanged,
+  * raises ``EmailBackendError`` on 4xx/5xx/transport failures so the caller
+    degrades to the deterministic template.
 
-Data-safety note: Groq's free tier does not train on prompts, the email prompt
-carries only anonymised feature summaries (no raw PII — see
-docs/compliance/australia.md), and the whole system runs on synthetic data.
-See backend/docs/adr/010-groq-free-email-backend-data-safety.md.
+Ollama notes (see ADR 010 + the research that drove this):
+  * Ollama's OpenAI ``/v1`` endpoint *ignores* forced ``tool_choice``, so a
+    small local model may answer in plain text. The adapter already emits a text
+    block alongside any tool block, so ``_parse_tool_response``'s text fallback
+    covers it; if that fails, guardrails + the template fallback are the floor.
+  * Ollama's ``/v1`` endpoint also ignores a per-request context window, so the
+    ~9k-token compliance prompt must be served by a model whose context window
+    is baked in (a Modelfile ``PARAMETER num_ctx 16384`` — done in the compose
+    ``ollama-init`` step, exposed as the ``loan-email`` model). Nothing extra is
+    sent in the payload for that reason.
 """
 
 import json
@@ -41,6 +55,11 @@ logger = logging.getLogger("email_engine.llm_client")
 
 DEFAULT_GROQ_BASE_URL = "https://api.groq.com/openai/v1"
 DEFAULT_GROQ_MODEL = "llama-3.1-8b-instant"
+
+# Local Ollama defaults. ``loan-email`` is the custom model baked with a 16k
+# context window (Modelfile) by the compose ``ollama-init`` service.
+DEFAULT_OLLAMA_BASE_URL = "http://ollama:11434/v1"
+DEFAULT_OLLAMA_MODEL = "loan-email"
 
 
 class _Block:
@@ -108,23 +127,34 @@ def _map_finish_reason(finish_reason):
     return finish_reason
 
 
-class GroqLLMClient:
-    """Minimal OpenAI-compatible client for Groq, duck-typed as anthropic.Anthropic.
+class OpenAICompatibleLLMClient:
+    """Minimal OpenAI-compatible chat client, duck-typed as anthropic.Anthropic.
 
-    Only the surface ``EmailGenerator`` + ``guarded_api_call`` actually use is
-    implemented: ``.messages.create(**anthropic_shaped_kwargs)`` returning an
-    object exposing ``.content`` / ``.usage`` / ``.stop_reason``.
+    Works against any OpenAI-/chat-completions-compatible endpoint (Groq's free
+    hosted tier or a local Ollama server). Only the surface ``EmailGenerator`` +
+    ``guarded_api_call`` actually use is implemented:
+    ``.messages.create(**anthropic_shaped_kwargs)`` returning an object exposing
+    ``.content`` / ``.usage`` / ``.stop_reason``.
+
+    ``provider`` is recorded on each APICallLog (Privacy Act APP 8 audit) — e.g.
+    ``"groq"`` / ``"ollama"`` — and drives the logged destination country.
     """
 
-    #: Recorded on each APICallLog for Privacy Act APP 8 cross-border audit.
-    provider = "groq"
-
-    def __init__(self, api_key, base_url=DEFAULT_GROQ_BASE_URL, model=DEFAULT_GROQ_MODEL, seed=0, timeout=None):
+    def __init__(
+        self,
+        api_key,
+        base_url=DEFAULT_GROQ_BASE_URL,
+        model=DEFAULT_GROQ_MODEL,
+        seed=0,
+        timeout=None,
+        provider="groq",
+    ):
         self._api_key = api_key
         self._base_url = (base_url or DEFAULT_GROQ_BASE_URL).rstrip("/")
         self._default_model = model or DEFAULT_GROQ_MODEL
         self._seed = seed
         self._http = httpx.Client(timeout=timeout or httpx.Timeout(60.0, connect=10.0))
+        self.provider = provider
         self.messages = _Messages(self)
 
     # -- internal -----------------------------------------------------------
@@ -141,16 +171,17 @@ class GroqLLMClient:
                 json=payload,
             )
         except httpx.HTTPError as exc:
-            # Transport-level failure — surface as a backend error so the caller
-            # degrades to the deterministic template instead of crashing.
-            raise EmailBackendError(f"Groq request failed: {exc}") from exc
+            # Transport-level failure (e.g. a local Ollama server that isn't up)
+            # — surface as a backend error so the caller degrades to the
+            # deterministic template instead of crashing.
+            raise EmailBackendError(f"{self.provider} request failed: {exc}") from exc
 
         if resp.status_code == 429:
             raise self._rate_limit_error(resp)
         if resp.status_code >= 400:
             # 4xx (e.g. 413 request-too-large on a small free tier) / 5xx →
             # degrade to the template rather than hard-error.
-            raise EmailBackendError(f"Groq API error {resp.status_code}: {resp.text[:300]}")
+            raise EmailBackendError(f"{self.provider} API error {resp.status_code}: {resp.text[:300]}")
 
         return self._normalise(resp.json())
 
@@ -158,8 +189,8 @@ class GroqLLMClient:
         payload = {
             "model": kwargs.get("model") or self._default_model,
             "messages": kwargs.get("messages", []),
-            # AI_TEMPERATURE_DECISION_EMAIL is 0.0; seed makes Groq best-effort
-            # reproducible for the same prompt.
+            # AI_TEMPERATURE_DECISION_EMAIL is 0.0; seed makes the model
+            # best-effort reproducible for the same prompt.
             "temperature": kwargs.get("temperature", 0.0),
             "seed": self._seed,
         }
@@ -174,6 +205,8 @@ class GroqLLMClient:
         tool_choice = kwargs.get("tool_choice")
         if isinstance(tool_choice, dict) and tool_choice.get("name"):
             # Anthropic {"type":"tool","name":X} -> OpenAI forced function call.
+            # (Groq honours this; Ollama's /v1 ignores it and may answer in plain
+            # text — handled by the text block emitted in _normalise.)
             payload["tool_choice"] = {"type": "function", "function": {"name": tool_choice["name"]}}
         return payload
 
@@ -182,9 +215,9 @@ class GroqLLMClient:
         ``except anthropic.RateLimitError`` seam is reused. Falls back to a
         generic error if the SDK signature differs."""
         try:
-            return anthropic.RateLimitError("Groq API rate limited", response=resp, body=None)
+            return anthropic.RateLimitError(f"{self.provider} API rate limited", response=resp, body=None)
         except Exception:  # noqa: BLE001 — defensive against SDK signature drift
-            return RuntimeError("Groq API rate limited (429)")
+            return EmailBackendError(f"{self.provider} API rate limited (429)")
 
     def _normalise(self, data):
         """Convert an OpenAI chat-completion dict into the Anthropic-ish shape."""
@@ -201,13 +234,14 @@ class GroqLLMClient:
             try:
                 parsed = json.loads(raw_args)
             except (TypeError, ValueError):
-                logger.warning("Groq tool_call arguments were not valid JSON — relying on text fallback")
+                logger.warning("tool_call arguments were not valid JSON — relying on text fallback")
                 continue
             blocks.append(_Block(type="tool_use", input=parsed))
 
         # Always also expose any plain text so the caller's text-parse fallback
         # (EmailGenerator._parse_tool_response) can recover if the tool call was
-        # malformed or empty — smaller models are less reliable at tool use.
+        # malformed or empty — smaller / local models are less reliable at tool
+        # use, and Ollama's /v1 endpoint ignores forced tool_choice entirely.
         text = message.get("content")
         if text:
             blocks.append(_Block(type="text", text=text))
@@ -219,3 +253,9 @@ class GroqLLMClient:
         )
         stop_reason = _map_finish_reason(choice.get("finish_reason"))
         return _Response(content=blocks, usage=usage, stop_reason=stop_reason)
+
+
+# Back-compat alias: the original Groq-specific name. ``provider`` defaults to
+# "groq", so existing call sites and tests that import/patch ``GroqLLMClient``
+# keep working unchanged.
+GroqLLMClient = OpenAICompatibleLLMClient

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -417,14 +417,22 @@ AI_TEMPERATURE_MARKETING = 0.2  # Marketing/retention content (slight variance f
 #   "anthropic" (default): paid Claude API (claude-sonnet-4-6).
 #   "groq": free, OpenAI-compatible Groq (llama-3.1-8b-instant) — chosen because
 #           its free tier does NOT train on prompts. See ADR 010.
-# Either way the lending DECISION stays deterministic ML, and a missing key
-# degrades cleanly to the deterministic template fallback. EmailGenerator reads
-# these from the environment directly; declared here for documentation + audit.
+#   "ollama": free, LOCAL/on-prem Ollama — no per-minute token cap (so it fits
+#           the ~9k-token compliance prompts that overran Groq's free tier) and
+#           nothing leaves the host, so it is NOT an APP 8 cross-border
+#           disclosure. Requires the `ollama` compose service. See ADR 010.
+# Either way the lending DECISION stays deterministic ML, and a missing key /
+# unreachable backend degrades cleanly to the deterministic template fallback.
+# EmailGenerator reads these from the environment directly; declared here for
+# documentation + audit.
 EMAIL_LLM_BACKEND = os.environ.get("EMAIL_LLM_BACKEND", "anthropic")
 EMAIL_LLM_MODEL = os.environ.get("EMAIL_LLM_MODEL", "")  # blank -> backend default
-EMAIL_LLM_SEED = int(os.environ.get("EMAIL_LLM_SEED", "0"))  # reproducibility (Groq best-effort)
+EMAIL_LLM_SEED = int(os.environ.get("EMAIL_LLM_SEED", "0"))  # reproducibility (best-effort)
 GROQ_API_KEY = os.environ.get("GROQ_API_KEY", "")
 GROQ_BASE_URL = os.environ.get("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
+OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://ollama:11434/v1")
+OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "")  # blank -> backend default (loan-email)
+OLLAMA_API_KEY = os.environ.get("OLLAMA_API_KEY", "ollama")  # dummy; Ollama ignores auth
 
 # Bias detection thresholds (used by orchestrator pipeline)
 BIAS_THRESHOLD_PASS = 30  # 0-30: compliant, email can be sent

--- a/backend/docs/adr/010-pluggable-email-llm-backend-data-safety.md
+++ b/backend/docs/adr/010-pluggable-email-llm-backend-data-safety.md
@@ -79,6 +79,36 @@ grounds, not just price.
   model writes prose; it is not put in charge of the safety-critical compliance
   gate (ADR 003). That keeps the safety floor auditable and model-independent.
 
+### Update (2026-06-10): a local Ollama backend
+
+End-to-end testing of the Groq backend on a real key surfaced a hard limit:
+Groq's free tier caps at **6,000 tokens/min**, but the compliance email prompts
+are ~9k tokens (they embed the full verbatim template), so **every** email
+returned HTTP 413. Free Groq is therefore unusable for *these* prompts. A
+**local Ollama** backend was added because local inference has **no per-minute
+token cap** and the data never leaves the host.
+
+- The adapter was generalized to `OpenAICompatibleLLMClient` (with a
+  `GroqLLMClient` back-compat alias) — Groq and Ollama share one client; only
+  `base_url`, `model`, auth, and `provider` differ.
+- Selected by `EMAIL_LLM_BACKEND=ollama` (`OLLAMA_BASE_URL`, `OLLAMA_MODEL`, a
+  *dummy* `OLLAMA_API_KEY` since Ollama ignores auth). The `ollama` service is an
+  **opt-in compose profile**; if it isn't running, the email path degrades to
+  the template (a connection error → `EmailBackendError` → fallback), so the
+  default stack is unaffected.
+- **Context window:** Ollama's OpenAI `/v1` endpoint cannot set `num_ctx` per
+  request, so the 16k window is **baked into a Modelfile** (`ollama/Modelfile`,
+  built as the `loan-email` model by the `ollama-init` service). Without it, the
+  default 4k context would silently truncate the 9k prompt.
+- **Forced tool calls:** Ollama's `/v1` *ignores* `tool_choice`, so a small
+  local model may answer in plain text — covered by the adapter's text block +
+  the existing text-parse / guardrail / template-fallback chain.
+- **APP 8 correctness:** local inference is on-prem (Australia), so it is **not**
+  a cross-border disclosure. `destination_country` is now **derived per
+  provider** (`ollama` → `AU`; `anthropic`/`groq` → `US`), fixing a previously
+  hardcoded `"US"` that would have logged a false cross-border record for local
+  inference.
+
 ## Consequences
 
 ### Positive
@@ -99,6 +129,11 @@ grounds, not just price.
   bitwise — acceptable given temperature 0 and the constrained prompt.
 - Two providers' response shapes to keep in parity (mitigated by the adapter and
   its unit tests).
+- The local Ollama backend is **slow on CPU** (~20–60s per email, dominated by
+  prompt ingestion) and **heavy** (~5GB model + ~8GB-RAM container), and a small
+  local model trips the structured-output guardrails more often (→ more template
+  fallbacks). It is an opt-in capability, not the recommended default over
+  templates for a demo.
 
 ### Production note
 

--- a/backend/tests/test_api_budget_provider_audit.py
+++ b/backend/tests/test_api_budget_provider_audit.py
@@ -1,0 +1,48 @@
+"""The APICallLog cross-border (Privacy Act APP 8) record must reflect WHERE the
+prompt was actually processed, derived from the client's provider:
+
+  * hosted providers (Anthropic, Groq) are US  -> a cross-border disclosure;
+  * local Ollama runs on-prem in Australia      -> NOT a cross-border disclosure.
+
+A hardcoded "US" would manufacture a false cross-border record for local
+inference, so this pins the per-provider derivation.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.agents.services.api_budget import guarded_api_call
+
+
+def _fake_client(provider):
+    """A stub LLM client whose .messages.create returns a minimal usage-bearing
+    response, tagged with the given provider (as the real adapters expose)."""
+    client = MagicMock()
+    client.provider = provider
+    client.messages.create.return_value = SimpleNamespace(usage=SimpleNamespace(input_tokens=10, output_tokens=5))
+    return client
+
+
+@pytest.mark.django_db
+@patch("apps.agents.services.api_budget.ApiBudgetGuard")
+def test_apicalllog_destination_country_reflects_provider(mock_guard_cls):
+    # Neutralise the Redis-backed budget guard so no broker is required.
+    mock_guard_cls.return_value = MagicMock()
+    from apps.agents.models import APICallLog
+
+    msgs = [{"role": "user", "content": "hi"}]
+
+    # Local Ollama -> AU (on-prem; not a cross-border disclosure).
+    guarded_api_call(_fake_client("ollama"), model="loan-email", messages=msgs)
+    ollama_log = APICallLog.objects.get(provider="ollama")
+    assert ollama_log.destination_country == "AU"
+
+    # Hosted Groq -> US (cross-border).
+    guarded_api_call(_fake_client("groq"), model="llama-3.1-8b-instant", messages=msgs)
+    assert APICallLog.objects.get(provider="groq").destination_country == "US"
+
+    # Default/Anthropic -> US.
+    guarded_api_call(_fake_client("anthropic"), model="claude-sonnet-4-6", messages=msgs)
+    assert APICallLog.objects.get(provider="anthropic").destination_country == "US"

--- a/backend/tests/test_email_generator.py
+++ b/backend/tests/test_email_generator.py
@@ -468,3 +468,69 @@ class TestEmailBackendSelection:
         result = gen.generate(app, "denied", confidence=0.35)
         assert result["template_fallback"] is True
         assert result["passed_guardrails"] is True
+
+    @patch.dict(os.environ, {"EMAIL_LLM_BACKEND": "ollama"}, clear=True)
+    @patch("apps.email_engine.services.llm_client.OpenAICompatibleLLMClient")
+    def test_ollama_backend_builds_client_without_explicit_key(self, mock_cls):
+        """Ollama needs no real key, so a client is built from the dummy default
+        — the opposite of the groq missing-key -> template path."""
+        mock_cls.return_value = MagicMock()
+        from apps.email_engine.services.email_generator import EmailGenerator
+
+        gen = EmailGenerator()
+        assert gen.provider == "ollama"
+        assert gen._model == "loan-email"
+        assert gen.client is mock_cls.return_value
+        _, kwargs = mock_cls.call_args
+        assert kwargs["provider"] == "ollama"
+        assert kwargs["base_url"] == "http://ollama:11434/v1"
+        assert kwargs["api_key"] == "ollama"  # dummy default
+
+    @patch.dict(os.environ, {"EMAIL_LLM_BACKEND": "ollama"}, clear=True)
+    @patch("apps.email_engine.services.llm_client.OpenAICompatibleLLMClient")
+    @patch("apps.agents.services.api_budget.ApiBudgetGuard")
+    def test_ollama_unreachable_falls_back_to_template(self, mock_budget_cls, mock_cls):
+        """An unreachable local Ollama server (ConnectError -> EmailBackendError)
+        degrades to the deterministic template, not a crash."""
+        from apps.email_engine.services.exceptions import EmailBackendError
+
+        client = MagicMock()
+        client.provider = "ollama"
+        mock_cls.return_value = client
+        client.messages.create.side_effect = EmailBackendError("ollama request failed: ConnectError")
+        mock_budget_cls.return_value = MagicMock()
+
+        from apps.email_engine.services.email_generator import EmailGenerator
+
+        gen = EmailGenerator()
+        app = _make_mock_application(decision="approved")
+        result = gen.generate(app, "approved", confidence=0.92)
+        assert result["template_fallback"] is True
+
+    @patch.dict(os.environ, {"EMAIL_LLM_BACKEND": "ollama"}, clear=True)
+    @patch("apps.email_engine.services.llm_client.OpenAICompatibleLLMClient")
+    @patch("apps.agents.services.api_budget.ApiBudgetGuard")
+    def test_generate_denial_email_via_ollama(self, mock_budget_cls, mock_cls):
+        """A denial email written through the local Ollama backend still runs the
+        full guardrail battery and honours the locked no-apology rule."""
+        client = MagicMock()
+        client.provider = "ollama"
+        mock_cls.return_value = client
+        client.messages.create.return_value = _make_mock_tool_response(
+            "Update on Your Personal Loan Application",
+            GOOD_DENIAL_BODY,
+        )
+        mock_budget_cls.return_value = MagicMock()
+
+        from apps.email_engine.services.email_generator import EmailGenerator
+
+        gen = EmailGenerator()
+        app = _make_mock_application(decision="denied", loan_amount=20000)
+        app.applicant.first_name = "Jane"
+        app.applicant.last_name = "Doe"
+        result = gen.generate(app, "denied", confidence=0.35)
+        assert result["template_fallback"] is False
+        assert len(result["guardrail_results"]) == 18
+        lowered = result["body"].lower()
+        for banned in ("sorry", "apologis", "disappoint"):
+            assert banned not in lowered

--- a/backend/tests/test_groq_llm_client.py
+++ b/backend/tests/test_groq_llm_client.py
@@ -16,6 +16,7 @@ from apps.email_engine.services.email_generator import EMAIL_SUBMIT_TOOL
 from apps.email_engine.services.exceptions import EmailBackendError
 from apps.email_engine.services.llm_client import (
     GroqLLMClient,
+    OpenAICompatibleLLMClient,
     _map_finish_reason,
     _to_openai_tool,
 )
@@ -169,3 +170,9 @@ class TestGroqErrorHandling:
         # guarded_api_call reads getattr(client, "provider", "anthropic") for the
         # cross-border audit log.
         assert GroqLLMClient(api_key="x").provider == "groq"
+
+    def test_provider_is_configurable_for_ollama(self):
+        # The generalized client records whatever provider it's told (drives the
+        # APICallLog provider + destination country); the Groq alias defaults to "groq".
+        assert OpenAICompatibleLLMClient(api_key="x", provider="ollama").provider == "ollama"
+        assert OpenAICompatibleLLMClient(api_key="x").provider == "groq"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -299,6 +299,56 @@ services:
     networks:
       - internal
 
+  # --- Local LLM for free, private email generation (opt-in) ---
+  # Start with: docker compose --profile ollama up -d ollama ollama-init
+  # When EMAIL_LLM_BACKEND=ollama but these aren't running, email generation
+  # degrades cleanly to the deterministic template (ConnectError -> fallback),
+  # so the default stack is unaffected.
+  ollama:
+    image: ollama/ollama:latest  # pin a version for reproducibility, e.g. ollama/ollama:0.5.7
+    profiles: ["ollama"]
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'      # inference is CPU-bound; give it threads
+          memory: 8G       # qwen2.5:7b Q4 ~5GB weights + 16k KV-cache headroom
+    volumes:
+      - ollama_models:/root/.ollama
+    environment:
+      OLLAMA_KEEP_ALIVE: "30m"        # keep the model warm between emails
+      OLLAMA_MAX_LOADED_MODELS: "1"
+      OLLAMA_NUM_PARALLEL: "1"
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    networks:
+      - internal
+
+  # One-shot: pull the base model and bake the 16k-context `loan-email` model,
+  # then exit. Re-runs are cheap (model cached in the named volume).
+  ollama-init:
+    image: ollama/ollama:latest
+    profiles: ["ollama"]
+    depends_on:
+      ollama:
+        condition: service_healthy
+    entrypoint: ["/bin/sh", "-c"]
+    command: >
+      "ollama pull qwen2.5:7b &&
+       ollama create loan-email -f /models/Modelfile &&
+       echo 'ollama loan-email model ready'"
+    environment:
+      OLLAMA_HOST: http://ollama:11434
+    volumes:
+      - ./ollama:/models:ro
+    restart: "no"
+    networks:
+      - internal
+
   # --- Monitoring stack (opt-in via: docker compose --profile monitoring up) ---
   prometheus:
     image: prom/prometheus:v3.1.0
@@ -428,3 +478,4 @@ volumes:
   # grafana_data is declared in docker-compose.monitoring.yml
   frontend_next:
   frontend_node_modules:
+  ollama_models:  # pulled Ollama models persist here (opt-in `ollama` profile)

--- a/ollama/Modelfile
+++ b/ollama/Modelfile
@@ -1,0 +1,19 @@
+# Custom Ollama model for loan decision emails.
+#
+# WHY: the ~9k-token compliance prompt would be silently truncated at Ollama's
+# CPU default context window (4096 tokens), mangling the email. Ollama's OpenAI
+# /v1 endpoint cannot set num_ctx per request, so the larger window must be
+# BAKED into the model. A Modelfile PARAMETER also takes precedence over the
+# OLLAMA_CONTEXT_LENGTH env var (which is unreliable), so this is the robust fix.
+#
+# Built once by the compose `ollama-init` service:
+#   ollama create loan-email -f /models/Modelfile
+# and selected via EMAIL_LLM_BACKEND=ollama (OLLAMA_MODEL defaults to loan-email).
+#
+# Swap the base model for a lighter one on a low-RAM host, e.g. `FROM llama3.2:3b`
+# (~2GB, faster, slightly less reliable at the structured tool call — the
+# guardrail + template fallback covers that). Keep num_ctx >= 12288 to fit the
+# ~9k input + ~4k output.
+FROM qwen2.5:7b
+PARAMETER num_ctx 16384
+PARAMETER temperature 0


### PR DESCRIPTION
## Summary

Real end-to-end testing of the free **Groq** backend (#234) found its free tier caps at **6,000 tokens/min**, but our compliance email prompts are ~9k tokens — so every email returned **HTTP 413**. Free Groq is unusable for *these* prompts. This adds a **local Ollama** backend: no per-minute token cap (fits the big prompts), runs offline, and applicant data never leaves the host.

Stacks on #234 (pluggable backend) + #239 (provider-error → template fallback).

## What changed

- **Generalized adapter** → `OpenAICompatibleLLMClient` (with a `GroqLLMClient` back-compat alias so existing imports/patches/tests are unchanged). Groq and Ollama share one client; only `base_url`/`model`/auth/`provider` differ. `provider` is now a constructor arg.
- **`EMAIL_LLM_BACKEND=ollama`** branch: a *dummy* default `OLLAMA_API_KEY` (Ollama ignores auth) so the client is always built; an **unreachable** local server degrades to the template at runtime (`ConnectError` → `EmailBackendError` → fallback). 180s read timeout for slow CPU prefill. `OLLAMA_BASE_URL`/`OLLAMA_MODEL` settings + `.env.example`.
- **Opt-in `ollama` compose profile** — `ollama` server + `ollama-init` (pulls `qwen2.5:7b`, bakes a **16k-context `loan-email`** model via `ollama/Modelfile`). **Absent from the default stack.**
  - Context must be **baked into a Modelfile** because Ollama's `/v1` ignores per-request `num_ctx` (the 4k default would silently truncate the 9k prompt).
  - Ollama's `/v1` also **ignores forced `tool_choice`** — covered by the adapter's text block + the existing text-parse / guardrail / template-fallback chain.
- **APP 8 correctness fix:** `destination_country` is now **derived per provider** (`ollama` → `AU` on-prem, `anthropic`/`groq` → `US`), fixing a hardcoded `"US"` that would log a *false cross-border disclosure* for local inference. `$0` `MODEL_PRICING` rows for the Ollama models.
- **Unchanged:** bias detection stays deterministic, plus the `$5/day` budget guard, 18 guardrails, retries, and template fallback.

## Honest tradeoffs (documented in ADR 010)

Local Ollama is **slow on CPU** (~20–60s/email, prefill-dominated) and **heavy** (~5GB model + ~8GB-RAM container), and a small local model trips the structured-output guardrails more often (→ more template fallbacks). It's an **opt-in capability**, not the recommended default over templates for a demo.

## Test plan

- Ollama backend selection (dummy-key → client built), unreachable → template fallback, denial-via-Ollama (full guardrails + no-apology rule), configurable provider, and an **AU-destination audit** test (`test_api_budget_provider_audit.py`).
- All existing Groq/Claude tests stay green under the rename+alias.
- **Full backend suite: 2106 passed, 33 skipped.** Ruff check + format clean. `docker compose --profile ollama config` validates.

## To run it (opt-in)

```
docker compose --profile ollama up -d ollama ollama-init   # pulls ~5GB once
# set EMAIL_LLM_BACKEND=ollama in .env, then: docker compose up -d backend celery_worker_io
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)