### PR TITLE
fix(email_engine): raise Ollama read timeout 180s -> 300s for CPU cold starts

### DIFF
--- a/backend/apps/email_engine/services/email_generator.py
+++ b/backend/apps/email_engine/services/email_generator.py
@@ -124,10 +124,13 @@ class EmailGenerator:
                 base_url=os.environ.get("OLLAMA_BASE_URL", DEFAULT_OLLAMA_BASE_URL),
                 model=model,
                 seed=seed,
-                # Local CPU inference of a ~9k-token prompt can take tens of
-                # seconds; allow a long read timeout so a slow (not failed)
-                # generation isn't mistaken for an outage and bounced to template.
-                timeout=httpx.Timeout(180.0, connect=10.0),
+                # Local CPU inference is slow: a warm attempt on the ~4.5k-token
+                # prompt takes ~2 min, and a COLD first call also pays model-load
+                # time. 180s bounced cold starts to the template fallback; 300s
+                # lets a slow (not failed) generation finish instead of looking
+                # like an outage. Email runs in the async Celery queue, so the
+                # extra wall-clock is invisible to the request path.
+                timeout=httpx.Timeout(300.0, connect=10.0),
                 provider="ollama",
             )
             return client, "ollama", model


### PR DESCRIPTION
## Why

On a CPU-only host the local Ollama email model (`loan-email`, the free backend from #242) is slow: a **warm** attempt on the ~4.5k-token compliance prompt takes ~120s, and the **first (cold) call** also pays model-load time. That cold path exceeded the hardcoded **180s** read timeout, so `EmailGenerator` raised `EmailBackendError` and silently dropped the email to the deterministic **template fallback** every time after a restart — i.e. Ollama looked "configured but never used."

Diagnosed live against the running stack:
- `ollama ps` → 100% CPU, no GPU; generation ~18 tok/s.
- A real generation with an extended timeout produced a **compliant, guardrail-passing** denial email (4673 in / 653 out tokens), confirming the backend works — it was only the cold-start timeout that bounced it.

## Change

Raise the Ollama client read timeout **180s → 300s** (ollama branch only; Groq/Anthropic stay at 60s). Email generation runs in the async Celery `email` queue, so the extra wall-clock is invisible to the request path. The template fallback still covers genuine outages and guardrail exhaustion.

## Testing

- Single timeout constant + comment; module imports cleanly and the backend restarted **healthy** (a syntax/logic error would crash-loop it). `pytest` is not present in the runtime image, so no unit run here — but no test asserts the old value, and warm end-to-end generation was verified producing a compliant email.
- Live source confirmed carrying `httpx.Timeout(300.0, connect=10.0)`.

> Note: making `EMAIL_LLM_BACKEND=ollama` durable also needs `EMAIL_LLM_BACKEND=ollama` + `OLLAMA_MODEL=loan-email` in `.env` (gitignored, not part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
