### PR TITLE
fix(agents): adaptive-model sampling strip + senior reviewer on Opus 4.8, hardened per review

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,13 @@ OLLAMA_BASE_URL=http://ollama:11434/v1
 OLLAMA_MODEL=
 OLLAMA_API_KEY=ollama
 
+# Senior bias-reviewer model (Head of Compliance holistic email review).
+# Blank/unset -> claude-opus-4-8 (free same-price upgrade over legacy opus-4-7).
+# Only runs when ANTHROPIC_API_KEY is set. Must be an Anthropic model ID.
+# claude-fable-5 works but is premium ($10/$50/MTok) and a 30-day-retention
+# covered model — not recommended for this use case.
+BIAS_REVIEWER_MODEL=claude-opus-4-8
+
 # Security
 FIELD_ENCRYPTION_KEY=change-me-generate-with-python-c-from-cryptography.fernet-import-Fernet-print-Fernet.generate_key
 DJANGO_SUPERUSER_PASSWORD=change-me-admin-password

--- a/backend/apps/agents/services/api_budget.py
+++ b/backend/apps/agents/services/api_budget.py
@@ -31,6 +31,8 @@ logger = logging.getLogger("agents.api_budget")
 # Legacy IDs retained so historical APICallLog records resolve correctly.
 MODEL_PRICING = {
     # Current models
+    "claude-fable-5": {"input": 10.00, "output": 50.00},
+    "claude-opus-4-8": {"input": 5.00, "output": 25.00},
     "claude-opus-4-7": {"input": 5.00, "output": 25.00},
     "claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
     "claude-haiku-4-5-20251001": {"input": 1.00, "output": 5.00},
@@ -56,6 +58,24 @@ MODEL_PRICING = {
 
 # Fallback: assume Sonnet pricing for unknown models
 _DEFAULT_PRICING = {"input": 3.00, "output": 15.00}
+
+# Model families that REMOVED the sampling parameters — sending temperature/
+# top_p/top_k returns HTTP 400 (these are adaptive-thinking-only: Opus 4.7+,
+# Fable 5). Steer them with the `effort` parameter instead. We strip these
+# kwargs centrally in guarded_api_call so a call site that passes temperature=0
+# (valid for Sonnet/Haiku and the Groq/Ollama backends) does not 400 on an
+# adaptive-only model. Matched as substrings so dated snapshots
+# ("claude-opus-4-8-20260301") and platform-prefixed IDs
+# ("anthropic.claude-opus-4-8" on Bedrock) are covered too.
+# Add future adaptive-only model families here.
+_SAMPLING_PARAMS_REMOVED_FAMILIES = ("claude-opus-4-7", "claude-opus-4-8", "claude-fable-5")
+_REMOVED_SAMPLING_KWARGS = ("temperature", "top_p", "top_k")
+
+
+def _sampling_params_removed(model):
+    """True when ``model`` belongs to a family that rejects sampling params."""
+    return any(family in model for family in _SAMPLING_PARAMS_REMOVED_FAMILIES)
+
 
 # Where each provider physically processes the prompt — drives the APICallLog
 # cross-border (Privacy Act APP 8) record. Local Ollama runs on-prem in
@@ -479,6 +499,13 @@ def guarded_api_call(client, **kwargs):
     agent_run_id = kwargs.pop("_agent_run_id", None)
 
     model = kwargs.get("model", "")
+    # See _SAMPLING_PARAMS_REMOVED_FAMILIES: adaptive-only models 400 on
+    # temperature/top_p/top_k, so they never reach the API.
+    if _sampling_params_removed(model):
+        stripped = {p: kwargs.pop(p) for p in _REMOVED_SAMPLING_KWARGS if p in kwargs}
+        if stripped:
+            logger.debug("Stripped sampling params %s for adaptive-only model %s", stripped, model)
+
     budget = ApiBudgetGuard()
     # Authoritative atomic gate (M5): reserve a conservative worst-case before the
     # call so concurrent workers cannot collectively overshoot the daily cap.

--- a/backend/apps/agents/services/bias/helpers.py
+++ b/backend/apps/agents/services/bias/helpers.py
@@ -45,6 +45,18 @@ def _make_anthropic_client():
     return None
 
 
+# Default for the senior compliance reviewers (Opus 4.8 — free same-price
+# upgrade over legacy 4.7). Configurable via BIAS_REVIEWER_MODEL.
+DEFAULT_REVIEWER_MODEL = "claude-opus-4-8"
+
+
+def _reviewer_model():
+    """Resolve the senior-reviewer model; blank or unset falls back to the default."""
+    from django.conf import settings as django_settings
+
+    return getattr(django_settings, "BIAS_REVIEWER_MODEL", "") or DEFAULT_REVIEWER_MODEL
+
+
 def _format_flag_detail(prescreen):
     """Format each individual flag with its details for the junior analyst."""
     if not prescreen["findings"]:

--- a/backend/apps/agents/services/bias/marketing.py
+++ b/backend/apps/agents/services/bias/marketing.py
@@ -5,7 +5,7 @@ from django.conf import settings as django_settings
 from utils.sanitization import sanitize_prompt_input as _sanitize_prompt_input
 
 from ..deterministic_prescreen import DeterministicBiasPreScreen
-from .helpers import _call_with_retry, _format_flag_detail, _make_anthropic_client
+from .helpers import _call_with_retry, _format_flag_detail, _make_anthropic_client, _reviewer_model
 from .thresholds import is_severe
 from .tools import MARKETING_BIAS_TOOL, MARKETING_REVIEW_TOOL
 
@@ -224,10 +224,9 @@ class MarketingEmailReviewer:
     judgment that a pattern-matching system or junior analyst cannot provide.
     """
 
-    MODEL = "claude-opus-4-7"
-
     def __init__(self):
         self.client = _make_anthropic_client()
+        self.model = _reviewer_model()
 
     def review(self, email_text, bias_result, application_context):
         """Senior review of a flagged marketing email.
@@ -300,7 +299,7 @@ Use the record_marketing_review_decision tool to submit your decision."""
             fallback,
             "Marketing senior review",
             "defaulting to human escalation",
-            model=self.MODEL,
+            model=self.model,
             max_tokens=1024,
             temperature=getattr(django_settings, "AI_TEMPERATURE_ANALYSIS", 0.0),
             messages=[{"role": "user", "content": prompt}],

--- a/backend/apps/agents/services/bias/reviewer.py
+++ b/backend/apps/agents/services/bias/reviewer.py
@@ -4,7 +4,7 @@ from django.conf import settings as django_settings
 
 from utils.sanitization import sanitize_prompt_input as _sanitize_prompt_input
 
-from .helpers import _call_with_retry, _make_anthropic_client
+from .helpers import _call_with_retry, _make_anthropic_client, _reviewer_model
 from .tools import EMAIL_REVIEW_TOOL
 
 logger = logging.getLogger("agents.bias_detector")
@@ -29,11 +29,9 @@ class AIEmailReviewer:
     decision carries more weight — if the senior approves, the email ships.
     """
 
-    # Use Opus for the senior reviewer — tougher model, harder to fool
-    MODEL = "claude-opus-4-7"
-
     def __init__(self):
         self.client = _make_anthropic_client()
+        self.model = _reviewer_model()
 
     def review(self, email_text, bias_result, application_context):
         """Review a flagged email as the senior compliance authority.
@@ -123,7 +121,7 @@ Use the record_review_decision tool to submit your decision."""
             fallback,
             "Senior review",
             "defaulting to human escalation",
-            model=self.MODEL,
+            model=self.model,
             max_tokens=1024,
             temperature=getattr(django_settings, "AI_TEMPERATURE_ANALYSIS", 0.0),
             messages=[{"role": "user", "content": prompt}],

--- a/backend/apps/email_engine/services/email_generator.py
+++ b/backend/apps/email_engine/services/email_generator.py
@@ -430,12 +430,14 @@ class EmailGenerator:
         # Call Claude API with tool_use for structured output (with budget check)
         from django.conf import settings as django_settings
 
-        from apps.agents.services.api_budget import ApiBudgetGuard, BudgetExhausted, guarded_api_call
+        from apps.agents.services.api_budget import ApiBudgetGuard, BudgetExhausted, CircuitOpen, guarded_api_call
 
         budget = ApiBudgetGuard()
         try:
             budget.check_budget()
-        except BudgetExhausted:
+        except (BudgetExhausted, CircuitOpen):
+            # CircuitOpen: the shared breaker may have been tripped by ANOTHER
+            # AI service's failures — the customer still gets a template email.
             return self._generate_fallback(application, decision, context, start_time)
 
         # Approval emails are much longer (loan details, next steps, documentation,
@@ -467,7 +469,7 @@ class EmailGenerator:
             if usage:
                 input_tokens = getattr(usage, "input_tokens", 0)
                 output_tokens = getattr(usage, "output_tokens", 0)
-        except BudgetExhausted:
+        except (BudgetExhausted, CircuitOpen):
             return self._generate_fallback(application, decision, context, start_time)
         except anthropic.RateLimitError as exc:
             from .exceptions import RateLimited

--- a/backend/config/env_validation.py
+++ b/backend/config/env_validation.py
@@ -80,5 +80,16 @@ def validate_env():
             if not os.environ.get(var):
                 logger.warning("Environment variable %s is not set — %s.", var, consequence)
 
+        # The senior bias reviewer always calls the Anthropic API; a non-Claude
+        # model ID (e.g. an Ollama tag) would 404 every senior review, silently
+        # degrading to human escalation and feeding the shared circuit breaker.
+        reviewer_model = os.environ.get("BIAS_REVIEWER_MODEL", "")
+        if reviewer_model and not reviewer_model.startswith(("claude-", "anthropic.", "us.anthropic.")):
+            logger.warning(
+                "BIAS_REVIEWER_MODEL=%r does not look like an Anthropic model ID — "
+                "senior bias reviews will fail and fall back to human escalation.",
+                reviewer_model,
+            )
+
 
 validate_env()

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -464,6 +464,12 @@ OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://ollama:11434/v1")
 OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "")  # blank -> backend default (loan-email)
 OLLAMA_API_KEY = os.environ.get("OLLAMA_API_KEY", "ollama")  # dummy; Ollama ignores auth
 
+# Model for the senior bias reviewer (Head of Compliance — holistic email review).
+# Blank/unset -> Opus 4.8 (the free same-price upgrade over the now-legacy Opus
+# 4.7: ~4x less likely to miss a flaw). Sampling-param handling for adaptive-only
+# models lives in guarded_api_call.
+BIAS_REVIEWER_MODEL = os.environ.get("BIAS_REVIEWER_MODEL", "") or "claude-opus-4-8"
+
 # Bias detection thresholds (used by orchestrator pipeline)
 BIAS_THRESHOLD_PASS = 30  # 0-30: compliant, email can be sent
 BIAS_THRESHOLD_REVIEW = 60  # 31-60: moderate bias, LLM reviews for false positives

--- a/backend/tests/test_adaptive_model_sampling.py
+++ b/backend/tests/test_adaptive_model_sampling.py
@@ -1,0 +1,121 @@
+"""Guards for the adaptive-only-model sampling-parameter fix.
+
+Opus 4.7+ and Fable 5 reject temperature/top_p/top_k with a 400 — they are
+adaptive-thinking only. The senior bias reviewers pass temperature=0, so
+without a central strip every senior review would 400 the moment a real
+ANTHROPIC_API_KEY is set, and silently fall through to human escalation.
+These tests pin the family-based strip (including dated and platform-prefixed
+model IDs), the Opus 4.8 / Fable 5 pricing, and the configurable reviewer
+model with its blank-value fallback.
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test import override_settings
+
+from apps.agents.services import api_budget
+from apps.agents.services.api_budget import estimate_cost_usd, guarded_api_call
+from apps.agents.services.bias.helpers import DEFAULT_REVIEWER_MODEL, _reviewer_model
+
+
+def _stub_client():
+    """An LLM client stub; inspect kwargs via client.messages.create.call_args."""
+    client = MagicMock()
+    client.messages.create.return_value = SimpleNamespace(usage=SimpleNamespace(input_tokens=1, output_tokens=1))
+    return client
+
+
+@pytest.fixture
+def no_side_effects():
+    """Neutralise the Redis budget guard and the APICallLog audit write."""
+    with (
+        patch("apps.agents.services.api_budget.ApiBudgetGuard"),
+        patch("apps.agents.models.APICallLog"),
+    ):
+        yield
+
+
+def test_adaptive_only_families_pinned():
+    """Membership changes here must be deliberate (and priced in MODEL_PRICING)."""
+    assert api_budget._SAMPLING_PARAMS_REMOVED_FAMILIES == (
+        "claude-opus-4-7",
+        "claude-opus-4-8",
+        "claude-fable-5",
+    )
+
+
+def test_strips_sampling_params_for_adaptive_only_models(no_side_effects):
+    """temperature/top_p/top_k must NOT reach the API for adaptive-only models,
+    including dated snapshots and platform-prefixed (Bedrock-style) IDs."""
+    models = [
+        variant
+        for family in api_budget._SAMPLING_PARAMS_REMOVED_FAMILIES
+        for variant in (family, f"{family}-20260301", f"anthropic.{family}")
+    ]
+    for model in models:
+        client = _stub_client()
+        guarded_api_call(
+            client,
+            model=model,
+            max_tokens=64,
+            temperature=0.0,
+            top_p=0.5,
+            top_k=10,
+            messages=[{"role": "user", "content": "x"}],
+        )
+        sent = client.messages.create.call_args.kwargs
+        assert "temperature" not in sent, model
+        assert "top_p" not in sent, model
+        assert "top_k" not in sent, model
+        assert sent["model"] == model
+
+
+def test_keeps_sampling_params_for_models_that_accept_them(no_side_effects):
+    """Sonnet/Haiku and the Groq/Ollama models still accept temperature."""
+    for model in ("claude-sonnet-4-6", "claude-haiku-4-5-20251001", "llama-3.1-8b-instant"):
+        client = _stub_client()
+        guarded_api_call(
+            client,
+            model=model,
+            max_tokens=64,
+            temperature=0.3,
+            messages=[{"role": "user", "content": "x"}],
+        )
+        assert client.messages.create.call_args.kwargs["temperature"] == 0.3, model
+
+
+def test_adaptive_only_models_are_priced_not_default_fallback():
+    """Every settable adaptive-only model needs a real MODEL_PRICING row, or the
+    $5/day budget guard counts it at the (cheaper) Sonnet fallback price."""
+    assert api_budget.MODEL_PRICING["claude-opus-4-8"] == {"input": 5.00, "output": 25.00}
+    assert api_budget.MODEL_PRICING["claude-fable-5"] == {"input": 10.00, "output": 50.00}
+    # 1M input + 1M output
+    assert estimate_cost_usd(1_000_000, 1_000_000, "claude-opus-4-8") == 30.0
+    assert estimate_cost_usd(1_000_000, 1_000_000, "claude-fable-5") == 60.0
+
+
+@override_settings(BIAS_REVIEWER_MODEL="claude-fable-5")
+def test_senior_reviewers_use_configured_model():
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+        from apps.agents.services.bias.marketing import MarketingEmailReviewer
+        from apps.agents.services.bias.reviewer import AIEmailReviewer
+
+        assert AIEmailReviewer().model == "claude-fable-5"
+        assert MarketingEmailReviewer().model == "claude-fable-5"
+
+
+@override_settings(BIAS_REVIEWER_MODEL="")
+def test_blank_reviewer_model_falls_back_to_default():
+    """A set-but-blank BIAS_REVIEWER_MODEL= line in .env must not reach the API
+    as model='' — it falls back to the default."""
+    assert _reviewer_model() == DEFAULT_REVIEWER_MODEL == "claude-opus-4-8"
+
+
+def test_reviewer_has_no_client_without_api_key():
+    with patch.dict(os.environ, {}, clear=True):
+        from apps.agents.services.bias.reviewer import AIEmailReviewer
+
+        assert AIEmailReviewer().client is None


### PR DESCRIPTION
## Summary

Opus 4.7+ and Fable 5 are adaptive-thinking-only and reject `temperature`/`top_p`/`top_k` with HTTP 400. The senior bias reviewers pass `temperature=0`, so the moment a real `ANTHROPIC_API_KEY` is set every senior review 400'd and silently fell through to human escalation. This PR strips those params centrally in `guarded_api_call`, upgrades the senior reviewer default to Opus 4.8 (same list price as 4.7), and makes the model configurable via `BIAS_REVIEWER_MODEL`.

Before committing, the diff went through a 7-angle / 10-verifier self-review; all 10 confirmed findings are fixed in this PR:

## Review hardening

| # | Severity | Fix |
|---|----------|-----|
| 1 | HIGH | Strip now matches model **families as substrings** (dated snapshots, Bedrock-prefixed IDs) instead of exact strings — a near-miss `BIAS_REVIEWER_MODEL` can no longer silently reintroduce the 400-into-escalation failure |
| 2 | HIGH | `claude-fable-5` gets a real `MODEL_PRICING` row ($10/$50/MTok) — previously the $5/day budget guard counted it at the Sonnet fallback ($3/$15), admitting ~$16.7 of real spend before tripping |
| 3 | HIGH | `email_generator` degrades to template on `CircuitOpen`, not just `BudgetExhausted` — a breaker tripped by another AI service no longer hard-fails email Celery tasks |
| 4 | MED | Blank `BIAS_REVIEWER_MODEL=` line in `.env` falls back to the default instead of sending `model=""` |
| 5 | MED | `env_validation.py` warns at startup when the reviewer model is not an Anthropic ID (a wrong-provider value otherwise 404s every review and feeds the global circuit breaker) |
| 6 | MED | Default-model test no longer clears `os.environ` after settings already baked the value (asserted host-env state, false-red wherever `BIAS_REVIEWER_MODEL` is exported) |
| 7 | MED | Dropped fictitious `claude-mythos-5` ID from the frozenset and tests |
| 8 | LOW | Stripped params are logged (debug), matching the funnel's log-every-adjustment convention |
| 9 | LOW | Single `_reviewer_model()` helper in `bias/helpers.py` replaces duplicated resolution lines + dead `getattr` fallbacks in both reviewers |
| 10 | LOW | Tests iterate the real family tuple (incl. dated/prefixed variants), pin membership + pricing, and drop the DB dependency |

## Behavior note

Fixing the 400 means the senior reviewers gain **live approval authority** for the first time under a real API key — flagged emails in the moderate band that previously always escalated to a human (via the silent 400 fallback) can now be auto-approved by Opus per the ADR 003 design. This is the intended behavior of the original design finally working, but worth knowing when watching the review queue after deploy.

## Testing

- `tests/test_adaptive_model_sampling.py` — 7 tests: family strip (incl. dated + Bedrock-prefixed variants), keeps-params for Sonnet/Haiku/Groq, membership + pricing pins, configured/blank/default model resolution
- agents + email_engine + tests suites: 1529 passed, 32 skipped, 4 failed — the 4 failures are **pre-existing and environmental** (verified identical on a clean tree: local `.env` sets `EMAIL_LLM_BACKEND=ollama` so `tests/test_email_generator.py` hits the live Ollama container, which 500s; CI runs the Anthropic-mocked default)
- `ruff check` + `ruff format --check` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
